### PR TITLE
fix z-index

### DIFF
--- a/ts-packages/web/src/components/header.tsx
+++ b/ts-packages/web/src/components/header.tsx
@@ -99,7 +99,7 @@ function Header(props: HeaderProps) {
   ];
 
   return (
-    <header className="border-b border-neutral-800 px-2.5 py-2.5 flex items-center justify-center !bg-bg h-[var(--header-height)]">
+    <header className="border-b border-neutral-800 px-2.5 py-2.5 flex items-center justify-center !bg-bg h-[var(--header-height)] z-999">
       <nav className="flex items-center justify-between mx-2.5 gap-12.5 w-full max-w-desktop">
         <div className="flex items-center gap-5">
           <Link

--- a/ts-packages/web/src/components/profile.tsx
+++ b/ts-packages/web/src/components/profile.tsx
@@ -67,7 +67,7 @@ export default function Profile({ profileUrl, name }: ProfileProps) {
 
       <DropdownMenuContent
         align="end"
-        className="w-[250px] h-fit rounded-lg border border-primary p-[10px] bg-bg z-20"
+        className="w-[250px] h-fit rounded-lg border border-primary p-[10px] bg-bg z-999"
       >
         <DropdownMenuLabel className="text-xs text-neutral-400 px-2 py-1">
           {t('teams')}


### PR DESCRIPTION
menu z index 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved layering issues where the header and profile dropdown could be hidden behind page content, modals, or tooltips. Menus now consistently appear above other elements, preventing clipping and improving interaction reliability.

- Style
  - Increased the visual stacking order for the header and profile dropdown to enhance visibility and consistency across pages. No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->