### PR TITLE
feat(dto): enhance group permissions and user membership structure

### DIFF
--- a/packages/dto/src/tables/groups/group.rs
+++ b/packages/dto/src/tables/groups/group.rs
@@ -85,11 +85,19 @@ impl Default for GroupPermissions {
     fn default() -> Self {
         Self(vec![
             GroupPermission::ReadPosts,
+            GroupPermission::WritePosts,
+            GroupPermission::DeletePosts,
+            GroupPermission::WritePendingPosts,
+            GroupPermission::ReadPostDrafts,
             GroupPermission::ReadReplies,
             GroupPermission::WriteReplies,
             GroupPermission::DeleteReplies,
             GroupPermission::ReadProfile,
             GroupPermission::UpdateProfile,
+            GroupPermission::InviteMember,
+            GroupPermission::ManageGroup,
+            GroupPermission::DeleteGroup,
+            GroupPermission::ManageSpace,
         ])
     }
 }

--- a/packages/dto/src/tables/users/user.rs
+++ b/packages/dto/src/tables/users/user.rs
@@ -82,6 +82,10 @@ pub struct User {
     #[api_model(version = v0.4, action = [email_signup], read_action = login_by_password)]
     #[serde(default)]
     pub password: String,
+
+    #[api_model(version = v0.5, type = INTEGER)]
+    #[serde(default)]
+    pub membership: Membership,
 }
 
 impl User {
@@ -106,30 +110,14 @@ pub enum UserType {
 #[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
 pub enum Membership {
     #[default]
-    #[translate(en = "General", ko = "일반")]
-    General = 1,
-    #[translate(en = "Limited", ko = "리미티드")]
-    Limited = 2,
+    #[translate(en = "Free", ko = "일반")]
+    Free = 1,
+    #[translate(en = "Starter", ko = "스타터")]
+    Paid1 = 2,
     #[translate(en = "Premium", ko = "프리미엄")]
-    Premium = 3,
-}
-
-impl Membership {
-    pub fn get_description(&self) -> &'static str {
-        match self {
-            Membership::General => "General membership with basic features.",
-            Membership::Limited => "Limited membership with some advanced features.",
-            Membership::Premium => {
-                "Premium membership with all features.(receive legislative updates ahead of others"
-            }
-        }
-    }
-
-    pub fn get_price(&self) -> i32 {
-        match self {
-            Membership::General => 10000,
-            Membership::Limited => 30000,
-            Membership::Premium => 50000,
-        }
-    }
+    Paid2 = 3,
+    #[translate(en = "VIP", ko = "VIP")]
+    Paid3 = 4,
+    #[translate(en = "Admin", ko = "관리자")]
+    Admin = 99,
 }

--- a/packages/main-api/src/controllers/v1/bots.rs
+++ b/packages/main-api/src/controllers/v1/bots.rs
@@ -12,7 +12,7 @@ use by_types::QueryResponse;
 use dto::*;
 use sqlx::postgres::PgRow;
 
-use crate::utils::users::extract_user_id;
+use crate::utils::users::{extract_user, extract_user_id};
 
 #[derive(
     Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema, aide::OperationIo,
@@ -79,7 +79,8 @@ impl BotController {
             username,
         }: BotCreateRequest,
     ) -> Result<Bot> {
-        let user_id = extract_user_id(&self.pool, auth).await?;
+        let user = extract_user(&self.pool, auth).await?;
+        let user_id = user.id;
         let repo = User::get_repository(self.pool.clone());
         let bot = repo
             .insert(
@@ -95,6 +96,7 @@ impl BotController {
                 "".to_string(),
                 username,
                 "".to_string(),
+                user.membership,
             )
             .await?;
 

--- a/packages/main-api/src/controllers/v1/teams.rs
+++ b/packages/main-api/src/controllers/v1/teams.rs
@@ -104,6 +104,7 @@ impl TeamController {
                 html_contents,
                 username,
                 "".to_string(),
+                Membership::Free,
             )
             .await
             .map_err(|e| {

--- a/packages/main-api/src/controllers/v1/users.rs
+++ b/packages/main-api/src/controllers/v1/users.rs
@@ -250,6 +250,7 @@ impl UserControllerV1 {
                 "".to_string(),
                 req.evm_address,
                 "".to_string(),
+                Membership::Free,
             )
             .await?;
 
@@ -307,6 +308,7 @@ impl UserControllerV1 {
                 "".to_string(),
                 "".to_string(),
                 req.password,
+                Membership::Free,
             )
             .await?;
 

--- a/packages/main-api/src/main.rs
+++ b/packages/main-api/src/main.rs
@@ -132,6 +132,7 @@ async fn migration(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<()> {
                 "".to_string(),
                 "0x000".to_string(),
                 "password".to_string(),
+                Membership::Free,
             )
             .await?;
     }
@@ -317,6 +318,7 @@ pub mod tests {
                 email.clone(),
                 "".to_string(),
                 format!("0x{}", id),
+                Membership::Free,
             )
             .await?
             .unwrap();
@@ -352,6 +354,7 @@ pub mod tests {
                 email.clone(),
                 "".to_string(),
                 format!("0x{}", id),
+                Membership::Free,
             )
             .await?;
 

--- a/packages/main-api/src/utils/users.rs
+++ b/packages/main-api/src/utils/users.rs
@@ -35,6 +35,7 @@ pub async fn extract_user_with_allowing_anonymous(
                             "".to_string(),
                             principal.clone(),
                             "".to_string(),
+                            Membership::Free,
                         )
                         .await?
                 }

--- a/packages/racing-space/index.html
+++ b/packages/racing-space/index.html
@@ -7,9 +7,5 @@
     <link data-trunk rel="copy-dir" href="assets">
   </head>
   <body style="width: 100%; height: 100%;">
-    <script type="module">
-     import init from './target/racing-space.js';
-     init();
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Added new permissions to `GroupPermissions` default implementation, including `InviteMember`, `ManageGroup`, and `ManageSpace`. Updated `Membership` enum in `User` struct to include new membership levels (`Free`, `Starter`, `VIP`, etc.) and removed redundant methods. Adjusted related controllers and utilities to incorporate the updated membership structure. Removed unused script initialization in `racing-space/index.html`.