### PR TITLE
feat(icons): add Facebook icon component and integrate into ResultsPage

### DIFF
--- a/packages/main-ui/src/components/icons/logos/facebook.rs
+++ b/packages/main-ui/src/components/icons/logos/facebook.rs
@@ -1,0 +1,24 @@
+use bdk::prelude::*;
+
+#[component]
+pub fn Facebook(
+    #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
+    #[props(default = 40)] size: i64,
+) -> Element {
+    rsx! {
+        svg {
+            height: "{size}",
+            view_box: "0 0 48 48",
+            width: "{size}",
+            xmlns: "http://www.w3.org/2000/svg",
+            path {
+                d: "M24 5A19 19 0 1 0 24 43A19 19 0 1 0 24 5Z",
+                fill: "#039be5",
+            }
+            path {
+                d: "M26.572,29.036h4.917l0.772-4.995h-5.69v-2.73c0-2.075,0.678-3.915,2.619-3.915h3.119v-4.359c-0.548-0.074-1.707-0.236-3.897-0.236c-4.573,0-7.254,2.415-7.254,7.917v3.323h-4.701v4.995h4.701v13.729C22.089,42.905,23.032,43,24,43c0.875,0,1.729-0.08,2.572-0.194V29.036z",
+                fill: "#fff",
+            }
+        }
+    }
+}

--- a/packages/main-ui/src/components/icons/logos/mod.rs
+++ b/packages/main-ui/src/components/icons/logos/mod.rs
@@ -1,5 +1,6 @@
 mod bsky;
 mod discord;
+mod facebook;
 mod google;
 mod logo;
 mod metamask;
@@ -10,6 +11,7 @@ mod youtube;
 
 pub use bsky::*;
 pub use discord::*;
+pub use facebook::*;
 pub use google::*;
 pub use logo::*;
 pub use metamask::*;

--- a/packages/main-ui/src/pages/quizzes/results/page.rs
+++ b/packages/main-ui/src/pages/quizzes/results/page.rs
@@ -1,5 +1,7 @@
+use crate::components::icons::{Facebook, X};
+
 use super::*;
-use bdk::prelude::{by_components::icons::links_share::Share3, *};
+use bdk::prelude::*;
 use controller::*;
 use i18n::*;
 
@@ -55,11 +57,20 @@ pub fn ResultsPage(
                     onclick: move |_| ctrl.sign_up(),
                     "Sign up and Save"
                 }
-                a {
-                    href: "https://x.com/intent/tweet?text=My+stance+on+crypto+policy+by+Ratel!&url={ctrl.location()}&hashtags=Ratel,crypto,election_pledge,south_korea,presidential_election",
-                    target: "_blank",
-                    class: "btn",
-                    Share3 { class: "[&>path]:stroke-white" }
+                div { class: "flex flex-row gap-20 items-center",
+                    a {
+                        href: "https://www.facebook.com/sharer/sharer.php?u={ctrl.location()}",
+                        target: "_blank",
+                        class: "btn",
+                        Facebook { size: 40 }
+                    }
+
+                    a {
+                        href: "https://x.com/intent/tweet?text=My+stance+on+crypto+policy+by+Ratel!&url={ctrl.location()}&hashtags=Ratel,crypto,election_pledge,south_korea,presidential_election",
+                        target: "_blank",
+                        class: "btn rounded-[2px] bg-black w-35 h-35",
+                        X { size: 20 }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added a new Facebook icon component to the icons library. Updated the ResultsPage to include a Facebook share button alongside the existing X (formerly Twitter) share button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a Facebook share button alongside the existing Twitter (X) share button on quiz results pages.
	- Introduced a new Facebook icon for use in the interface.
- **Style**
	- Updated the layout of social share buttons to display Facebook and Twitter (X) options side by side with improved visual grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->