### PR TITLE
Fix: pr workflow

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -85,6 +85,7 @@ jobs:
           P256_D: ${{ secrets.P256_D }}
           P256_CRV: ${{ secrets.P256_CRV }}
 
+          # Kaia blockchain config (test values)
           KAIA_ENDPOINT: https://public-en-kairos.node.kaia.io
           KAIA_FEEPAYER_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
           KAIA_FEEPAYER_ADDR: "0xFEEDFACE1234567890abcdef0123456789abcdef"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,10 @@
-# Allowlist for test KAIA keys and addresses in PR workflow
-[[allowlist]]
+# Allowlist for test KAIA keys and addresses in PR workflow only
+[allowlist]
 description = "Test Kaia private keys and addresses in GitHub Actions"
 paths = [
-    '''.github/workflows/pr-workflow.yml''',
+    ".github/workflows/pr-workflow.yml"
 ]
 regexes = [
-    '''0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef''',
-    '''0xFEEDFACE1234567890abcdef0123456789abcdef''',
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "0xFEEDFACE1234567890abcdef0123456789abcdef"
 ]


### PR DESCRIPTION
using mock KAIA data for tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI PR workflow updated to use explicit test credentials for server-backed tests.
  * Added secret-scan allowlist to permit recognized PR-only test keys/addresses.
* **Tests**
  * Standardized CI test roles so fee-payer and owner use PR-specific test credentials, reducing flakiness.
* **Note**
  * No user-facing or production behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->