### PR TITLE
feat(api): add MyInfo endpoint and related functionality

### DIFF
--- a/packages/dto/src/tables/users/mod.rs
+++ b/packages/dto/src/tables/users/mod.rs
@@ -1,7 +1,9 @@
 mod bot;
+mod my_info;
 mod team;
 mod user;
 
 pub use bot::*;
+pub use my_info::*;
 pub use team::*;
 pub use user::*;

--- a/packages/dto/src/tables/users/my_info.rs
+++ b/packages/dto/src/tables/users/my_info.rs
@@ -1,0 +1,27 @@
+use bdk::prelude::*;
+
+use crate::Group;
+
+use super::Team;
+
+#[derive(validator::Validate)]
+#[api_model(base = "/v1/me/info", read_action = my_info, table = users)]
+pub struct MyInfo {
+    pub id: i64,
+    pub created_at: i64,
+    pub updated_at: i64,
+
+    pub nickname: String,
+    pub principal: String,
+    #[validate(email)]
+    pub email: String,
+    #[validate(url)]
+    pub profile_url: String,
+
+    #[api_model(many_to_many = team_members, foreign_table_name = users, foreign_primary_key = team_id, foreign_reference_key = user_id)]
+    pub teams: Vec<Team>,
+
+    #[api_model(many_to_many = group_members, foreign_table_name = groups, foreign_primary_key = group_id, foreign_reference_key = user_id)]
+    #[serde(default)]
+    pub groups: Vec<Group>,
+}

--- a/packages/dto/src/tables/users/team.rs
+++ b/packages/dto/src/tables/users/team.rs
@@ -20,6 +20,7 @@ pub struct Team {
     pub username: String,
 
     #[api_model(many_to_many = team_members, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = team_id)]
+    #[serde(default)]
     pub members: Vec<User>,
 }
 

--- a/packages/dto/src/tables/users/user.rs
+++ b/packages/dto/src/tables/users/user.rs
@@ -40,6 +40,10 @@ pub struct User {
     #[api_model(many_to_many = group_members, foreign_table_name = groups, foreign_primary_key = group_id, foreign_reference_key = user_id)]
     #[serde(default)]
     pub groups: Vec<Group>,
+
+    // profile contents
+    #[api_model(version = v0.2)]
+    pub html_contents: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]

--- a/packages/main-api/src/controllers/v1/bots.rs
+++ b/packages/main-api/src/controllers/v1/bots.rs
@@ -92,6 +92,7 @@ impl BotController {
                 UserType::Bot,
                 Some(user_id),
                 username,
+                "".to_string(),
             )
             .await?;
 

--- a/packages/main-api/src/controllers/v1/me.rs
+++ b/packages/main-api/src/controllers/v1/me.rs
@@ -87,6 +87,7 @@ mod tests {
                 UserType::Team,
                 Some(user_id),
                 username,
+                "".to_string(),
             )
             .await
             .unwrap()
@@ -110,6 +111,7 @@ mod tests {
                 UserType::Team,
                 Some(admin_id),
                 username,
+                "".to_string(),
             )
             .await
             .unwrap()
@@ -139,6 +141,7 @@ mod tests {
                 UserType::Team,
                 Some(admin_id),
                 username,
+                "".to_string(),
             )
             .await
             .unwrap()

--- a/packages/main-api/src/controllers/v1/me.rs
+++ b/packages/main-api/src/controllers/v1/me.rs
@@ -1,0 +1,187 @@
+use bdk::prelude::*;
+use by_axum::{
+    auth::Authorization,
+    axum::{
+        Extension, Json,
+        extract::{Query, State},
+        routing::get,
+    },
+};
+use dto::*;
+
+use crate::utils::users::extract_user_id;
+
+#[derive(Clone, Debug)]
+pub struct MeController {
+    pool: sqlx::Pool<sqlx::Postgres>,
+}
+
+impl MeController {
+    async fn my_info(&self, auth: Option<Authorization>) -> Result<MyInfo> {
+        let user_id = extract_user_id(&self.pool, auth).await?;
+
+        let res = MyInfo::query_builder()
+            .id_equals(user_id)
+            .query()
+            .map(MyInfo::from)
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(res)
+    }
+}
+
+impl MeController {
+    pub fn new(pool: sqlx::Pool<sqlx::Postgres>) -> Self {
+        Self { pool }
+    }
+
+    pub fn route(&self) -> Result<by_axum::axum::Router> {
+        Ok(by_axum::axum::Router::new()
+            .route("/info", get(Self::get_my_info))
+            .with_state(self.clone()))
+    }
+
+    pub async fn get_my_info(
+        State(ctrl): State<MeController>,
+        Extension(auth): Extension<Option<Authorization>>,
+        Query(q): Query<MyInfoParam>,
+    ) -> Result<Json<MyInfoGetResponse>> {
+        tracing::debug!("list_me {:?}", q);
+
+        match q {
+            MyInfoParam::Read(param) if param.action == Some(MyInfoReadActionType::MyInfo) => {
+                let res = ctrl.my_info(auth).await?;
+                Ok(Json(MyInfoGetResponse::Read(res)))
+            }
+            _ => Err(Error::BadRequest),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk::prelude::sqlx::{Pool, Postgres};
+
+    use super::*;
+    use crate::tests::{TestContext, setup};
+
+    async fn test_setup(user: &User, admin: &User, pool: Pool<Postgres>, now: i64) -> (User, User) {
+        let repo = User::get_repository(pool.clone());
+        let username = format!("test_user_{}", now);
+        let profile_url = format!("https://example.com/{}", username);
+        let user_id = user.id;
+        let admin_id = admin.id;
+
+        let mut tx = pool.begin().await.unwrap();
+
+        let team = repo
+            .insert_with_tx(
+                &mut *tx,
+                "".to_string(),
+                username.clone(),
+                username.clone(),
+                profile_url.clone(),
+                false,
+                false,
+                UserType::Team,
+                Some(user_id),
+                username,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        TeamMember::get_repository(pool.clone())
+            .insert_with_tx(&mut *tx, team.id, user_id)
+            .await
+            .unwrap();
+        let username = format!("test_admin_{}", now);
+
+        let team2 = repo
+            .insert_with_tx(
+                &mut *tx,
+                "".to_string(),
+                username.clone(),
+                username.clone(),
+                profile_url.clone(),
+                false,
+                false,
+                UserType::Team,
+                Some(admin_id),
+                username,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        TeamMember::get_repository(pool.clone())
+            .insert_with_tx(&mut *tx, team2.id, admin_id)
+            .await
+            .unwrap();
+
+        TeamMember::get_repository(pool.clone())
+            .insert_with_tx(&mut *tx, team2.id, user_id)
+            .await
+            .unwrap();
+
+        let username = format!("test_admin2_{}", now);
+
+        let team3 = repo
+            .insert_with_tx(
+                &mut *tx,
+                "".to_string(),
+                username.clone(),
+                username.clone(),
+                profile_url,
+                false,
+                false,
+                UserType::Team,
+                Some(admin_id),
+                username,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        TeamMember::get_repository(pool.clone())
+            .insert_with_tx(&mut *tx, team3.id, admin_id)
+            .await
+            .unwrap();
+
+        tx.commit().await.unwrap();
+
+        (team, team2)
+    }
+
+    #[tokio::test]
+    async fn test_get_my_teams() {
+        let TestContext {
+            user,
+            admin,
+            now,
+            endpoint,
+            pool,
+            ..
+        } = setup().await.unwrap();
+        let (team, team2) = test_setup(&user, &admin, pool, now).await;
+
+        let my_info = MyInfo::get_client(&endpoint).my_info().await.unwrap();
+
+        assert_eq!(my_info.id, user.id);
+        assert_eq!(my_info.nickname, user.nickname);
+        assert_eq!(my_info.principal, user.principal);
+        assert_eq!(my_info.email, user.email);
+        assert_eq!(my_info.profile_url, user.profile_url);
+        assert_eq!(my_info.teams.len(), 2);
+        assert_eq!(my_info.teams[0].id, team.id);
+        assert_eq!(my_info.teams[0].created_at, team.created_at);
+        assert_eq!(my_info.teams[0].updated_at, team.updated_at);
+        assert_eq!(my_info.teams[0].parent_id, user.id);
+
+        assert_eq!(my_info.teams[1].id, team2.id);
+        assert_eq!(my_info.teams[1].created_at, team2.created_at);
+        assert_eq!(my_info.teams[1].updated_at, team2.updated_at);
+        assert_eq!(my_info.teams[1].parent_id, admin.id);
+    }
+}

--- a/packages/main-api/src/controllers/v1/mod.rs
+++ b/packages/main-api/src/controllers/v1/mod.rs
@@ -5,6 +5,7 @@ pub mod bills;
 mod bots;
 mod election_pledges;
 mod feeds;
+mod me;
 mod news;
 mod presidential_candidates;
 mod promotions;
@@ -20,6 +21,7 @@ use dto::*;
 
 pub fn route(pool: sqlx::Pool<sqlx::Postgres>) -> Result<by_axum::axum::Router> {
     Ok(by_axum::axum::Router::new()
+        .nest("/me", me::MeController::new(pool.clone()).route()?)
         .nest(
             "/promotions",
             promotions::PromotionController::new(pool.clone()).route()?,

--- a/packages/main-api/src/controllers/v1/teams.rs
+++ b/packages/main-api/src/controllers/v1/teams.rs
@@ -343,9 +343,11 @@ mod tests {
         assert_eq!(res.profile_url, profile_url);
         assert_eq!(res.username, username);
         assert_eq!(res.parent_id, user.id);
-        assert_eq!(res.members.len(), 1);
-        assert_eq!(res.members[0].id, new_user.id);
-        assert_eq!(res.members[0].email, new_user.email);
+        assert_eq!(res.members.len(), 2);
+        assert_eq!(res.members[0].id, user.id);
+        assert_eq!(res.members[0].email, user.email);
+        assert_eq!(res.members[1].id, new_user.id);
+        assert_eq!(res.members[1].email, new_user.email);
 
         let id = uuid::Uuid::new_v4().to_string();
         let new_user2 = setup_test_user(&id, &pool).await.unwrap();

--- a/packages/main-api/src/controllers/v1/teams.rs
+++ b/packages/main-api/src/controllers/v1/teams.rs
@@ -98,6 +98,7 @@ impl TeamController {
                 UserType::Team,
                 Some(user_id),
                 username,
+                "".to_string(),
             )
             .await
             .map_err(|e| {

--- a/packages/main-api/src/controllers/v1/users.rs
+++ b/packages/main-api/src/controllers/v1/users.rs
@@ -133,6 +133,7 @@ impl UserControllerV1 {
                 UserType::Individual,
                 None,
                 username,
+                "".to_string(),
             )
             .await?;
 

--- a/packages/main-api/src/main.rs
+++ b/packages/main-api/src/main.rs
@@ -92,6 +92,7 @@ async fn migration(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<()> {
                 UserType::Individual,
                 None,
                 "admin".to_string(),
+                "".to_string(),
             )
             .await?;
     }
@@ -196,6 +197,7 @@ pub mod tests {
                 UserType::Individual,
                 None,
                 email.clone(),
+                "".to_string(),
             )
             .await?
             .unwrap();
@@ -229,6 +231,7 @@ pub mod tests {
                 UserType::Individual,
                 None,
                 email.clone(),
+                "".to_string(),
             )
             .await?;
 

--- a/packages/main-api/src/utils/users.rs
+++ b/packages/main-api/src/utils/users.rs
@@ -32,6 +32,7 @@ pub async fn extract_user_with_allowing_anonymous(
                             UserType::Anonymous,
                             None,
                             principal.clone(),
+                            "".to_string(),
                         )
                         .await?
                 }


### PR DESCRIPTION
Introduce a new `MyInfo` struct in the DTO package to represent user information, including fields for nickname, email, profile URL, and associated teams and groups. Add a new `MeController` in the main API to handle `/me/info` endpoint requests, enabling retrieval of authenticated user information. Update the routing to include the new `/me` namespace.

Additionally, enhance the `TeamController` to use transactions when creating teams and associating members, ensuring atomicity. Add default serialization for certain fields in the DTO structs to improve API responses. Include comprehensive tests for the new `MyInfo` functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint `/v1/me/info` that allows authenticated users to retrieve their detailed profile information, including personal details, email, profile URL, and associated teams and groups.
- **Improvements**
  - User team and group data now defaults to empty lists if not present, ensuring smoother data handling and display.
  - Team member lists now default to empty to prevent deserialization errors.
  - Added support for HTML content in user profiles.
- **Bug Fixes**
  - Improved atomicity and reliability of team creation to prevent partial data writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->