### PR TITLE
feat(users): add support for EVM address management

### DIFF
--- a/packages/dto/src/tables/feeds/feed.rs
+++ b/packages/dto/src/tables/feeds/feed.rs
@@ -1,7 +1,7 @@
 use bdk::prelude::*;
 use validator::Validate;
 
-use crate::{File, Industry, Space, User};
+use crate::*;
 
 #[derive(Validate)]
 #[api_model(base = "/v1/feeds", table = feeds, action = [], action_by_id = [delete, like(value = bool)])]
@@ -70,7 +70,7 @@ pub struct Feed {
     pub url_type: UrlType,
 
     #[api_model(one_to_many = users, reference_key = user_id, foreign_key = id, summary)]
-    pub author: Vec<User>,
+    pub author: Vec<FeedAuthor>,
 
     #[api_model(one_to_many = industries, reference_key = industry_id, foreign_key = id, summary)]
     pub industry: Vec<Industry>,

--- a/packages/dto/src/tables/users/feed_author.rs
+++ b/packages/dto/src/tables/users/feed_author.rs
@@ -1,0 +1,24 @@
+use bdk::prelude::*;
+
+use super::UserType;
+
+#[derive(validator::Validate)]
+#[api_model(table = users)]
+pub struct FeedAuthor {
+    pub id: i64,
+    pub created_at: i64,
+    pub updated_at: i64,
+
+    pub nickname: String,
+    pub principal: String,
+    pub profile_url: String,
+
+    #[api_model(type = INTEGER, indexed, version = v0.1)]
+    pub user_type: UserType,
+    pub parent_id: Option<i64>,
+    pub username: String,
+
+    // profile contents
+    #[serde(default)]
+    pub html_contents: String,
+}

--- a/packages/dto/src/tables/users/mod.rs
+++ b/packages/dto/src/tables/users/mod.rs
@@ -1,5 +1,6 @@
 mod author;
 mod bot;
+mod feed_author;
 mod my_info;
 mod team;
 mod total_info;
@@ -7,6 +8,7 @@ mod user;
 
 pub use author::*;
 pub use bot::*;
+pub use feed_author::*;
 pub use my_info::*;
 pub use team::*;
 pub use total_info::*;

--- a/packages/dto/src/tables/users/user.rs
+++ b/packages/dto/src/tables/users/user.rs
@@ -58,6 +58,10 @@ pub struct User {
     #[api_model(many_to_many = user_badges, foreign_table_name = badges, foreign_primary_key = badge_id, foreign_reference_key = user_id)]
     #[serde(default)]
     pub badges: Vec<Badge>,
+
+    #[api_model(version = v0.3, indexed, unique, action = signup, action = update_evm_address)]
+    #[serde(default)]
+    pub evm_address: String,
 }
 
 impl User {

--- a/packages/main-api/src/controllers/v1/bots.rs
+++ b/packages/main-api/src/controllers/v1/bots.rs
@@ -91,8 +91,9 @@ impl BotController {
                 false,
                 UserType::Bot,
                 Some(user_id),
-                username,
+                username.clone(),
                 "".to_string(),
+                username,
             )
             .await?;
 

--- a/packages/main-api/src/controllers/v1/spaces/badges.rs
+++ b/packages/main-api/src/controllers/v1/spaces/badges.rs
@@ -114,8 +114,10 @@ impl SpaceBadgeController {
 
         for b in badges.iter() {
             let path = format!(
-                "{}/json/{:064x}.json",
+                "{}/json/{}/{}/{}.json",
                 c.asset_dir,
+                config::get().env,
+                space_id,
                 b.token_id.unwrap_or_default()
             );
             match self

--- a/packages/main-api/src/controllers/v1/teams.rs
+++ b/packages/main-api/src/controllers/v1/teams.rs
@@ -99,8 +99,9 @@ impl TeamController {
                 false,
                 UserType::Team,
                 Some(user_id),
-                username,
+                username.clone(),
                 html_contents,
+                username,
             )
             .await
             .map_err(|e| {

--- a/packages/main-api/src/main.rs
+++ b/packages/main-api/src/main.rs
@@ -110,6 +110,7 @@ async fn migration(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<()> {
                 None,
                 "admin".to_string(),
                 "".to_string(),
+                "0x000".to_string(),
             )
             .await?;
     }
@@ -215,6 +216,7 @@ pub mod tests {
                 None,
                 email.clone(),
                 "".to_string(),
+                id.clone(),
             )
             .await?
             .unwrap();
@@ -249,6 +251,7 @@ pub mod tests {
                 None,
                 email.clone(),
                 "".to_string(),
+                id.to_string(),
             )
             .await?;
 

--- a/packages/main-api/src/utils/users.rs
+++ b/packages/main-api/src/utils/users.rs
@@ -33,6 +33,7 @@ pub async fn extract_user_with_allowing_anonymous(
                             None,
                             principal.clone(),
                             "".to_string(),
+                            principal.clone(),
                         )
                         .await?
                 }


### PR DESCRIPTION
Introduce `evm_address` field in the `User` model to support Ethereum Virtual Machine (EVM) address management. Added functionality for updating EVM addresses via `update_evm_address` action in the `UserControllerV1`. Updated related controllers and utilities to handle the new field.