### PR TITLE
feat(dto): add Badge table and update Space table structure

### DIFF
--- a/packages/dto/src/tables/badges/badge.rs
+++ b/packages/dto/src/tables/badges/badge.rs
@@ -1,0 +1,33 @@
+use bdk::prelude::*;
+use validator::Validate;
+
+#[derive(Validate)]
+#[api_model(base = "/", table = badge, action = [], action_by_id = [delete, update])]
+pub struct Badge {
+    #[api_model(primary_key)]
+    pub id: i64,
+    #[api_model(auto = [insert])]
+    pub created_at: i64,
+    #[api_model(auto = [insert, update])]
+    pub updated_at: i64,
+
+    #[api_model(many_to_one = users)]
+    pub creator_id: i64,
+
+    pub name: String,
+    #[api_model(type = INTEGER)]
+    pub scope: Scope,
+    pub image_url: String,
+
+    pub contract: Option<String>,
+    pub token_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub enum Scope {
+    #[default]
+    Global = 1,
+    Space = 2,
+    Team = 3,
+}

--- a/packages/dto/src/tables/badges/mod.rs
+++ b/packages/dto/src/tables/badges/mod.rs
@@ -1,0 +1,3 @@
+mod badge;
+
+pub use badge::*;

--- a/packages/dto/src/tables/mod.rs
+++ b/packages/dto/src/tables/mod.rs
@@ -1,5 +1,6 @@
 mod advocacy_campaigns;
 mod assembly_members;
+mod badges;
 mod bills;
 mod ch_bills;
 mod dto;
@@ -32,6 +33,7 @@ mod votes;
 
 pub use advocacy_campaigns::*;
 pub use assembly_members::*;
+pub use badges::*;
 pub use bills::*;
 pub use ch_bills::*;
 pub use dto::*;

--- a/packages/dto/src/tables/spaces/space.rs
+++ b/packages/dto/src/tables/spaces/space.rs
@@ -18,10 +18,9 @@ pub struct Space {
     #[api_model(summary, type = INTEGER, action = [create_space])]
     #[serde(default)]
     pub space_type: SpaceType,
-    #[api_model(version = v0.1, summary, type = INTEGER, action = [create_space])]
-    #[serde(default)]
-    pub space_form: SpaceForm,
-
+    // #[api_model(version = v0.1, summary, type = INTEGER, action = [create_space])]
+    // #[serde(default)]
+    // pub space_form: SpaceForm,
     #[api_model(summary, many_to_one = users)]
     pub user_id: i64,
     #[api_model(summary, many_to_one = industries)]
@@ -34,9 +33,10 @@ pub struct Space {
     pub proposer_profile: Option<String>,
     #[api_model(summary)]
     pub proposer_nickname: Option<String>,
-    #[api_model(summary , type = INTEGER)]
-    #[serde(default)]
-    pub content_type: ContentType,
+    // FIXME: remove this field. duplicated with industry_id
+    // #[api_model(summary , type = INTEGER)]
+    // #[serde(default)]
+    // pub content_type: ContentType,
     #[api_model(summary, version = v0.1, type = INTEGER)]
     #[serde(default)]
     pub status: SpaceStatus,
@@ -44,28 +44,35 @@ pub struct Space {
     #[serde(default)]
     pub files: Vec<File>,
 
+    // FIXME: separate members into a different table for joined table of users and spaces
     #[api_model(one_to_many = space_members, foreign_key = space_id)]
     #[serde(default)]
     pub members: Vec<SpaceMember>,
     #[api_model(summary, one_to_many = space_contracts, foreign_key = space_id)]
     #[serde(default)]
     pub contracts: Vec<SpaceContract>,
+    // FIXME: separate holders into a different table for joined table of users and spaces
     #[api_model(summary, one_to_many = space_holders, foreign_key = space_id)]
     #[serde(default)]
     pub holders: Vec<SpaceHolder>,
 
-    #[api_model(summary, many_to_many = space_users, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = space_id, aggregator = count, unique)]
-    #[serde(default)]
-    pub likes: i64,
-    #[api_model(summary, one_to_many = space_comments, foreign_key = space_id, aggregator=count)]
-    #[serde(default)]
-    pub comments: i64,
-    #[api_model(summary)]
-    #[serde(default)]
-    pub rewards: i64,
-    #[api_model(summary)]
-    #[serde(default)]
-    pub shares: i64,
+    // #[api_model(summary, many_to_many = space_users, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = space_id, aggregator = count, unique)]
+    // #[serde(default)]
+    // pub likes: i64,
+    // #[api_model(summary, one_to_many = space_comments, foreign_key = space_id, aggregator=count)]
+    // #[serde(default)]
+    // pub comments: i64,
+    // #[api_model(summary)]
+    // #[serde(default)]
+    // pub rewards: i64,
+    // #[api_model(summary)]
+    // #[serde(default)]
+    // pub shares: i64,
+    #[api_model(one_to_many = users, reference_key = user_id, foreign_key = id, summary)]
+    pub author: Vec<User>,
+
+    #[api_model(one_to_many = industries, reference_key = industry_id, foreign_key = id, summary)]
+    pub industry: Vec<Industry>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]
@@ -79,25 +86,13 @@ pub enum SpaceStatus {
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]
 #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
-pub enum SpaceForm {
+pub enum SpaceType {
     #[default]
     Legislation = 1,
-
     Poll = 2,
     Deliberation = 3,
     Nft = 4,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]
-#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
-pub enum SpaceType {
-    #[default]
-    Post = 1,
-
-    // Belows are kinds of comments
-    Reply = 2,
-    Repost = 3,
-    DocReview = 4,
+    Commitee = 5,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]
@@ -112,7 +107,7 @@ pub enum ContentType {
 
 pub use bdk::prelude::*;
 
-use crate::{SpaceContract, SpaceHolder, SpaceMember};
+use crate::{Industry, SpaceContract, SpaceHolder, SpaceMember, User};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]

--- a/packages/main-api/src/controllers/v1/spaces.rs
+++ b/packages/main-api/src/controllers/v1/spaces.rs
@@ -40,7 +40,6 @@ impl SpaceController {
         auth: Option<Authorization>,
         SpaceCreateSpaceRequest {
             space_type,
-            space_form,
             feed_id,
             user_ids,
         }: SpaceCreateSpaceRequest,
@@ -74,17 +73,13 @@ impl SpaceController {
                 feed.title,
                 feed.html_contents,
                 space_type,
-                space_form,
                 user.id,
                 feed.industry_id,
                 feed_id,
                 Some(user.profile_url),
                 Some(user.nickname),
-                ContentType::Crypto,
                 SpaceStatus::Draft,
                 feed.files,
-                0,
-                0,
             )
             .await
             .map_err(|e| {


### PR DESCRIPTION
- Introduced a new `Badge` table with fields such as `id`, `created_at`, `updated_at`, `creator_id`, `name`, `scope`, `image_url`, and optional fields `contract` and `token_id`.
- Added a `Scope` enum to define badge scopes (`Global`, `Space`, `Team`).
- Updated the `Space` table:
  - Removed unused fields like `space_form`, `content_type`, `likes`, `comments`, `rewards`, and `shares`.
  - Added new relationships: `author` (one-to-many with `users`) and `industry` (one-to-many with `industries`).
  - Added `FIXME` comments to indicate areas for improvement, such as separating `members` and `holders` into joined tables.
- Updated the `SpaceController` to remove references to the deprecated `space_form` field.