### PR TITLE
Fix google login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bdk"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "aide",
  "bigdecimal",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "btracing"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "dioxus",
  "gloo-timers",
@@ -500,7 +500,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "by-axum"
-version = "0.2.12"
+version = "0.2.14"
 dependencies = [
  "aide",
  "axum 0.8.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "by-components"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "by-macros",
  "dioxus",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "by-macros"
-version = "0.6.7"
+version = "0.6.9"
 dependencies = [
  "bigdecimal",
  "convert_case 0.7.1",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "by-types"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "aide",
  "axum 0.8.1",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-aws"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "axum 0.7.9",
  "axum-core 0.4.5",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-oauth"
-version = "0.6.4"
+version = "0.6.6"
 dependencies = [
  "dioxus",
  "reqwest",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-popup"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "by-components",
  "dioxus",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-translate"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "dioxus-translate-macro",
  "dioxus-translate-types",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-translate-macro"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "dioxus-translate-types",
  "proc-macro2",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-translate-types"
-version = "0.1.1"
+version = "0.1.3"
 
 [[package]]
 name = "dioxus-web"
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "google-wallet"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "candid",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "rest-api"
-version = "0.1.8"
+version = "0.1.10"
 dependencies = [
  "base64 0.22.1",
  "candid",

--- a/packages/main-ui/Makefile
+++ b/packages/main-ui/Makefile
@@ -1,7 +1,7 @@
 SERVICE ?= main-ui
 VERSION ?= $(shell toml get Cargo.toml package.version | tr -d \")
 COMMIT ?= $(shell git rev-parse --short HEAD)
-ENV ?= local
+ENV ?= dev
 
 ACCESS_KEY_ID ?= $(shell aws configure get aws_access_key_id $(AWS_FLAG))
 SECRET_ACCESS_KEY ?= $(shell aws configure get aws_secret_access_key $(AWS_FLAG))


### PR DESCRIPTION
- FirebaseWallet use a file in AppFolder, named `ENV` environment.
  - For example, `ENV` is set to `local`, it will use seed in `local` file.
  - So if someone signup on local, they can't be logged in on `dev`.
  - Because inconsistent address if using `dev` database for `local` development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Rust SDK dependency to reference the latest stable improvements.
	- Modified the build configuration to use the development environment, streamlining testing and development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->