### PR TITLE
feat(api): add logout functionality for users

### DIFF
--- a/packages/main-api/src/controllers/v2/users/logout.rs
+++ b/packages/main-api/src/controllers/v2/users/logout.rs
@@ -1,0 +1,13 @@
+use bdk::prelude::by_axum::axum::Json;
+use dto::{Error, Result};
+use tower_sessions::Session;
+
+pub async fn logout_handler(session: Session) -> Result<Json<()>> {
+    if let Err(e) = session.delete().await {
+        tracing::error!("Failed to delete session: {}", e);
+
+        return Err(Error::Unknown("failed to delete session".to_string()));
+    }
+
+    Ok(Json(()))
+}

--- a/packages/main-api/src/lib.rs
+++ b/packages/main-api/src/lib.rs
@@ -1,0 +1,19 @@
+pub mod controllers {
+    pub mod m1;
+    pub mod mcp;
+    pub mod v1;
+    pub mod v2 {
+        pub mod users {
+            pub mod logout;
+        }
+    }
+}
+
+pub mod config;
+pub mod models;
+pub mod route;
+pub mod security;
+pub mod utils;
+
+pub use bdk::prelude::*;
+pub use dto::*;

--- a/packages/main-api/src/route.rs
+++ b/packages/main-api/src/route.rs
@@ -1,0 +1,15 @@
+use bdk::prelude::*;
+
+use crate::controllers::{self, v2::users::logout::logout_handler};
+
+use dto::{Result, by_axum::axum::native_routing::post};
+
+pub async fn route(pool: sqlx::Pool<sqlx::Postgres>) -> Result<by_axum::axum::Router> {
+    Ok(by_axum::axum::Router::new()
+        .nest("/v1", controllers::v1::route(pool.clone()).await?)
+        .nest(
+            "/m1",
+            controllers::m1::MenaceController::route(pool.clone())?,
+        )
+        .native_route("/v2/users/logout", post(logout_handler)))
+}

--- a/ts-packages/web/src/app/api/logout/route.ts
+++ b/ts-packages/web/src/app/api/logout/route.ts
@@ -1,3 +1,5 @@
+import { config } from '@/config';
+import { ratelApi } from '@/lib/api/ratel_api';
 import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -6,6 +8,19 @@ export async function POST(request: NextRequest) {
   const host = request.headers.get('host') || 'localhost';
 
   logger.debug('host', host);
+
+  const apiBaseUrl: string = config.api_url;
+
+  let targetUrl = `${apiBaseUrl}${ratelApi.users.logout()}`;
+  const res = await fetch(targetUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Cookie: request.headers.get('cookie') || '',
+    },
+  });
+
+  logger.debug('response header', res.headers, 'status', res.status);
 
   const response = NextResponse.json(
     { message: 'Logout successful' },

--- a/ts-packages/web/src/lib/api/ratel_api.ts
+++ b/ts-packages/web/src/lib/api/ratel_api.ts
@@ -55,6 +55,7 @@ export function useFeedById(id: number): UseSuspenseQueryResult<Feed> {
 export const ratelApi = {
   users: {
     login: () => '/v1/users?action=login',
+    logout: () => '/v2/users/logout',
     loginWithPassword: (email: string, password: string) =>
       `/v1/users?action=login-by-password&email=${encodeURIComponent(email)}&password=${password}`,
     getTotalInfo: (page: number, size: number) =>


### PR DESCRIPTION
Introduce a new logout endpoint in the main API under `/v2/users/logout`.
- Added `logout_handler` to handle session deletion in `logout.rs`.
- Refactored routing logic to include the new endpoint in `route.rs`.
- Updated `main.rs` to use the centralized routing module.

feat(web): integrate logout API in the web application

- Updated `route.ts` to call the new logout API endpoint.
- Added `logout` method to `ratelApi` for constructing the logout URL.

These changes enable user logout functionality across the backend and frontend.