### PR TITLE
feat(teams): add TeamsById page with layout, controller, and i18n support

### DIFF
--- a/packages/dto/src/error.rs
+++ b/packages/dto/src/error.rs
@@ -141,6 +141,9 @@ pub enum Error {
     // quizzes
     #[translate(en = "You must select a valid quiz")]
     InvalidQuizId,
+
+    #[translate(en = "You must pass a valid team name")]
+    InvalidTeamname,
 }
 
 impl<E: StdError + 'static> From<E> for Error {

--- a/packages/dto/src/error.rs
+++ b/packages/dto/src/error.rs
@@ -1,8 +1,8 @@
-use std::error::Error as StdError;
+use std::{error::Error as StdError, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use bdk::prelude::*;
+use bdk::prelude::{dioxus::CapturedError, *};
 
 #[derive(Debug, Serialize)]
 pub struct ServiceException {
@@ -152,6 +152,19 @@ impl<E: StdError + 'static> From<E> for Error {
 impl Into<ServiceException> for Error {
     fn into(self) -> ServiceException {
         ServiceException { inner: self }
+    }
+}
+
+impl Into<CapturedError> for Error {
+    fn into(self) -> CapturedError {
+        CapturedError::from_str(&self.to_string())
+            .expect("Failed to convert Error to CapturedError. This should not happen.")
+    }
+}
+
+impl Into<RenderError> for Error {
+    fn into(self) -> RenderError {
+        RenderError::Aborted(self.into())
     }
 }
 

--- a/packages/dto/src/tables/users/team.rs
+++ b/packages/dto/src/tables/users/team.rs
@@ -16,7 +16,7 @@ pub struct Team {
     pub profile_url: String,
 
     pub parent_id: i64,
-    #[api_model(action = create, action_by_id = [update_team_name])]
+    #[api_model(action = create, read_action = get_by_username, action_by_id = [update_team_name])]
     pub username: String,
 
     #[api_model(many_to_many = team_members, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = team_id)]

--- a/packages/main-ui/src/pages/mod.rs
+++ b/packages/main-ui/src/pages/mod.rs
@@ -10,6 +10,7 @@ mod my_profile;
 mod notifications;
 mod page;
 mod quizzes;
+mod teams;
 mod threads;
 
 pub use layout::*;
@@ -22,4 +23,5 @@ pub use my_network::*;
 pub use my_profile::*;
 pub use notifications::*;
 pub use quizzes::*;
+pub use teams::*;
 pub use threads::*;

--- a/packages/main-ui/src/pages/teams/_id/controller.rs
+++ b/packages/main-ui/src/pages/teams/_id/controller.rs
@@ -1,0 +1,32 @@
+use bdk::prelude::*;
+use dto::*;
+
+#[derive(Clone, Copy, DioxusController)]
+pub struct Controller {
+    #[allow(dead_code)]
+    pub lang: Language,
+    #[allow(dead_code)]
+    pub team: Resource<Team>,
+}
+
+impl Controller {
+    pub fn new(
+        lang: Language,
+        id: ReadOnlySignal<String>,
+    ) -> std::result::Result<Self, RenderError> {
+        let team = use_server_future(move || {
+            let username = id();
+            async move {
+                Team::get_client(crate::config::get().main_api_endpoint)
+                    .get_by_username(username)
+                    .await
+                    .unwrap_or_default()
+            }
+        })?;
+        let ctrl = Self { lang, team };
+
+        use_context_provider(move || ctrl);
+
+        Ok(ctrl)
+    }
+}

--- a/packages/main-ui/src/pages/teams/_id/i18n.rs
+++ b/packages/main-ui/src/pages/teams/_id/i18n.rs
@@ -1,0 +1,10 @@
+use bdk::prelude::*;
+
+translate! {
+    TeamsByIdTranslate;
+
+    title: {
+        ko: "TEAMS_BY_ID",
+        en: "TEAMS_BY_ID",
+    },
+}

--- a/packages/main-ui/src/pages/teams/_id/layout.rs
+++ b/packages/main-ui/src/pages/teams/_id/layout.rs
@@ -1,0 +1,28 @@
+use super::*;
+use crate::Route;
+use bdk::prelude::*;
+use controller::*;
+
+// id: teamname(username)
+#[component]
+pub fn TeamsByIdLayout(
+    #[props(default = Language::En)] lang: Language,
+    teamname: ReadOnlySignal<String>,
+) -> Element {
+    tracing::debug!(
+        "TeamsByIdLayout called with lang: {:?}, id: {:?}",
+        lang,
+        teamname
+    );
+
+    let mut _ctrl = Controller::new(lang, teamname)?;
+
+    rsx! {
+        SuspenseBoundary {
+            fallback: |_| rsx! {
+                div { class: "loader w-200" }
+            },
+            Outlet::<Route> {}
+        }
+    }
+}

--- a/packages/main-ui/src/pages/teams/_id/mod.rs
+++ b/packages/main-ui/src/pages/teams/_id/mod.rs
@@ -1,0 +1,7 @@
+mod controller;
+mod i18n;
+mod layout;
+mod page;
+
+pub use layout::*;
+pub use page::*;

--- a/packages/main-ui/src/pages/teams/_id/page.rs
+++ b/packages/main-ui/src/pages/teams/_id/page.rs
@@ -1,0 +1,24 @@
+use super::*;
+use bdk::prelude::*;
+use controller::*;
+use i18n::*;
+
+#[component]
+pub fn TeamsByIdPage(
+    teamname: ReadOnlySignal<String>,
+    #[props(default = Language::En)] lang: Language,
+) -> Element {
+    tracing::debug!(
+        "TeamsByIdPage called with lang: {:?}, teamname: {:?}",
+        lang,
+        teamname
+    );
+    let mut _ctrl: Controller = use_context();
+    let tr: TeamsByIdTranslate = translate(&lang);
+
+    rsx! {
+        by_components::meta::MetaPage { title: tr.title }
+
+        div { id: "teams-by-id", "{tr.title} PAGE" } // end of this page
+    }
+}

--- a/packages/main-ui/src/pages/teams/mod.rs
+++ b/packages/main-ui/src/pages/teams/mod.rs
@@ -1,0 +1,3 @@
+mod _id;
+
+pub use _id::*;

--- a/packages/main-ui/src/route.rs
+++ b/packages/main-ui/src/route.rs
@@ -28,6 +28,13 @@ pub enum Route {
         PoliticiansByIdPage { id: i64 },
         #[route("/presidential-election")]
         PresidentialElectionPage {},
+
+        #[nest("/teams/:teamname")]
+            #[layout(TeamsByIdLayout)]
+                #[route("/")]
+                TeamsByIdPage { teamname: String },
+            #[end_layout]
+        #[end_nest]
     #[end_layout]
 
     #[layout(LandingLayout)]


### PR DESCRIPTION
Introduce a new TeamsById page under the `/teams/:teamname` route. This includes:

- A `TeamsByIdLayout` component for handling the layout of the page.
- A `TeamsByIdPage` component for rendering the page content.
- A `Controller` for managing the page's state and fetching team data.
- Internationalization (i18n) support for the page title.
- Updates to the routing configuration to include the new nested route.

Additionally, enhancements were made to the `Team` struct in the DTO package to support the new functionality.# [copilot:gpt-4o] Generating commit message...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Teams page accessible via `/teams/:teamname`, displaying team-specific information with localized content.
  - Added support for dynamic routing and layout for team pages, including asynchronous data loading and error handling.
  - Implemented internationalization for the Teams by ID page with English and Korean support.
  - Added API endpoint to fetch team details by username.

- **Improvements**
  - Updated API model metadata for team usernames to enhance data retrieval by username.

- **Other**
  - Expanded internal error handling and conversion capabilities for improved robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->