### PR TITLE
fix signup logic

### DIFF
--- a/packages/dto/src/tables/users/user.rs
+++ b/packages/dto/src/tables/users/user.rs
@@ -34,7 +34,7 @@ pub struct User {
     pub user_type: UserType,
     #[api_model(version = v0.1, indexed)]
     pub parent_id: Option<i64>,
-    #[api_model(version = v0.1, indexed, unique)]
+    #[api_model(action = signup, version = v0.1, indexed, unique)]
     pub username: String,
 
     #[api_model(one_to_many = followers, foreign_key = user_id)]

--- a/packages/main-api/src/controllers/v1/users.rs
+++ b/packages/main-api/src/controllers/v1/users.rs
@@ -141,8 +141,6 @@ impl UserControllerV1 {
             return Err(Error::BadRequest);
         }
 
-        let username = req.email.split("@").collect::<Vec<&str>>()[0].to_string();
-
         if let Ok(user) = User::query_builder()
             .principal_equals(principal.clone())
             .user_type_equals(UserType::Anonymous)
@@ -161,7 +159,7 @@ impl UserControllerV1 {
                         .with_profile_url(req.profile_url)
                         .with_term_agreed(req.term_agreed)
                         .with_informed_agreed(req.informed_agreed)
-                        .with_username(username)
+                        .with_username(req.username)
                         .with_user_type(UserType::Individual),
                 )
                 .await?;
@@ -180,7 +178,7 @@ impl UserControllerV1 {
                 req.informed_agreed,
                 UserType::Individual,
                 None,
-                username,
+                req.username,
                 "".to_string(),
             )
             .await?;
@@ -210,9 +208,9 @@ impl UserControllerV1 {
         &self,
         UserReadAction { principal, .. }: UserReadAction,
     ) -> Result<Json<User>> {
+        tracing::debug!("principal 111: {:?}", principal);
         let user = User::query_builder()
             .principal_equals(principal.ok_or(Error::InvalidUser)?)
-            .user_type_equals(UserType::Individual)
             .query()
             .map(User::from)
             .fetch_one(&self.pool)


### PR DESCRIPTION
signup username 필드 외부에서 입력받을 수 있도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usernames provided during signup are now accepted directly, rather than being derived from email addresses.

- **Other Changes**
  - Improved debug logging for user information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->