### PR TITLE
feat(auth): implement environment-specific cookie naming for session and auth tokens

### DIFF
--- a/ts-packages/web/src/app/api/login/route.ts
+++ b/ts-packages/web/src/app/api/login/route.ts
@@ -39,8 +39,10 @@ export async function GET(request: NextRequest) {
   const setCookies: string[] = res.headers.getSetCookie();
   logger.debug('raw set-cookie headers:', setCookies);
 
-  const idCookie = setCookies.find((c) => c.startsWith('id='));
-  const authCookie = setCookies.find((c) => c.startsWith('auth_token='));
+  const idCookie = setCookies.find((c) => c.startsWith(`${config.env}_sid=`));
+  const authCookie = setCookies.find((c) =>
+    c.startsWith(`${config.env}_auth_token=`),
+  );
 
   const commonSuffix =
     protocol === 'https'
@@ -65,17 +67,6 @@ export async function GET(request: NextRequest) {
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
       'Access-Control-Allow-Credentials': 'true',
       'Set-Cookie': cookies.join(', '),
-    },
-  });
-}
-
-export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 200,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': '*',
-      'Access-Control-Allow-Headers': '*',
     },
   });
 }

--- a/ts-packages/web/src/app/api/logout/route.ts
+++ b/ts-packages/web/src/app/api/logout/route.ts
@@ -28,20 +28,20 @@ export async function POST(request: NextRequest) {
   );
 
   if (host.includes('localhost')) {
-    response.cookies.set('id', '', {
+    response.cookies.set(`${config.env}_sid`, '', {
       maxAge: 0,
       path: '/',
       sameSite: 'lax',
       domain: 'localhost',
     });
-    response.cookies.set('auth_token', '', {
+    response.cookies.set(`${config.env}_auth_token`, '', {
       maxAge: 0,
       path: '/',
       sameSite: 'lax',
       domain: 'localhost',
     });
   } else {
-    response.cookies.set('id', '', {
+    response.cookies.set(`${config.env}_sid`, '', {
       maxAge: 0,
       path: '/',
       sameSite: 'none',
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
       secure: true,
       httpOnly: true,
     });
-    response.cookies.set('auth_token', '', {
+    response.cookies.set(`${config.env}_auth_token`, '', {
       maxAge: 0,
       path: '/',
       sameSite: 'none',

--- a/ts-packages/web/src/middleware.ts
+++ b/ts-packages/web/src/middleware.ts
@@ -6,6 +6,17 @@ export function middleware(req: NextRequest) {
   let sessionId = req.cookies.get('nx_session_id')?.value;
   const exists = sessionId !== undefined;
 
+  if (req.method === 'OPTIONS') {
+    return new NextResponse(null, {
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': '*',
+        'Access-Control-Allow-Headers': '*',
+      },
+    });
+  }
+
   if (!sessionId) {
     sessionId = uuidv4();
     req.cookies.set('nx_session_id', sessionId);


### PR DESCRIPTION
- Updated Rust SDK submodule to the latest commit.
- Introduced environment-specific cookie names for session (`<env>_sid`) and auth tokens (`<env>_auth_token`) in the Rust backend.
- Modified session layer configuration to dynamically set cookie names and attributes based on the environment.
- Adjusted cookie handling in the `login` and `logout` API routes to use environment-specific cookie names in the TypeScript frontend.
- Added CORS preflight handling for `OPTIONS` requests in middleware and API routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication and session cookies now use environment-specific names for improved separation between environments.
  * Session and authentication cookie security settings are dynamically adjusted based on the environment.

* **Bug Fixes**
  * Improved handling of CORS preflight (OPTIONS) requests in middleware for better cross-origin compatibility.

* **Chores**
  * Updated dependencies for the Rust SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->