### PR TITLE
feat(dto): add Onboard model and integrate with Feed

### DIFF
--- a/packages/dto/src/joined_tables/mod.rs
+++ b/packages/dto/src/joined_tables/mod.rs
@@ -2,6 +2,7 @@ mod election_pledges_quizzes;
 mod election_pledges_users;
 mod feed_users;
 mod group_member;
+mod onboards;
 mod redeem_codes;
 mod space_badges;
 mod space_users;
@@ -21,6 +22,7 @@ pub use advocacy_campaign_authors::*;
 mod advocacy_campaign_voters;
 pub use advocacy_campaign_voters::*;
 
+pub use onboards::*;
 pub use redeem_codes::*;
 pub use space_badges::*;
 pub use user_badges::*;

--- a/packages/dto/src/joined_tables/onboards.rs
+++ b/packages/dto/src/joined_tables/onboards.rs
@@ -1,0 +1,16 @@
+use bdk::prelude::*;
+use validator::Validate;
+
+#[derive(Validate)]
+#[api_model(table = onboards)]
+pub struct Onboard {
+    #[api_model(primary_key)]
+    pub id: i64,
+    #[api_model(auto = [insert])]
+    pub created_at: i64,
+    #[api_model(auto = [insert, update])]
+    pub updated_at: i64,
+
+    #[api_model(indexed)]
+    pub meta_id: i64,
+}

--- a/packages/dto/src/tables/feeds/feed.rs
+++ b/packages/dto/src/tables/feeds/feed.rs
@@ -70,6 +70,10 @@ pub struct Feed {
 
     #[api_model(one_to_many = industries, reference_key = industry_id, foreign_key = id, summary)]
     pub industry: Vec<Industry>,
+
+    #[api_model(one_to_many = onboards, foreign_key = meta_id, summary, aggregator = exist)]
+    #[serde(default)]
+    pub onboard: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, ApiModel, Translate, Copy)]

--- a/packages/main-api/src/main.rs
+++ b/packages/main-api/src/main.rs
@@ -74,6 +74,7 @@ async fn migration(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<()> {
         UserBadge,
         SpaceBadge,
         SpaceGroup,
+        Onboard,
     );
 
     if Industry::query_builder()


### PR DESCRIPTION
Introduce the Onboard model in `joined_tables` with relevant fields and validations. Update Feed to include a one-to-many relationship with Onboard, enabling aggregation and summary functionality.