### PR TITLE
feat(team): add nickname and html_contents fields to Team model

### DIFF
--- a/packages/dto/src/tables/users/team.rs
+++ b/packages/dto/src/tables/users/team.rs
@@ -11,6 +11,8 @@ pub struct Team {
     #[api_model(auto = [insert, update])]
     pub updated_at: i64,
 
+    #[api_model(action = create)]
+    pub nickname: String,
     #[api_model(action = create, action_by_id = [update_profile_image])]
     #[validate(url)]
     pub profile_url: String,
@@ -22,6 +24,10 @@ pub struct Team {
     #[api_model(many_to_many = team_members, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = team_id)]
     #[serde(default)]
     pub members: Vec<User>,
+
+    #[api_model(action = create)]
+    #[serde(default)]
+    pub html_contents: String,
 }
 
 impl From<User> for Team {
@@ -33,6 +39,8 @@ impl From<User> for Team {
             profile_url: user.profile_url,
             parent_id: user.parent_id.expect("Team must have parent_id"),
             username: user.username,
+            nickname: user.nickname,
+            html_contents: user.html_contents,
 
             ..Default::default()
         }

--- a/packages/dto/src/tables/users/team.rs
+++ b/packages/dto/src/tables/users/team.rs
@@ -11,6 +11,7 @@ pub struct Team {
     #[api_model(auto = [insert, update])]
     pub updated_at: i64,
 
+    pub user_type: UserType,
     #[api_model(action = create)]
     pub nickname: String,
     #[api_model(action = create, action_by_id = [update_profile_image])]

--- a/packages/dto/src/tables/users/user.rs
+++ b/packages/dto/src/tables/users/user.rs
@@ -4,6 +4,8 @@ use bdk::prelude::*;
 
 use crate::{Follower, Group};
 
+use super::Team;
+
 #[derive(validator::Validate)]
 #[api_model(base = "/v1/users", read_action = user_info, table = users, iter_type=QueryResponse)]
 pub struct User {
@@ -43,6 +45,10 @@ pub struct User {
     #[api_model(many_to_many = group_members, foreign_table_name = groups, foreign_primary_key = group_id, foreign_reference_key = user_id)]
     #[serde(default)]
     pub groups: Vec<Group>,
+
+    #[api_model(many_to_many = team_members, foreign_table_name = users, foreign_primary_key = team_id, foreign_reference_key = user_id)]
+    #[serde(default)]
+    pub teams: Vec<Team>,
 
     // profile contents
     #[api_model(version = v0.2, action_by_id = edit_profile)]

--- a/packages/main-api/src/controllers/v1/teams.rs
+++ b/packages/main-api/src/controllers/v1/teams.rs
@@ -79,6 +79,8 @@ impl TeamController {
         TeamCreateRequest {
             profile_url,
             username,
+            nickname,
+            html_contents,
         }: TeamCreateRequest,
     ) -> Result<Team> {
         let user_id = extract_user_id(&self.pool, auth).await?;
@@ -89,7 +91,7 @@ impl TeamController {
             .user
             .insert_with_tx(
                 &mut *tx,
-                "".to_string(),
+                nickname,
                 username.clone(),
                 username.clone(),
                 profile_url,
@@ -98,7 +100,7 @@ impl TeamController {
                 UserType::Team,
                 Some(user_id),
                 username,
-                "".to_string(),
+                html_contents,
             )
             .await
             .map_err(|e| {

--- a/packages/main-api/src/controllers/v1/teams.rs
+++ b/packages/main-api/src/controllers/v1/teams.rs
@@ -320,7 +320,12 @@ mod tests {
         let username = format!("create-team-{}", now);
 
         let res = cli
-            .create(profile_url.clone(), username.clone())
+            .create(
+                username.clone(),
+                profile_url.clone(),
+                username.clone(),
+                "".to_string(),
+            )
             .await
             .expect("failed to create team");
 
@@ -344,7 +349,12 @@ mod tests {
         let username = format!("invite-team-{}", now);
 
         let res = cli
-            .create(profile_url.clone(), username.clone())
+            .create(
+                username.clone(),
+                profile_url.clone(),
+                username.clone(),
+                "".to_string(),
+            )
             .await
             .expect("failed to create team");
 
@@ -401,7 +411,12 @@ mod tests {
         let username = format!("update-team-{}", now);
 
         let res = cli
-            .create(profile_url.clone(), username.clone())
+            .create(
+                username.clone(),
+                profile_url.clone(),
+                username.clone(),
+                "".to_string(),
+            )
             .await
             .expect("failed to create team");
 
@@ -430,7 +445,12 @@ mod tests {
         let username = format!("update-team-{}", now);
 
         let res = cli
-            .create(profile_url.clone(), username.clone())
+            .create(
+                username.clone(),
+                profile_url.clone(),
+                username.clone(),
+                "".to_string(),
+            )
             .await
             .expect("failed to create team");
 


### PR DESCRIPTION
Added `nickname` and `html_contents` fields to the `Team` struct in the DTO package. Updated the `From<User>` implementation to include these fields. Modified the `TeamController` to handle these fields in the `TeamCreateRequest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for "nickname" and "html_contents" fields when creating a new team.
  - Users can now specify a nickname and provide HTML content as part of the team creation process.
  - Users can belong to multiple teams, with team memberships now tracked and displayed.
  - Teams now include a user type attribute for enhanced categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->