### PR TITLE
feat(web): expose /api/version and propagate build version

### DIFF
--- a/scripts/latency-testing.sh
+++ b/scripts/latency-testing.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+PROTO=https
+API_DOMAIN=api.dev.ratel.foundation
+DOMAIN=dev.ratel.foundation
+
+echo "API Latencies:"
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$API_DOMAIN/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$API_DOMAIN/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$API_DOMAIN/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$API_DOMAIN/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$API_DOMAIN/version
+
+echo "Website Latencies:"
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN
+
+
+echo "Website API Latencies:"
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN/api/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN/api/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN/api/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN/api/version
+curl -o /dev/null -s -w 'dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n' $PROTO://$DOMAIN/api/version

--- a/ts-packages/web/Makefile
+++ b/ts-packages/web/Makefile
@@ -1,11 +1,14 @@
 PORT ?= 8080
+VERSION ?= $(shell git rev-parse --short HEAD)
+
+BUILD_ENV ?= VERSION=$(VERSION)
 
 .PHONY: run node_module
 node_module:
 	pnpm i
 
 run: node_module
-	PORT=$(PORT) pnpm dev
+	VERSION=$(VERSION) PORT=$(PORT) pnpm dev
 
 build: node_module
-	pnpm build
+	$(BUILD_ENV) pnpm build

--- a/ts-packages/web/src/app/api/version/route.ts
+++ b/ts-packages/web/src/app/api/version/route.ts
@@ -1,0 +1,9 @@
+import { config } from '@/config';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  return new NextResponse({
+    version: config.version,
+  });
+
+}

--- a/ts-packages/web/src/config.ts
+++ b/ts-packages/web/src/config.ts
@@ -13,6 +13,8 @@ type Config = {
   sign_domain: string;
   experiment: boolean;
   graphql_url: string;
+
+  version: string;
 };
 
 export enum Env {
@@ -43,4 +45,6 @@ export const config: Config = {
   graphql_url:
     process.env.NEXT_PUBLIC_GRAPHQL_URL ||
     'https://graphql.dev.ratel.foundation/v1/graphql',
+
+  version: process.env.NEXT_PUBLIC_VERSION || 'unknown',
 };


### PR DESCRIPTION
- Add GET /api/version returning config.version
- Add config.version from NEXT_PUBLIC_VERSION or 'unknown'
- Pass VERSION to dev/build via Makefile using BUILD_ENV
- Add scripts/latency-testing.sh for curl-based latency checks