### PR TITLE
feat(m2): add user registration handler for noncelab API integration

### DIFF
--- a/packages/main-api/src/controllers/m2/noncelab/users/register_users.rs
+++ b/packages/main-api/src/controllers/m2/noncelab/users/register_users.rs
@@ -44,7 +44,9 @@ pub struct RegisterUserRequest {
     JsonSchema,
 )]
 pub struct RegisterUserResponse {
+    #[schemars(description = "User ID in Ratel")]
     pub user_id: i64,
+    #[schemars(description = "Principal of ICP (Internet Computer Protocol)")]
     pub principal: String,
 }
 

--- a/packages/main-api/src/controllers/m2/noncelab/users/register_users.rs
+++ b/packages/main-api/src/controllers/m2/noncelab/users/register_users.rs
@@ -1,0 +1,56 @@
+use bdk::prelude::*;
+use by_axum::axum::{Json, extract::Path};
+use dto::Result;
+
+pub async fn register_users_by_noncelab_handler(
+    Path(PathParams { user_id }): Path<PathParams>,
+    Json(req): Json<RegisterUserRequest>,
+) -> Result<Json<RegisterUserResponse>> {
+    tracing::debug!("Registering user with ID: {}, request: {:?}", user_id, req);
+    // TODO: implement logic and verify noncelab API token
+
+    Ok(Default::default())
+}
+
+#[derive(
+    Debug,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Default,
+    aide::OperationIo,
+    JsonSchema,
+)]
+pub struct RegisterUserRequest {
+    #[schemars(description = "User's display name shown publicly")]
+    pub display_name: String,
+
+    #[schemars(description = "Optional unique username (can be null)")]
+    pub username: Option<String>,
+
+    #[schemars(description = "Principal of ICP (Internet Computer Protocol)")]
+    pub principal: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Default,
+    aide::OperationIo,
+    JsonSchema,
+)]
+pub struct RegisterUserResponse {
+    pub user_id: i64,
+    pub principal: String,
+}
+
+#[derive(
+    Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema, aide::OperationIo,
+)]
+pub struct PathParams {
+    pub user_id: i64,
+}

--- a/packages/main-api/src/lib.rs
+++ b/packages/main-api/src/lib.rs
@@ -7,6 +7,13 @@ pub mod controllers {
             pub mod logout;
         }
     }
+    pub mod m2 {
+        pub mod noncelab {
+            pub mod users {
+                pub mod register_users;
+            }
+        }
+    }
 }
 
 pub mod api_main;

--- a/packages/main-api/src/route.rs
+++ b/packages/main-api/src/route.rs
@@ -1,11 +1,18 @@
 use bdk::prelude::*;
 
 use crate::controllers::{
-    self, m2::noncelab::users::register_users::register_users_by_noncelab_handler,
+    self,
+    m2::noncelab::users::register_users::{
+        RegisterUserResponse, register_users_by_noncelab_handler,
+    },
     v2::users::logout::logout_handler,
 };
 
-use dto::{Result, by_axum::axum::native_routing::post as npost, by_axum::axum::routing::post};
+use dto::{
+    Result,
+    aide::axum::routing::post_with,
+    by_axum::axum::{Json, native_routing::post as npost},
+};
 
 pub async fn route(pool: sqlx::Pool<sqlx::Postgres>) -> Result<by_axum::axum::Router> {
     Ok(
@@ -19,7 +26,17 @@ pub async fn route(pool: sqlx::Pool<sqlx::Postgres>) -> Result<by_axum::axum::Ro
             // Admin APIs
             .route(
                 "/m2/noncelab/users",
-                post(register_users_by_noncelab_handler),
+                post_with(register_users_by_noncelab_handler, |op| {
+                    op.response_with::<200, Json<RegisterUserResponse>, _>(|res| {
+                        res.description("Success response")
+                    })
+                    .response_range_with::<4, Json<dto::Error>, _>(|res| {
+                        res.description("Incorrect or invalid requests")
+                            .example(dto::Error::UserAlreadyExists)
+                    })
+                    .summary("Register users by Noncelab")
+                    .description("This endpoint allows you to register users by Noncelab.")
+                }),
             ), // End of APIs
     )
 }

--- a/packages/main-api/src/route.rs
+++ b/packages/main-api/src/route.rs
@@ -1,15 +1,25 @@
 use bdk::prelude::*;
 
-use crate::controllers::{self, v2::users::logout::logout_handler};
+use crate::controllers::{
+    self, m2::noncelab::users::register_users::register_users_by_noncelab_handler,
+    v2::users::logout::logout_handler,
+};
 
-use dto::{Result, by_axum::axum::native_routing::post};
+use dto::{Result, by_axum::axum::native_routing::post as npost, by_axum::axum::routing::post};
 
 pub async fn route(pool: sqlx::Pool<sqlx::Postgres>) -> Result<by_axum::axum::Router> {
-    Ok(by_axum::axum::Router::new()
-        .nest("/v1", controllers::v1::route(pool.clone()).await?)
-        .nest(
-            "/m1",
-            controllers::m1::MenaceController::route(pool.clone())?,
-        )
-        .native_route("/v2/users/logout", post(logout_handler)))
+    Ok(
+        by_axum::axum::Router::new()
+            .nest("/v1", controllers::v1::route(pool.clone()).await?)
+            .nest(
+                "/m1",
+                controllers::m1::MenaceController::route(pool.clone())?,
+            )
+            .native_route("/v2/users/logout", npost(logout_handler))
+            // Admin APIs
+            .route(
+                "/m2/noncelab/users",
+                post(register_users_by_noncelab_handler),
+            ), // End of APIs
+    )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new admin API endpoint for user registration at `/m2/noncelab/users`.
  * Users can now register by providing display name, optional username, and principal information.

* **Chores**
  * Updated internal routing to support the new user registration endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->