### PR TITLE
Feature/team posting

### DIFF
--- a/packages/dto/src/tables/discussions/discussion.rs
+++ b/packages/dto/src/tables/discussions/discussion.rs
@@ -38,6 +38,9 @@ pub struct Discussion {
     #[api_model(summary, action_by_id = update, nullable, version = v0.2)]
     #[serde(default)]
     pub media_pipeline_arn: Option<String>,
+    #[api_model(summary, action_by_id = update, nullable, version = v0.3)]
+    #[serde(default)]
+    pub record: Option<String>,
 
     #[api_model(summary, many_to_many = discussion_members, foreign_table_name = users, foreign_primary_key = user_id, foreign_reference_key = discussion_id)]
     #[serde(default)]

--- a/packages/dto/src/tables/discussions/discussion.rs
+++ b/packages/dto/src/tables/discussions/discussion.rs
@@ -3,8 +3,9 @@ use validator::Validate;
 
 use crate::*;
 
+//NOTE: discussion_id: need to use optional variables to check whether the action I am taking is creation, deletion, or update.
 #[derive(Validate)]
-#[api_model(base = "/v1/spaces/:space-id/discussions", table = discussions, action = [create(participants = Vec<i64>)], action_by_id = [start_meeting, participant_meeting, exit_meeting, start_recording, end_recording, delete])]
+#[api_model(base = "/v1/spaces/:space-id/discussions", table = discussions, action = [create(participants = Vec<i64>, discussion_id = Option<i64>)], action_by_id = [start_meeting, participant_meeting, exit_meeting, start_recording, end_recording, delete])]
 pub struct Discussion {
     #[api_model(summary, primary_key)]
     pub id: i64,

--- a/packages/main-api/src/controllers/v1/spaces.rs
+++ b/packages/main-api/src/controllers/v1/spaces.rs
@@ -303,6 +303,7 @@ impl SpaceController {
                     None,
                     "".to_string(),
                     None,
+                    None,
                 )
                 .await
             {

--- a/packages/main-api/src/controllers/v1/spaces.rs
+++ b/packages/main-api/src/controllers/v1/spaces.rs
@@ -332,7 +332,7 @@ impl SpaceController {
                     .discussion_id_equals(id)
                     .query()
                     .map(DiscussionParticipant::from)
-                    .fetch_all(&mut *tx)
+                    .fetch_all(&self.pool.clone())
                     .await?;
 
                 for p in ps {

--- a/packages/main-api/src/controllers/v1/spaces/discussions.rs
+++ b/packages/main-api/src/controllers/v1/spaces/discussions.rs
@@ -438,7 +438,12 @@ impl SpaceDiscussionController {
             return Err(Error::PipelineNotFound);
         }
 
-        let _ = client.end_pipeline(&discussion.pipeline_id).await?;
+        let _ = client
+            .end_pipeline(
+                &discussion.pipeline_id,
+                &discussion.clone().meeting_id.unwrap_or_default(),
+            )
+            .await?;
 
         //FIXME: store s3 mp4 file to db
 

--- a/packages/main-api/src/controllers/v1/spaces/discussions.rs
+++ b/packages/main-api/src/controllers/v1/spaces/discussions.rs
@@ -56,8 +56,10 @@ impl SpaceDiscussionController {
             name,
             description,
             participants,
+            discussion_id,
         }: DiscussionCreateRequest,
     ) -> Result<Discussion> {
+        let _discussion_id = discussion_id;
         let user = extract_user_with_allowing_anonymous(&self.pool, auth).await?;
 
         let mut tx = self.pool.begin().await?;

--- a/packages/main-api/src/controllers/v1/spaces/discussions.rs
+++ b/packages/main-api/src/controllers/v1/spaces/discussions.rs
@@ -75,6 +75,7 @@ impl SpaceDiscussionController {
                 None,
                 "".to_string(),
                 None,
+                None,
             )
             .await?;
 

--- a/packages/main-api/src/models/folder_type/folder_type.rs
+++ b/packages/main-api/src/models/folder_type/folder_type.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FolderType {
+    Video,
+    Audio,
+    MeetingEvents,
+    Etc,
+}
+
+impl FromStr for FolderType {
+    type Err = ();
+
+    fn from_str(key: &str) -> Result<Self, Self::Err> {
+        if key.contains("/video/") {
+            Ok(FolderType::Video)
+        } else if key.contains("/audio/") {
+            Ok(FolderType::Audio)
+        } else if key.contains("/meeting-events/") {
+            Ok(FolderType::MeetingEvents)
+        } else {
+            Ok(FolderType::Etc)
+        }
+    }
+}
+
+impl fmt::Display for FolderType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            FolderType::Video => "video",
+            FolderType::Audio => "audio",
+            FolderType::MeetingEvents => "meeting-events",
+            FolderType::Etc => "etc",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/packages/main-api/src/models/mod.rs
+++ b/packages/main-api/src/models/mod.rs
@@ -4,3 +4,7 @@ pub mod openapi {
     pub mod national_proposer;
     pub mod national_vote;
 }
+
+pub mod folder_type {
+    pub mod folder_type;
+}

--- a/packages/main-api/src/utils/aws_chime_sdk_meeting.rs
+++ b/packages/main-api/src/utils/aws_chime_sdk_meeting.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::Error;
+use crate::{Error, models::folder_type::folder_type::FolderType};
 use aws_config::{BehaviorVersion, load_defaults};
 use aws_sdk_chimesdkmediapipelines::{
     Client as MediaPipelinesClient,
@@ -338,15 +338,7 @@ impl ChimeMeetingService {
                 if let Some(key) = obj.key {
                     let filename = key.split('/').last().unwrap_or("artifact");
 
-                    let folder = if key.contains("/video/") {
-                        "video"
-                    } else if key.contains("/audio/") {
-                        "audio"
-                    } else if key.contains("/meeting-events/") {
-                        "meeting-events"
-                    } else {
-                        "etc"
-                    };
+                    let folder: FolderType = key.parse().unwrap_or(FolderType::Etc);
 
                     let destination_key =
                         format!("{}/{}/{}/{}", conf.env, meeting_id, folder, filename);

--- a/packages/main-api/src/utils/aws_chime_sdk_meeting.rs
+++ b/packages/main-api/src/utils/aws_chime_sdk_meeting.rs
@@ -11,6 +11,7 @@ use aws_sdk_chimesdkmeetings::{
 };
 use aws_sdk_s3::Client as S3Client;
 use dto::*;
+use tokio::time::{Duration, sleep};
 
 #[derive(Debug)]
 pub struct AttendeeInfo {
@@ -241,57 +242,142 @@ impl ChimeMeetingService {
             .and_then(|p| Some((p.media_pipeline_id.clone(), p.media_pipeline_arn.clone())))
             .unwrap_or_default();
 
-        // let object_key = format!("{}.mp4", pipeline_id);
-        // let destination_key = format!("chime/{}", object_key);
-
-        // self.s3
-        //     .copy_object()
-        //     .copy_source(format!("{}/{}", bucket_name, object_key))
-        //     .bucket(&bucket_name)
-        //     .key(&destination_key)
-        //     .send()
-        //     .await
-        //     .map_err(|e| {
-        //         tracing::error!("failed to copy Chime artifact to chime/ folder: {:?}", e);
-        //         Error::AwsS3Error(e.to_string())
-        //     })?;
-
-        // self.s3
-        //     .delete_object()
-        //     .bucket(&bucket_name)
-        //     .key(&object_key)
-        //     .send()
-        //     .await
-        //     .map_err(|e| {
-        //         tracing::warn!(
-        //             "failed to delete original Chime artifact after copy: {:?}",
-        //             e
-        //         );
-        //         Error::AwsS3Error(e.to_string())
-        //     })?;
-
         Ok((
             pipeline_id.unwrap_or_default(),
             pipeline_arn.unwrap_or_default(),
         ))
     }
 
-    pub async fn end_pipeline(&self, pipeline_id: &str) -> Result<()> {
-        let resp = match self
+    pub async fn end_pipeline(&self, pipeline_id: &str, _meeting_id: &str) -> Result<()> {
+        let _bucket_name = crate::config::get().chime_bucket_name.to_string();
+
+        let resp = self
             .pipeline
             .delete_media_capture_pipeline()
             .media_pipeline_id(pipeline_id)
             .send()
             .await
-        {
-            Ok(v) => v,
-            Err(e) => {
+            .map_err(|e| {
                 tracing::error!("delete_media_capture_pipeline error: {:?}", e);
-                return Err(Error::AwsChimeError(e.to_string()));
-            }
-        };
+                Error::AwsChimeError(e.to_string())
+            })?;
 
         tracing::debug!("delete_media_capture_pipeline response: {:?}", resp);
+
+        Ok(())
+    }
+
+    pub async fn move_meeting_artifacts_with_retry(
+        &self,
+        bucket_name: &str,
+        meeting_id: &str,
+    ) -> Result<()> {
+        let prefix = format!("{}/", meeting_id);
+        let mut attempt = 0;
+        let max_attempts = 10;
+        let delay = Duration::from_secs(2);
+
+        loop {
+            attempt += 1;
+
+            let list_result = self
+                .s3
+                .list_objects_v2()
+                .bucket(bucket_name)
+                .prefix(&prefix)
+                .send()
+                .await
+                .map_err(|e| {
+                    tracing::error!("S3 list_objects_v2 failed on attempt {}: {:?}", attempt, e);
+                    Error::AwsS3Error(e.to_string())
+                })?;
+
+            if let Some(objects) = list_result.contents {
+                if !objects.is_empty() {
+                    tracing::info!("S3 artifacts found after {} attempt(s)", attempt);
+                    return self.move_meeting_artifacts(bucket_name, meeting_id).await;
+                }
+            }
+
+            if attempt >= max_attempts {
+                tracing::warn!(
+                    "No artifacts found after {} attempts (~{}s). Skipping move.",
+                    attempt,
+                    attempt * delay.as_secs()
+                );
+                return Ok(());
+            }
+
+            tracing::debug!(
+                "Waiting for artifacts... attempt {}/{}. Retrying in {}s",
+                attempt,
+                max_attempts,
+                delay.as_secs()
+            );
+            sleep(delay).await;
+        }
+    }
+
+    pub async fn move_meeting_artifacts(&self, bucket_name: &str, meeting_id: &str) -> Result<()> {
+        let conf = crate::config::get();
+
+        let list_result = self
+            .s3
+            .list_objects_v2()
+            .bucket(bucket_name)
+            .prefix(format!("{}/", meeting_id))
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::error!("S3 list_objects error: {:?}", e);
+                Error::AwsS3Error(e.to_string())
+            })?;
+
+        if let Some(objects) = list_result.contents {
+            for obj in objects {
+                if let Some(key) = obj.key {
+                    let filename = key.split('/').last().unwrap_or("artifact");
+
+                    let folder = if key.contains("/video/") {
+                        "video"
+                    } else if key.contains("/audio/") {
+                        "audio"
+                    } else if key.contains("/meeting-events/") {
+                        "meeting-events"
+                    } else {
+                        "etc"
+                    };
+
+                    let destination_key =
+                        format!("{}/{}/{}/{}", conf.env, meeting_id, folder, filename);
+
+                    tracing::debug!("Copying from {} to {}", key, destination_key);
+
+                    self.s3
+                        .copy_object()
+                        .copy_source(format!("{}/{}", bucket_name, key))
+                        .bucket(bucket_name)
+                        .key(&destination_key)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            tracing::error!("S3 copy error for {}: {:?}", key, e);
+                            Error::AwsS3Error(e.to_string())
+                        })?;
+
+                    self.s3
+                        .delete_object()
+                        .bucket(bucket_name)
+                        .key(&key)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            tracing::warn!("S3 delete error for {}: {:?}", key, e);
+                            Error::AwsS3Error(e.to_string())
+                        })?;
+                }
+            }
+        }
 
         Ok(())
     }

--- a/packages/main-api/src/utils/aws_media_convert.rs
+++ b/packages/main-api/src/utils/aws_media_convert.rs
@@ -148,7 +148,7 @@ pub async fn merge_recording_chunks(
                         media_pipeline_id
                     );
                 } else {
-                    tracing::warn!(
+                    tracing::error!(
                         "No objects found under media_pipeline_id prefix: {}",
                         cleanup_prefix
                     );
@@ -157,7 +157,7 @@ pub async fn merge_recording_chunks(
                 return Some(new_url);
             }
 
-            tracing::warn!("No mp4 file found in {}/video/", media_pipeline_id);
+            tracing::error!("No mp4 file found in {}/video/", media_pipeline_id);
             return None;
         } else {
             return Some(record);

--- a/packages/main-api/src/utils/aws_media_convert.rs
+++ b/packages/main-api/src/utils/aws_media_convert.rs
@@ -4,6 +4,7 @@ use dto::*;
 pub async fn merge_recording_chunks(
     meeting_id: &str,
     media_pipeline_arn: String,
+    record: Option<String>,
 ) -> Option<String> {
     use aws_config::{BehaviorVersion, Region, defaults};
     use aws_sdk_chimesdkmediapipelines::Client as ChimePipelinesClient;
@@ -35,6 +36,55 @@ pub async fn merge_recording_chunks(
 
     let bucket_name = config.chime_bucket_name.to_string();
     let destination_arn = format!("arn:aws:s3:::{}", bucket_name);
+
+    if let Some(record) = record {
+        if record.contains("video") {
+            return Some(record);
+        }
+
+        let trimmed = record
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+
+        let parts: Vec<&str> = trimmed.split('/').collect();
+
+        tracing::debug!("record parts: {:?}", parts);
+
+        let media_pipeline_id = match parts.get(1) {
+            Some(id) => *id,
+            None => {
+                tracing::warn!("Invalid record format: {}", record);
+                return None;
+            }
+        };
+
+        let prefix = format!("{}/video/", media_pipeline_id);
+
+        let s3 = aws_sdk_s3::Client::new(&aws_config);
+        let resp = s3
+            .list_objects_v2()
+            .bucket(&bucket_name)
+            .prefix(&prefix)
+            .send()
+            .await
+            .unwrap();
+
+        let contents = resp.contents();
+
+        if let Some(object) = contents
+            .iter()
+            .find(|obj| obj.key().map(|k| k.ends_with(".mp4")).unwrap_or(false))
+        {
+            let file_key = object.key().unwrap();
+
+            let video_url = format!("https://{}/{}", bucket_name, file_key);
+
+            return Some(video_url);
+        }
+
+        tracing::warn!("No mp4 file found in {}/video/", media_pipeline_id);
+        return None;
+    }
 
     let client = ChimePipelinesClient::new(&aws_config);
 
@@ -118,7 +168,15 @@ pub async fn merge_recording_chunks(
     match request.send().await {
         Ok(resp) => {
             tracing::info!("Concatenation pipeline started: {:?}", resp);
-            return Some(format!("s3://{}/concatenated/{}/", bucket_name, meeting_id));
+
+            if resp.media_concatenation_pipeline.is_none() {
+                return None;
+            }
+
+            match resp.media_concatenation_pipeline.unwrap().media_pipeline_id {
+                Some(v) => Some(format!("https://{}/{}", bucket_name, v)),
+                None => None,
+            }
         }
         Err(err) => {
             tracing::error!("Failed to start concatenation pipeline: {:?}", err);

--- a/ts-packages/web/src/app/(social)/threads/[id]/_components/header.tsx
+++ b/ts-packages/web/src/app/(social)/threads/[id]/_components/header.tsx
@@ -16,16 +16,26 @@ import SpaceCreateModal from './space-create-modal';
 import { SpaceType } from '@/lib/api/models/spaces';
 import { useRouter } from 'next/navigation';
 import { useSuspenseUserInfo } from '@/lib/api/hooks/users';
+import { useContext, useEffect, useState } from 'react';
+import { TeamContext } from '@/lib/contexts/team-context';
 
 export default function Header({ post_id }: { post_id: number }) {
   const { data: post } = useFeedByID(post_id);
   const popup = usePopup();
   const router = useRouter();
+  const { teams } = useContext(TeamContext);
   const user = useSuspenseUserInfo();
+  const [selectedTeam, setSelectedTeam] = useState<boolean>(false);
+
   const space_id = post?.spaces[0]?.id;
 
   const author_id = post?.author[0].id;
   const user_id = user.data ? user.data.id : 0;
+
+  useEffect(() => {
+    const index = teams.findIndex((t) => t.id === author_id);
+    setSelectedTeam(index !== -1);
+  }, [teams]);
 
   let target;
   if (space_id) {
@@ -63,7 +73,7 @@ export default function Header({ post_id }: { post_id: number }) {
           <Link href={target ?? ''}>
             <Button variant="rounded_secondary">Join Space</Button>
           </Link>
-        ) : author_id == user_id ? (
+        ) : author_id == user_id || selectedTeam ? (
           <Button variant="rounded_secondary" onClick={handleCreateSpace}>
             <Plus className="size-5" />
             Create Space

--- a/ts-packages/web/src/app/(social)/threads/[id]/_components/thread.tsx
+++ b/ts-packages/web/src/app/(social)/threads/[id]/_components/thread.tsx
@@ -12,13 +12,13 @@ export default function Thread({ post_id }: { post_id: number }) {
   return (
     <div className="flex flex-col w-full gap-2.5">
       <BlackBox>
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-5 w-full">
           <LexicalHtmlViewer htmlString={post?.html_contents || ''} />
           {post?.url && (
-            <div className="relative w-full h-72 rounded-[10px] overflow-hidden">
+            <div className="relative h-72 w-full rounded-[10px]">
               <Image
                 fill
-                className="object-cover"
+                className="object-contain"
                 src={post.url}
                 alt={post.title || 'Post Image'}
               />

--- a/ts-packages/web/src/app/spaces/[id]/_components/space_header.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/_components/space_header.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 // import Extra from '@/assets/icons/extra.svg';
 // import Bookmark from '@/assets/icons/bookmark.svg';
 import Badge from '@/assets/icons/badge.svg';
-import { getTimeAgo } from '@/lib/time-utils';
 import { UserType } from '@/lib/api/models/user';
 import Image from 'next/image';
 import { Input } from '@/components/ui/input';
 import { SpaceStatus } from '@/lib/api/models/spaces';
 import { Play } from 'lucide-react';
+import TimeAgo from './time_ago';
 
 export interface SpaceHeaderProps {
   title: string;
@@ -76,9 +76,7 @@ export default function SpaceHeader({
           <Badge />
         </div>
 
-        <div className="font-light text-white text-sm/[14px]">
-          {getTimeAgo(createdAt)}
-        </div>
+        <TimeAgo timestamp={createdAt} />
       </div>
     </div>
   );

--- a/ts-packages/web/src/app/spaces/[id]/_components/time_ago.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/_components/time_ago.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getTimeAgo } from '@/lib/time-utils';
+
+export default function TimeAgo({ timestamp }: { timestamp: number }) {
+  const [displayTime, setDisplayTime] = useState(getTimeAgo(timestamp));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDisplayTime(getTimeAgo(timestamp));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [timestamp]);
+
+  return (
+    <span className="font-light text-white text-sm/[14px]">{displayTime}</span>
+  );
+}

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/_components/deliberation.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/_components/deliberation.tsx
@@ -51,9 +51,7 @@ export default function DeliberationPage() {
           status={status}
           discussions={deliberation.discussions}
           discussionRaws={discussions}
-          viewRecord={async (discussionId: number, record: string) => {
-            await handleViewRecord(discussionId, record);
-          }}
+          viewRecord={handleViewRecord}
           onadd={(discussion: DiscussionInfo) => {
             setDeliberation({
               ...deliberation,

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/_components/deliberation.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/_components/deliberation.tsx
@@ -20,6 +20,7 @@ export default function DeliberationPage() {
     setTitle,
     deliberation,
     setDeliberation,
+    handleViewRecord,
     handleGoBack,
     status,
     proposerImage,
@@ -50,6 +51,9 @@ export default function DeliberationPage() {
           status={status}
           discussions={deliberation.discussions}
           discussionRaws={discussions}
+          viewRecord={async (discussionId: number, record: string) => {
+            await handleViewRecord(discussionId, record);
+          }}
           onadd={(discussion: DiscussionInfo) => {
             setDeliberation({
               ...deliberation,

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/_components/space_discussion.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/_components/space_discussion.tsx
@@ -33,6 +33,7 @@ export interface SpaceDiscussionProps {
   onremove?: (index: number) => void;
   onupdate?: (index: number, discussion: DiscussionInfo) => void;
   onadd?: (discussion: DiscussionInfo) => void;
+  viewRecord?: (discussionId: number, record: string) => void;
 }
 
 export default function SpaceDiscussion({
@@ -43,6 +44,7 @@ export default function SpaceDiscussion({
   onadd = () => {},
   onremove = () => {},
   onupdate = () => {},
+  viewRecord = () => {},
 }: SpaceDiscussionProps) {
   const router = useRouter();
   const { data: userInfo } = useSuspenseUserInfo();
@@ -84,6 +86,7 @@ export default function SpaceDiscussion({
           discussions={discussionRaws}
           status={status}
           moveDiscussion={moveDiscussion}
+          viewRecord={viewRecord}
         />
       )}
     </div>
@@ -95,11 +98,13 @@ function ViewDiscussion({
   discussions,
   status,
   moveDiscussion,
+  viewRecord,
 }: {
   userId: number;
   discussions: Discussion[];
   status: SpaceStatus;
   moveDiscussion: (spaceId: number, discussionId: number) => void;
+  viewRecord: (discussionId: number, record: string) => void;
 }) {
   return (
     <div className="flex flex-col w-full gap-2.5">
@@ -108,6 +113,7 @@ function ViewDiscussion({
         discussions={discussions}
         status={status}
         moveDiscussion={moveDiscussion}
+        viewRecord={viewRecord}
       />
     </div>
   );
@@ -118,11 +124,13 @@ function DiscussionSchedules({
   discussions,
   status,
   moveDiscussion,
+  viewRecord,
 }: {
   userId: number;
   discussions: Discussion[];
   status: SpaceStatus;
   moveDiscussion: (spaceId: number, discussionId: number) => void;
+  viewRecord: (discussionId: number, record: string) => void;
 }) {
   return (
     <div className="flex flex-col gap-2.5">
@@ -166,8 +174,12 @@ function DiscussionSchedules({
                   title={discussion.name}
                   description={discussion.description}
                   members={discussion.members}
+                  record={discussion.record}
                   onclick={() => {
                     moveDiscussion(discussion.space_id, discussion.id);
+                  }}
+                  viewRecordClick={() => {
+                    viewRecord(discussion.id, discussion.record ?? '');
                   }}
                 />
                 {index !== discussions.length - 1 ? (
@@ -192,7 +204,9 @@ export function DiscussionRoom({
   title,
   description,
   members,
+  record,
   onclick,
+  viewRecordClick,
 }: {
   userId: number;
   status: SpaceStatus;
@@ -200,9 +214,11 @@ export function DiscussionRoom({
   endDate: number;
   title: string;
   description: string;
+  record?: string;
   members: Member[];
 
   onclick: () => void;
+  viewRecordClick: () => void;
 }) {
   const now = Math.floor(Date.now() / 1000);
 
@@ -266,7 +282,31 @@ export function DiscussionRoom({
             />
           </div>
         )}
+
+        {isFinished && isMember && record && (
+          <div className="flex flex-row w-full justify-end items-end">
+            <ViewRecord
+              onClick={() => {
+                viewRecordClick();
+              }}
+            />
+          </div>
+        )}
       </div>
+    </div>
+  );
+}
+
+function ViewRecord({ onClick }: { onClick: () => void }) {
+  return (
+    <div
+      className="cursor-pointer flex flex-row items-center w-fit h-fit px-5 py-2.5 gap-2.5 bg-white hover:bg-neutral-300 rounded-lg"
+      onClick={() => {
+        onClick();
+      }}
+    >
+      <div className="font-bold text-[#000203] text-sm">View Record</div>
+      <ArrowRight className="stroke-black stroke-3 w-[15px] h-[15px]" />
     </div>
   );
 }

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/_components/space_discussion.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/_components/space_discussion.tsx
@@ -71,6 +71,7 @@ export default function SpaceDiscussion({
               name,
               description,
               participants: [],
+              discussion_id: undefined,
             });
           }}
           onupdate={(index: number, discussion: DiscussionInfo) => {
@@ -352,6 +353,7 @@ function EditableDiscussion({
           <EditableDiscussionInfo
             key={stableKeys[index]}
             index={index}
+            discussionId={discussion.discussion_id}
             startedAt={discussion.started_at}
             endedAt={discussion.ended_at}
             name={discussion.name}
@@ -396,6 +398,7 @@ function AddDiscussion({ onadd }: { onadd: () => void }) {
 
 function EditableDiscussionInfo({
   index,
+  discussionId,
   startedAt,
   endedAt,
   name,
@@ -405,6 +408,7 @@ function EditableDiscussionInfo({
   onremove,
 }: {
   index: number;
+  discussionId?: number;
   startedAt: number;
   endedAt: number;
   name: string;
@@ -443,6 +447,8 @@ function EditableDiscussionInfo({
       name: newTitle,
       description: newDesc,
       participants: newParticipants,
+
+      discussion_id: discussionId,
     });
   };
 

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/_components/space_side_menu.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/_components/space_side_menu.tsx
@@ -2,7 +2,7 @@
 
 import BlackBox from '@/app/(social)/_components/black-box';
 import { getTimeWithFormat } from '@/lib/time-utils';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import Clock from '@/assets/icons/clock.svg';
 import { BottomTriangle, Discuss, Edit1, PieChart1 } from '@/components/icons';
 import { File, Vote, CheckCircle } from 'lucide-react';
@@ -13,6 +13,7 @@ import {
   useDeliberationSpaceContext,
 } from '../provider.client';
 import { useUserInfo } from '@/app/(social)/_hooks/user';
+import { TeamContext } from '@/lib/contexts/team-context';
 
 export default function SpaceSideMenu() {
   const {
@@ -25,14 +26,23 @@ export default function SpaceSideMenu() {
     handleSave: onsave,
   } = useDeliberationSpaceContext();
   const space = useDeliberationSpace();
+  const { teams } = useContext(TeamContext);
+  const [selectedTeam, setSelectedTeam] = useState<boolean>(false);
 
   const { data: userInfo } = useUserInfo();
   const userId = userInfo ? userInfo.id : 0;
   const created_at = space.created_at;
 
+  const authorId = space?.author[0].id;
+
+  useEffect(() => {
+    const index = teams.findIndex((t) => t.id === authorId);
+    setSelectedTeam(index !== -1);
+  }, [teams]);
+
   return (
     <div className="flex flex-col max-w-[250px] max-tablet:!hidden w-full gap-[10px]">
-      {space.author.some((a) => a.id === userId) && (
+      {(authorId == userId || selectedTeam) && (
         <EditSplitButton
           status={status}
           isEdit={isEdit}

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
@@ -240,7 +240,7 @@ export default function ClientProviders({
 
   const handleViewRecord = async (discussionId: number, record: string) => {
     const response = await fetch(record);
-    if (!response.ok) throw new Error('파일 다운로드 실패');
+    if (!response.ok) throw new Error('failed to download files');
 
     const blob = await response.blob();
     const blobUrl = URL.createObjectURL(blob);

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
@@ -71,6 +71,7 @@ type ContextType = {
   setDraft: StateSetter<FinalConsensus>;
   handleGoBack: () => void;
   handleDownloadExcel: () => void;
+  handleViewRecord: (discussionId: number, record: string) => void;
 
   userType: UserType;
   proposerImage: string;
@@ -234,6 +235,24 @@ export default function ClientProviders({
 
   const handleEdit = () => {
     setIsEdit(true);
+  };
+
+  const handleViewRecord = async (discussionId: number, record: string) => {
+    const response = await fetch(record);
+    if (!response.ok) throw new Error('파일 다운로드 실패');
+
+    const blob = await response.blob();
+    const blobUrl = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = blobUrl;
+    a.download = `recording-${discussionId}.mp4`;
+    document.body.appendChild(a);
+    a.click();
+
+    // 클린업
+    document.body.removeChild(a);
+    URL.revokeObjectURL(blobUrl);
   };
 
   const handleDownloadExcel = () => {
@@ -423,6 +442,7 @@ export default function ClientProviders({
         handlePostingSpace,
         handleEdit,
         handleSave,
+        handleViewRecord,
       }}
     >
       {children}

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
@@ -71,7 +71,7 @@ type ContextType = {
   setDraft: StateSetter<FinalConsensus>;
   handleGoBack: () => void;
   handleDownloadExcel: () => void;
-  handleViewRecord: (discussionId: number, record: string) => void;
+  handleViewRecord: (discussionId: number, record: string) => Promise<void>;
 
   userType: UserType;
   proposerImage: string;

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/provider.client.tsx
@@ -123,6 +123,7 @@ export default function ClientProviders({
       ended_at: disc.ended_at,
       name: disc.name,
       description: disc.description,
+      discussion_id: disc.id,
       participants: disc.members.map((member) => ({
         id: member.id,
         created_at: member.created_at,
@@ -369,6 +370,7 @@ export default function ClientProviders({
       name: disc.name,
       description: disc.description,
       participants: disc.participants.map((member) => member.id),
+      discussion_id: disc.discussion_id,
     }));
 
     logger.debug('discussions: ', discussions);

--- a/ts-packages/web/src/app/spaces/[id]/deliberation/types.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/deliberation/types.tsx
@@ -39,6 +39,7 @@ export interface DiscussionInfo {
   ended_at: number;
   name: string;
   description: string;
+  discussion_id?: number;
 
   participants: TotalUser[];
 }

--- a/ts-packages/web/src/lib/api/models/discussion.ts
+++ b/ts-packages/web/src/lib/api/models/discussion.ts
@@ -37,6 +37,7 @@ export interface DiscussionCreateRequest {
   ended_at: number;
   name: string;
   description: string;
+  discussion_id?: number;
 
   participants: number[];
 }

--- a/ts-packages/web/src/lib/api/models/discussion.ts
+++ b/ts-packages/web/src/lib/api/models/discussion.ts
@@ -14,6 +14,7 @@ export interface Discussion {
 
   meeting_id?: string;
   pipeline_id: string;
+  record?: string;
 
   participants: DiscussionParticipant[];
   members: Member[];


### PR DESCRIPTION
- 녹화 기능 구현
- create space 팀 포스팅 기능 구현
- 뒤로가기, 창 닫았을 때 participants 목록 즉각적으로 반영되도록 수정
- record 후 병합 파일 생성 위치를 dev, prod 형태의 env가 되도록 지정


남은 기능
- shared 비디오 여러개 될 수 있도록
- 모든 인원에 기본적으로 참여 버튼을 두고 운영자의 조작하에 참여할 수 있도록 하는 기능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and downloading discussion recordings after a discussion has finished.
  * Introduced a dynamic "View Record" button in the discussion UI for eligible users.
  * Expanded permissions for creating and editing spaces to team authors and team members.
  * Displayed dynamically updating relative time for space creation.

* **Improvements**
  * Enhanced cleanup and resource management when leaving or closing a meeting session.
  * Improved handling and merging of meeting recording artifacts and media files.
  * Updated discussion creation and update flows to better manage discussion IDs and participants.
  * Integrated merging of recording chunks with persistent recording state updates.
  * Added robust retry logic for moving meeting artifacts in storage.

* **Bug Fixes**
  * Ensured consistent handling of discussion IDs throughout the discussion and deliberation features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->