### PR TITLE
implement create space

### DIFF
--- a/packages/dto/src/tables/dto/assets.rs
+++ b/packages/dto/src/tables/dto/assets.rs
@@ -29,6 +29,9 @@ pub enum FileType {
     SVG,
     AI,
 
+    PDF,
+    XLSX,
+
     // 3D Model
     GLB,
     GLTF,
@@ -49,6 +52,10 @@ impl FileType {
         match s {
             "jpg" | "jpeg" => Ok(FileType::JPG),
             "png" => Ok(FileType::PNG),
+            "svg" => Ok(FileType::SVG),
+            "pdf" => Ok(FileType::PDF),
+            "xlsx" | "xls" => Ok(FileType::XLSX),
+            "pptx" => Ok(FileType::PPTX),
             _ => Err(Error::InvalidType),
         }
     }

--- a/packages/dto/src/tables/feeds/feed.rs
+++ b/packages/dto/src/tables/feeds/feed.rs
@@ -1,7 +1,7 @@
 use bdk::prelude::*;
 use validator::Validate;
 
-use crate::Space;
+use crate::{File, Space};
 
 #[derive(Validate)]
 #[api_model(base = "/v1/feeds", table = feeds, action = [], action_by_id = [delete])]
@@ -57,6 +57,9 @@ pub struct Feed {
     pub likes: i64,
     #[api_model(summary, one_to_many = feed_comments, foreign_key = feed_id, aggregator=count)]
     pub comments: i64,
+    #[api_model(version = v0.1, summary, action = write_post, type = JSONB)]
+    #[serde(default)]
+    pub files: Vec<File>,
     #[api_model(version = v0.1, summary)]
     #[serde(default)]
     pub rewards: i64,

--- a/packages/dto/src/tables/spaces/space.rs
+++ b/packages/dto/src/tables/spaces/space.rs
@@ -33,6 +33,9 @@ pub struct Space {
     #[api_model(summary , type = INTEGER)]
     #[serde(default)]
     pub content_type: ContentType,
+    #[api_model(summary, version = v0.1, type = INTEGER)]
+    #[serde(default)]
+    pub status: SpaceStatus,
 
     #[api_model(one_to_many = space_members, foreign_key = space_id)]
     #[serde(default)]
@@ -50,6 +53,15 @@ pub struct Space {
     #[api_model(summary)]
     #[serde(default)]
     pub shares: i64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub enum SpaceStatus {
+    #[default]
+    Draft = 1,
+    InProgress = 2,
+    Finish = 3,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]

--- a/packages/dto/src/tables/spaces/space.rs
+++ b/packages/dto/src/tables/spaces/space.rs
@@ -36,6 +36,9 @@ pub struct Space {
     #[api_model(summary, version = v0.1, type = INTEGER)]
     #[serde(default)]
     pub status: SpaceStatus,
+    #[api_model(version = v0.1, summary, type = JSONB)]
+    #[serde(default)]
+    pub files: Vec<File>,
 
     #[api_model(one_to_many = space_members, foreign_key = space_id)]
     #[serde(default)]

--- a/packages/main-api/src/controllers/v1/feeds.rs
+++ b/packages/main-api/src/controllers/v1/feeds.rs
@@ -60,6 +60,7 @@ impl FeedController {
             title,
             quote_feed_id,
             user_id,
+            files,
         }: FeedWritePostRequest,
     ) -> Result<Feed> {
         let user = check_perm(
@@ -87,6 +88,7 @@ impl FeedController {
                 title,
                 None,
                 quote_feed_id,
+                files,
                 0,
                 0,
             )
@@ -148,6 +150,7 @@ impl FeedController {
                 None,
                 None,
                 None,
+                feed.files,
                 0,
                 0,
             )
@@ -210,6 +213,7 @@ impl FeedController {
                 None,
                 None,
                 None,
+                feed.files,
                 0,
                 0,
             )
@@ -255,7 +259,7 @@ impl FeedController {
             Error::FeedInvalidQuoteId
         })?;
 
-        let industry_id = Feed::query_builder()
+        let feed = Feed::query_builder()
             .id_equals(parent_id)
             .query()
             .map(Feed::from)
@@ -264,8 +268,7 @@ impl FeedController {
             .map_err(|e| {
                 tracing::error!("failed to get a feed {parent_id}: {e}");
                 Error::FeedInvalidParentId
-            })?
-            .industry_id;
+            })?;
 
         Feed::query_builder()
             .id_equals(quote_feed_id)
@@ -284,7 +287,7 @@ impl FeedController {
                 html_contents,
                 FeedType::Repost,
                 user_id,
-                industry_id,
+                feed.industry_id,
                 if user.nickname == "" {
                     Some(user.email)
                 } else {
@@ -295,6 +298,7 @@ impl FeedController {
                 None,
                 None,
                 Some(quote_feed_id),
+                feed.files,
                 0,
                 0,
             )
@@ -478,6 +482,7 @@ mod tests {
                 title,
                 None,
                 None,
+                vec![],
                 0,
                 0,
             )
@@ -496,6 +501,7 @@ mod tests {
                 None,
                 None,
                 None,
+                vec![],
                 0,
                 0,
             )
@@ -524,6 +530,7 @@ mod tests {
                 industry_id,
                 title.clone(),
                 None,
+                vec![],
             )
             .await;
 
@@ -572,6 +579,7 @@ mod tests {
                 industry_id,
                 title.clone(),
                 Some(quote.id),
+                vec![],
             )
             .await;
 

--- a/packages/main-api/src/controllers/v1/promotions.rs
+++ b/packages/main-api/src/controllers/v1/promotions.rs
@@ -286,6 +286,7 @@ mod tests {
                 title,
                 None,
                 None,
+                vec![],
                 0,
                 0,
             )

--- a/packages/main-api/src/controllers/v1/spaces.rs
+++ b/packages/main-api/src/controllers/v1/spaces.rs
@@ -72,6 +72,7 @@ impl SpaceController {
                 Some(user.nickname),
                 ContentType::Crypto,
                 SpaceStatus::Draft,
+                feed.files,
                 0,
                 0,
             )

--- a/packages/main-api/src/controllers/v1/spaces.rs
+++ b/packages/main-api/src/controllers/v1/spaces.rs
@@ -71,6 +71,7 @@ impl SpaceController {
                 Some(user.profile_url),
                 Some(user.nickname),
                 ContentType::Crypto,
+                SpaceStatus::Draft,
                 0,
                 0,
             )

--- a/packages/main-ui/public/custom.css
+++ b/packages/main-ui/public/custom.css
@@ -29,3 +29,7 @@
 .create-space-button {
   @apply flex flex-row w-fit h-fit justify-start items-center bg-white px-14 py-8 rounded-[100px] gap-4 font-bold text-[#18181B] text-sm/16
 }
+
+.create-space-small-button {
+  @apply flex flex-row w-fit h-fit justify-start items-center bg-white px-8 py-4 rounded-[100px] gap-4 font-bold text-[#18181B] text-xs/16
+}

--- a/packages/main-ui/public/custom.css
+++ b/packages/main-ui/public/custom.css
@@ -31,5 +31,5 @@
 }
 
 .create-space-small-button {
-  @apply flex flex-row w-fit h-fit justify-start items-center bg-white px-8 py-4 rounded-[100px] gap-4 font-bold text-[#18181B] text-xs/16
+  @apply flex flex-row w-fit h-fit justify-start items-center bg-white px-12 py-4 rounded-[100px] gap-4 font-bold text-[#18181B] text-xs/16
 }

--- a/packages/main-ui/src/pages/components/create_feed_box.rs
+++ b/packages/main-ui/src/pages/components/create_feed_box.rs
@@ -2,7 +2,10 @@ use bdk::prelude::{
     by_components::icons::{arrows::DoubleArrowDown, chat::RoundBubble},
     *,
 };
-use dto::ContentType;
+use dto::{
+    ContentType,
+    by_components::icons::{arrows::DoubleArrowUp, validations::Clear},
+};
 
 use crate::components::{dropdown::Dropdown, icons::Badge, rich_text::RichText};
 
@@ -14,6 +17,7 @@ pub fn CreateFeedBox(
     onsend: EventHandler<(ContentType, String)>,
     onclose: EventHandler<MouseEvent>,
 ) -> Element {
+    let mut minimize = use_signal(|| false);
     let tr: CreateFeedBoxTranslate = translate(&lang);
 
     let mut selected_value = use_signal(|| ContentType::Crypto);
@@ -24,7 +28,7 @@ pub fn CreateFeedBox(
             class: "relative flex flex-col w-full justify-start items-start px-14 pt-15 pb-12 border border-t-6 border-primary gap-11 rounded-t-lg z-60",
             id: "create_feed",
             div { class: "flex flex-col w-full justify-start items-start gap-10 pb-12",
-                div { class: "flex flex-row w-full justify-between items-center",
+                div { class: " flex flex-row w-full justify-between items-center",
                     div { class: "flex flex-row w-fit justify-start items-center gap-10",
                         img {
                             class: "w-24 h-24 rounded-full object-cover",
@@ -36,57 +40,91 @@ pub fn CreateFeedBox(
                         }
                     }
 
-                    div { class: "flex flex-row w-fit justify-start items-center gap-20",
-                        Dropdown {
-                            class: "w-320 h-40 border border-border-primary rounded-lg placeholder-text-neutral-500 max-tablet:!hidden",
-                            items: ContentType::variants(&lang),
-                            onselect: move |value: String| {
-                                selected_value.set(value.parse::<ContentType>().unwrap());
-                            },
-                        }
+                    if !minimize() {
+                        div { class: "flex flex-row w-fit justify-start items-center gap-20",
+                            Dropdown {
+                                class: "w-320 h-40 border border-border-primary rounded-lg placeholder-text-neutral-500 max-tablet:!hidden",
+                                items: ContentType::variants(&lang),
+                                onselect: move |value: String| {
+                                    selected_value.set(value.parse::<ContentType>().unwrap());
+                                },
+                            }
 
-                        div {
-                            class: "cursor-pointer w-fit h-fit",
-                            onclick: move |e| {
-                                onclose.call(e);
-                            },
-                            DoubleArrowDown {
-                                class: "[&>path]:stroke-white",
-                                width: "18",
-                                height: "18",
+                            div {
+                                class: "cursor-pointer w-fit h-fit",
+                                onclick: move |_| {
+                                    minimize.set(true);
+                                },
+                                DoubleArrowDown {
+                                    class: "[&>path]:stroke-white",
+                                    width: "18",
+                                    height: "18",
+                                }
+                            }
+                        }
+                    } else {
+                        div { class: "flex flex-row w-fit justify-start items-center gap-20",
+                            div {
+                                class: "cursor-pointer w-fit h-fit",
+                                onclick: move |_| {
+                                    minimize.set(false);
+                                },
+                                DoubleArrowUp {
+                                    class: "[&>path]:stroke-white",
+                                    width: "18",
+                                    height: "18",
+                                }
+                            }
+                            div {
+                                class: "cursor-pointer w-fit h-fit",
+                                onclick: move |e| {
+                                    onclose.call(e);
+                                    minimize.set(false);
+                                },
+                                Clear {
+                                    class: "[&>path]:stroke-white",
+                                    width: "18",
+                                    height: "18",
+                                }
                             }
                         }
                     }
                 }
 
-                Dropdown {
-                    class: "w-full h-40 border border-border-primary rounded-lg placeholder-text-neutral-500 hidden max-tablet:!flex",
-                    items: ContentType::variants(&lang),
-                    onselect: move |value: String| {
-                        selected_value.set(value.parse::<ContentType>().unwrap());
-                    },
-                }
+                div {
+                    class: format_args!(
+                        "transition-all duration-300 overflow-hidden w-full {}",
+                        if minimize() { "max-h-0 opacity-0" } else { "max-h-[600px] opacity-100" },
+                    ),
+                    Dropdown {
+                        class: "w-full h-40 border border-border-primary rounded-lg placeholder-text-neutral-500 hidden max-tablet:!flex",
+                        items: ContentType::variants(&lang),
+                        onselect: move |value: String| {
+                            selected_value.set(value.parse::<ContentType>().unwrap());
+                        },
+                    }
 
-                RichText {
-                    content: content(),
-                    onchange: move |value| content.set(value),
-                    change_location: true,
-                    remove_border: true,
-                    placeholder: tr.hint,
-                    send_button: rsx! {
-                        div {
-                            class: "cursor-pointer p-8 bg-primary rounded-full",
-                            onclick: move |_| {
-                                onsend.call((selected_value(), content()));
-                            },
-                            RoundBubble {
-                                width: "24",
-                                height: "24",
-                                fill: "none",
-                                class: "[&>path]:stroke-neutral-900 [&>line]:stroke-neutral-900",
+                    RichText {
+                        content: content(),
+                        onchange: move |value| content.set(value),
+                        change_location: true,
+                        remove_border: true,
+                        placeholder: tr.hint,
+                        send_button: rsx! {
+                            div {
+                                class: "cursor-pointer p-8 bg-primary rounded-full",
+                                onclick: move |_| {
+                                    onsend.call((selected_value(), content()));
+                                },
+                                RoundBubble {
+                                    width: "24",
+                                    height: "24",
+                                    fill: "none",
+                                    class: "[&>path]:stroke-neutral-900 [&>line]:stroke-neutral-900",
+                                }
                             }
-                        }
-                    },
+                        },
+                    }
                 }
             }
         }

--- a/packages/main-ui/src/pages/components/create_reply_box.rs
+++ b/packages/main-ui/src/pages/components/create_reply_box.rs
@@ -29,6 +29,7 @@ pub fn CreateReplyBox(id: String, lang: Language, onsend: EventHandler<String>) 
                         }
                     }
                 },
+                onupload: move |_| {},
             }
         }
     }

--- a/packages/main-ui/src/pages/components/feed_content.rs
+++ b/packages/main-ui/src/pages/components/feed_content.rs
@@ -4,7 +4,7 @@ use bdk::prelude::{
     },
     *,
 };
-use dto::FeedSummary;
+use dto::{FeedSummary, by_components::icons::validations::Add};
 
 use crate::{
     components::icons::{Badge, Feed2, RewardCoin},
@@ -13,7 +13,14 @@ use crate::{
 };
 
 #[component]
-pub fn FeedContent(lang: Language, feed: FeedSummary, onclick: EventHandler<i64>) -> Element {
+pub fn FeedContent(
+    lang: Language,
+    feed: FeedSummary,
+    is_creator: bool,
+    exist_spaces: bool,
+    create_space: EventHandler<MouseEvent>,
+    onclick: EventHandler<i64>,
+) -> Element {
     rsx! {
         div {
             class: "cursor-pointer flex flex-col w-full justify-start items-start px-20 pt-20 pb-10 bg-footer rounded-lg gap-10",
@@ -22,10 +29,14 @@ pub fn FeedContent(lang: Language, feed: FeedSummary, onclick: EventHandler<i64>
             },
             div { class: "flex flex-col w-full justify-start items-start gap-10",
                 TopContent {
+                    lang,
                     label: "Crypto",
                     title: feed.title.unwrap_or_default(),
                     image: feed.profile_image.unwrap_or_default(),
                     nickname: feed.proposer_name.unwrap_or_default(),
+                    create_space,
+                    is_creator,
+                    exist_spaces,
                     created_at: feed.created_at,
                 }
 
@@ -135,17 +146,25 @@ pub fn ContentDescription(id: i64, lang: Language, html: String) -> Element {
 
 #[component]
 pub fn TopContent(
+    lang: Language,
     label: String,
     title: String,
     image: String,
     nickname: String,
     created_at: i64,
+    is_creator: bool,
+    exist_spaces: bool,
+
+    create_space: EventHandler<MouseEvent>,
 ) -> Element {
     rsx! {
         div { class: "flex flex-col w-full justify-start items-start gap-10",
             div { class: "flex flex-row w-full justify-between items-center",
                 Label { label }
                 div { class: "flex flex-row w-fit justify-start items-center gap-10",
+                    if is_creator && !exist_spaces {
+                        CreateSpaceButton { lang, create_space }
+                    }
                     Bookmark {
                         class: "[&>path]:stroke-neutral-500",
                         width: "20",
@@ -183,6 +202,36 @@ pub fn TopContent(
                 }
             }
         }
+    }
+}
+
+#[component]
+pub fn CreateSpaceButton(lang: Language, create_space: EventHandler<MouseEvent>) -> Element {
+    let tr: CreateSpaceButtonTranslate = translate(&lang);
+    rsx! {
+        div {
+            class: "cursor-pointer create-space-small-button",
+            onclick: move |e| {
+                e.prevent_default();
+                e.stop_propagation();
+                create_space.call(e);
+            },
+            Add {
+                class: "[&>stroke]:fill-neutral-500",
+                width: "20",
+                height: "20",
+            }
+            div { {tr.create_space} }
+        }
+    }
+}
+
+translate! {
+    CreateSpaceButtonTranslate;
+
+    create_space: {
+        ko: "Create a Space",
+        en: "Create a Space"
     }
 }
 

--- a/packages/main-ui/src/pages/components/feed_content.rs
+++ b/packages/main-ui/src/pages/components/feed_content.rs
@@ -7,7 +7,7 @@ use bdk::prelude::{
 use dto::{FeedSummary, by_components::icons::validations::Add};
 
 use crate::{
-    components::icons::{Badge, Feed2, RewardCoin},
+    components::icons::{Badge, Feed2, Palace, RewardCoin},
     pages::components::Label,
     utils::time::format_prev_time,
 };
@@ -43,6 +43,7 @@ pub fn FeedContent(
                 ContentDescription { id: feed.id, lang, html: feed.html_contents }
 
                 BottomContent {
+                    exist_spaces,
                     like: feed.likes,
                     comment: feed.comments,
                     reward: feed.rewards,
@@ -54,9 +55,23 @@ pub fn FeedContent(
 }
 
 #[component]
-pub fn BottomContent(like: i64, comment: i64, reward: i64, shared: i64) -> Element {
+pub fn BottomContent(
+    exist_spaces: bool,
+    like: i64,
+    comment: i64,
+    reward: i64,
+    shared: i64,
+) -> Element {
     rsx! {
-        div { class: "flex flex-row w-full justify-between items-center px-20 py-10",
+        div { class: "flex flex-row w-full justify-end items-center",
+            if exist_spaces {
+                IconBox {
+                    icon: rsx! {
+                        Palace { class: "[&>path]:stroke-neutral-500", width: "18", height: "18" }
+                    },
+                    text: "Space",
+                }
+            }
             IconBox {
                 icon: rsx! {
                     ThumbsUp { class: "[&>path]:stroke-neutral-500", width: "18", height: "18" }
@@ -93,7 +108,7 @@ pub fn BottomContent(like: i64, comment: i64, reward: i64, shared: i64) -> Eleme
 #[component]
 pub fn IconBox(icon: Element, text: String) -> Element {
     rsx! {
-        div { class: "flex flex-row w-fit justify-start items-center px-20 py-16 gap-10",
+        div { class: "flex flex-row w-fit justify-start items-center px-10 py-15 gap-5",
             {icon}
             div { class: "font-medium text-white text-[15px]/18", {text} }
         }
@@ -197,7 +212,7 @@ pub fn TopContent(
                     }
                 }
 
-                div { class: "font-light text-sm/17 text-white whitespace-nowrap",
+                div { class: "font-thin text-sm/17 text-white whitespace-nowrap",
                     {format_prev_time(created_at)}
                 }
             }

--- a/packages/main-ui/src/pages/components/feed_contents.rs
+++ b/packages/main-ui/src/pages/components/feed_contents.rs
@@ -85,7 +85,7 @@ pub fn CreateFeed(lang: Language, profile: String, onwrite: EventHandler<MouseEv
     let tr: CreateFeedTranslate = translate(&lang);
 
     rsx! {
-        div { class: "flex flex-row w-full justify-start items-center bg-bg p-20 rounded-lg gap-10 mb-10",
+        div { class: "absolute top-0 flex flex-row w-full justify-start items-center bg-bg p-20 rounded-lg gap-10 mb-10",
             img { class: "w-36 h-36 rounded-full object-cover", src: profile }
             a {
                 class: "flex flex-row w-full h-fit justify-start items-center bg-neutral-800 border border-neutral-700 rounded-[100px] font-normal text-text-secondary text-sm/16 px-15 py-10",
@@ -127,7 +127,7 @@ pub fn MyFeedList(
                         let scroll_height = container.scroll_height();
                         let client_height = container.client_height();
 
-                        if scroll_top + client_height as i32 >= scroll_height as i32 - 5 {
+                        if scroll_top + client_height as i32 >= scroll_height as i32 - 20 {
                             add_size.call(visible_count() + 5);
                             visible_count.set(visible_count() + 5);
                             tracing::debug!("visible count: {}", visible_count());
@@ -150,6 +150,7 @@ pub fn MyFeedList(
         div {
             id: feed_container_id,
             class: "flex flex-col w-full h-[calc(100vh-300px)] max-tablet:!h-[calc(100vh-300px)]  overflow-y-scroll gap-10",
+            div { class: "pt-80" }
             for feed in visible_feeds {
                 if feed.spaces.is_empty() || feed.spaces[0].status != SpaceStatus::Draft
                     || (feed.spaces[0].user_id == my_user_id

--- a/packages/main-ui/src/pages/components/feed_contents.rs
+++ b/packages/main-ui/src/pages/components/feed_contents.rs
@@ -149,7 +149,7 @@ pub fn MyFeedList(
     rsx! {
         div {
             id: feed_container_id,
-            class: "flex flex-col w-full h-[calc(100vh-300px)] max-tablet:!h-[calc(100vh-300px)]  overflow-y-scroll",
+            class: "flex flex-col w-full h-[calc(100vh-300px)] max-tablet:!h-[calc(100vh-300px)]  overflow-y-scroll gap-10",
             for feed in visible_feeds {
                 if feed.spaces.is_empty() || feed.spaces[0].status != SpaceStatus::Draft
                     || (feed.spaces[0].user_id == my_user_id

--- a/packages/main-ui/src/pages/controller.rs
+++ b/packages/main-ui/src/pages/controller.rs
@@ -2,8 +2,8 @@ use crate::pages::components::{CreateSpacePopup, CreateTeamPopup};
 use bdk::prelude::*;
 use dto::dioxus_popup::PopupService;
 use dto::{
-    ContentType, Feed, FeedQuery, FeedSummary, MyInfo, News, NewsQuery, NewsSummary, Promotion,
-    Space, SpaceType, TotalInfoQuery, TotalInfoSummary, User,
+    ContentType, Feed, FeedQuery, FeedSummary, File, MyInfo, News, NewsQuery, NewsSummary,
+    Promotion, Space, SpaceType, TotalInfoQuery, TotalInfoSummary, User,
 };
 use dto::{Follower, LandingData};
 use dto::{Team, TotalInfo};
@@ -351,7 +351,12 @@ impl Controller {
         self.is_write.set(is_write);
     }
 
-    pub async fn create_feed(&mut self, content_type: ContentType, description: String) {
+    pub async fn create_feed(
+        &mut self,
+        files: Vec<File>,
+        content_type: ContentType,
+        description: String,
+    ) {
         //FIXME: fix to real industry_id
         let industry_id = 1;
         let title = extract_title_from_html(&description);
@@ -379,7 +384,7 @@ impl Controller {
         }
 
         match Feed::get_client(config::get().main_api_endpoint)
-            .write_post(description, user_id, industry_id, Some(title), None)
+            .write_post(description, user_id, industry_id, Some(title), None, files)
             .await
         {
             Ok(_) => {

--- a/packages/main-ui/src/pages/layout.rs
+++ b/packages/main-ui/src/pages/layout.rs
@@ -5,6 +5,7 @@ use bdk::prelude::*;
 use dto::ContentType;
 
 use crate::{
+    components::loader::Loader,
     pages::components::{
         BottomNavigationBar, BottomSheet, CreateFeedBox, LeftSidebar, RightSidebar, SocialHeader,
     },
@@ -52,7 +53,14 @@ pub fn SocialLayout(#[props(default = Language::En)] lang: Language) -> Element 
                 }
             }
 
-            div { class: "w-full max-w-desktop flex-1 overflow-y-auto", Outlet::<Route> {} }
+            SuspenseBoundary {
+                fallback: |_| rsx! {
+                    div { class: "absolute bg-background w-screen h-screen top-0 left-0 flex items-center justify-center text-white",
+                        Loader { class: "w-200" }
+                    }
+                },
+                div { class: "w-full max-w-desktop flex-1 overflow-y-auto", Outlet::<Route> {} }
+            }
 
             div { class: "flex-shrink-0 w-full",
                 // aria_hidden: selected() == RouteTab::Notification,

--- a/packages/main-ui/src/pages/layout.rs
+++ b/packages/main-ui/src/pages/layout.rs
@@ -96,7 +96,7 @@ pub fn MyPageLayout(#[props(default = Language::En)] lang: Language) -> Element 
     let recent_communities: Vec<String> = vec![];
 
     rsx! {
-        div { class: "flex flex-col w-full h-screen justify-start items-start",
+        div { class: "flex flex-col w-full h-screen justify-between items-between",
             div { class: "flex flex-row w-full h-full max-h-[calc(100vh)] justify-start items-start py-20 px-10 gap-20",
                 LeftSidebar {
                     lang,
@@ -134,7 +134,7 @@ pub fn MyPageLayout(#[props(default = Language::En)] lang: Language) -> Element 
             }
 
             div {
-                class: "flex flex-row w-full justify-start items-start mb-85 aria-hidden:!hidden z-50",
+                class: "flex flex-row w-full justify-end items-end aria-hidden:!hidden z-50",
                 aria_hidden: !is_write,
                 CreateFeedBox {
                     lang,

--- a/packages/main-ui/src/pages/layout.rs
+++ b/packages/main-ui/src/pages/layout.rs
@@ -2,7 +2,7 @@ use super::*;
 use controller::*;
 
 use bdk::prelude::*;
-use dto::ContentType;
+use dto::{ContentType, File};
 
 use crate::{
     components::loader::Loader,
@@ -143,8 +143,8 @@ pub fn MyPageLayout(#[props(default = Language::En)] lang: Language) -> Element 
                     onclose: move |_| {
                         ctrl.change_write(false);
                     },
-                    onsend: move |(content_type, description): (ContentType, String)| async move {
-                        ctrl.create_feed(content_type, description).await;
+                    onsend: move |(files, content_type, description): (Vec<File>, ContentType, String)| async move {
+                        ctrl.create_feed(files, content_type, description).await;
                     },
                 }
             }

--- a/packages/main-ui/src/pages/page.rs
+++ b/packages/main-ui/src/pages/page.rs
@@ -16,7 +16,7 @@ pub fn IndexPage(#[props(default = Language::En)] lang: Language) -> Element {
     rsx! {
         by_components::meta::MetaPage { title: tr.title }
 
-        div { class: "flex flex-col w-full h-fit justify-start items-start text-white",
+        div { class: "relative flex flex-col w-full h-fit justify-start items-start text-white",
             CreateFeed {
                 lang,
                 profile: my_info.profile_url,

--- a/packages/main-ui/src/pages/page.rs
+++ b/packages/main-ui/src/pages/page.rs
@@ -28,6 +28,10 @@ pub fn IndexPage(#[props(default = Language::En)] lang: Language) -> Element {
             MyFeedList {
                 lang,
                 feeds,
+                my_user_id: my_info.id,
+                create_space: move |feed_id: i64| {
+                    ctrl.create_space(feed_id);
+                },
                 add_size: move |_| {
                     ctrl.add_size();
                 },

--- a/packages/main-ui/src/utils/file.rs
+++ b/packages/main-ui/src/utils/file.rs
@@ -30,6 +30,8 @@ pub async fn handle_file_upload(file_engine: Arc<dyn FileEngine>, api: BackendAp
                 let file_name_copy = file_name.clone();
                 let ext = file_name.rsplitn(2, '.').nth(0).unwrap_or("").to_string();
 
+                tracing::debug!("file type: {:?}", ext.clone());
+
                 let file_type = FileType::from_str(&ext.clone());
                 let file_type = if file_type.is_ok() {
                     Some(file_type.unwrap())


### PR DESCRIPTION
- list에서 create space 가능하도록 수정
- suspendedboundary 추가
- bottom create box 애니메이션 추가
- scroll 시 없어지는 느낌의 scroll 수정(메뉴 뒤에 스크롤 배치하도록 하는건 어떻게 할지 고민 필요)
- rich text 파일 업로드 기능 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Create a Space" button for eligible users, allowing them to initiate new spaces directly from the feed.
  - Added a popup interface for inviting users to participate in a newly created space.
  - Spaces now have a status indicator (Draft, In Progress, Finish) to reflect their current state.
  - Added support for attaching and managing files in feeds and spaces.
  - Added a smaller button style variant for space creation actions.
  - Added a loading indicator while main content is being loaded.
  - Expanded supported file types to include PDF, XLSX, and PPTX.

- **Improvements**
  - Enhanced feed and space visibility logic, ensuring space creation options are shown based on user role and space status.
  - Improved user experience with asynchronous content loading and feedback.
  - Updated feed creation box with minimize/expand controls and file upload capabilities for a cleaner interface.
  - Added upload handling and reset logic to rich text inputs for smoother file attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->