### PR TITLE
fix: update prompt to use ISO 3361-1 country code.

### DIFF
--- a/packages/main-api/src/controllers/v2/documents/extract_passport_info.rs
+++ b/packages/main-api/src/controllers/v2/documents/extract_passport_info.rs
@@ -44,6 +44,7 @@ pub struct PassportInfo {
     #[serde(deserialize_with = "date_format::deserialize")]
     pub expiration_date: i64,
     pub gender: Gender,
+    pub place_of_birth: Option<String>,
 }
 
 mod date_format {
@@ -158,6 +159,9 @@ async fn worker(state: &PassportHandlerState, req: &PassportRequest) -> Result<P
         You are an expert data extraction AI.
         From the passport OCR text below, extract the `first_name`, `last_name`, `nationality`, `birth_date`, `sex`, and `expiration_date`. Pay close attention to the Machine Readable Zone (MRZ).
 
+        For nationality, always use the ISO 3166-1 alpha-3 country code (e.g., "KOR" for South Korea, "USA" for United States, "GBR" for United Kingdom).
+        For `place_of_birth`, if the information is missing or not present in the passport, use null.
+
         Your response **must** be a single, raw JSON object. Use `null` for missing fields. Add no explanations or markdown.
 
         **-- Example --**
@@ -188,8 +192,7 @@ Date of expiry
 01 /JAN 2020
 01 /JAN 2030
         **JSON Output:**
-        `{{"first_name":"GILDONG", "last_name":"HONG", "nationality":"ROK","birth_date":"2000/01/01","gender":"Male","expiration_date":"2030/01/01"}}`
-
+        `{{"first_name":"GILDONG", "last_name":"HONG", "nationality":"KOR","birth_date":"2000/01/01","gender":"Male","expiration_date":"2030/01/01","place_of_birth":null}}`
         **-- Task --**
         **Input Text:**
         `{}`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passport extraction now includes an optional place_of_birth field in API responses; when unavailable, it is returned as null.
  * Nationality output is standardized to ISO 3166-1 alpha-3 country codes (e.g., KOR, USA, GBR) for consistent formatting across responses.
  * These updates enhance the completeness and consistency of passport data returned by the service without changing existing workflows.
  * Existing consumers should handle the new nullable field and the standardized nationality codes in their integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->