### PR TITLE
feat(main-api): add support for bucket domain configuration

### DIFF
--- a/packages/main-api/Makefile
+++ b/packages/main-api/Makefile
@@ -26,7 +26,8 @@ SLACK_CHANNEL_SPONSOR ?=
 SLACK_CHANNEL_ABUSING ?=
 SLACK_CHANNEL_MONITOR ?=
 
-BUCKET_NAME ?= dev.ratel.foundation
+BUCKET_NAME ?= ratel-metadata
+BUCKET_DOMAIN ?= metadata.ratel.foundation
 BUCKET_EXPIRE ?= 3600
 ASSET_DIR ?= metadata
 

--- a/packages/main-api/src/config.rs
+++ b/packages/main-api/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
 #[derive(Debug)]
 pub struct BucketConfig {
     pub name: &'static str,
+    pub domain: &'static str,
     pub asset_dir: &'static str,
     pub expire: u64,
 }
@@ -42,6 +43,7 @@ impl Default for Config {
             auth: AuthConfig::default(),
             bucket: BucketConfig {
                 name: option_env!("BUCKET_NAME").expect("You must set BUCKET_NAME"),
+                domain: option_env!("BUCKET_DOMAIN").expect("You must set BUCKET_DOMAIN"),
                 asset_dir: option_env!("ASSET_DIR").expect("You must set ASSET_DIR"),
                 expire: option_env!("BUCKET_EXPIRE").unwrap_or_else(|| {
                     tracing::warn!("We recommend to set BUCKET_EXPIRE. BUCKET_EXPIRE is not set. Default is 3600.");

--- a/packages/main-api/src/controllers/v1/assets.rs
+++ b/packages/main-api/src/controllers/v1/assets.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 pub struct AssetController {
     config: Arc<AwsConfig>,
     bucket_name: &'static str,
+    bucket_domain: &'static str,
     asset_dir: &'static str,
     expire: u64,
 }
@@ -23,6 +24,7 @@ impl AssetController {
         config: &AwsConfig,
         &BucketConfig {
             name,
+            domain,
             asset_dir,
             expire,
         }: &BucketConfig,
@@ -36,6 +38,7 @@ impl AssetController {
         Self {
             config,
             bucket_name: name,
+            bucket_domain: domain,
             asset_dir,
             expire,
         }
@@ -96,7 +99,7 @@ impl AssetController {
                     Error::AssetError(e.to_string())
                 })?;
             presigned_uris.push(presigned_request.uri().to_string());
-            uris.push(format!("https://{}/{}", ctrl.bucket_name, key));
+            uris.push(format!("https://{}/{}", ctrl.bucket_domain, key));
         }
 
         Ok(Json(AssetPresignedUris {


### PR DESCRIPTION
Introduce `BUCKET_DOMAIN` environment variable and corresponding field in `BucketConfig` struct. Update `AssetController` to use `bucket_domain` for generating asset URIs instead of `bucket_name`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for specifying a custom bucket domain for asset access, allowing assets to be served from a configurable domain.

- **Chores**
  - Updated default bucket name and added a new bucket domain variable in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->