### PR TITLE
remove my inventory

### DIFF
--- a/ts-packages/web/src/app/(social)/settings/page.tsx
+++ b/ts-packages/web/src/app/(social)/settings/page.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl';
 
 export default function MyProfilePage() {
   const t = useTranslations('Settings');
-  const tabs = [t('my_info'), t('my_inventory'), t('settings')] as const;
+  const tabs = [t('my_info'), t('settings')] as const;
   const [activeIndex, setActiveIndex] = React.useState(0);
 
   return (
@@ -57,7 +57,7 @@ export default function MyProfilePage() {
           <MyInfo />
         </section>
 
-        <section
+        {/* <section
           id="panel-1"
           role="tabpanel"
           aria-labelledby="tab-1"
@@ -65,13 +65,13 @@ export default function MyProfilePage() {
           className="w-full max-w-[800px] mx-auto text-neutral-300"
         >
           {t('my_inventory_coming_soon')}
-        </section>
+        </section> */}
 
         <section
           id="panel-2"
           role="tabpanel"
           aria-labelledby="tab-2"
-          hidden={activeIndex !== 2}
+          hidden={activeIndex !== 1}
           className="w-full max-w-[800px] mx-auto"
         >
           <MySettings />

--- a/ts-packages/web/src/messages/en.json
+++ b/ts-packages/web/src/messages/en.json
@@ -506,7 +506,6 @@
   },
   "Settings": {
     "my_info": "My Info",
-    "my_inventory": "My Inventory",
     "settings": "Settings",
 
     "upload_logo": "Upload logo",

--- a/ts-packages/web/src/messages/ko.json
+++ b/ts-packages/web/src/messages/ko.json
@@ -506,7 +506,6 @@
   },
   "Settings": {
     "my_info": "나의 정보",
-    "my_inventory": "나의 인벤토리",
     "settings": "설정",
 
     "upload_logo": "로고 업로드",


### PR DESCRIPTION
my inventory setting page에서 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Settings page to two tabs: My Info and Settings. Removed the My Inventory tab and its associated content. Adjusted the tab layout to ensure correct switching between the remaining panels for a cleaner, more focused experience.

* **Chores**
  * Removed “My Inventory” translations from English and Korean locales to align with the updated interface and avoid displaying unused labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->