### PR TITLE
link user page

### DIFF
--- a/ts-packages/web/src/app/(social)/_components/suggestions-items.tsx
+++ b/ts-packages/web/src/app/(social)/_components/suggestions-items.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image';
 import { UserType } from '@/lib/api/models/user';
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { route } from '@/route';
 
 type SuggestionItemProps = {
   user: {
@@ -37,9 +39,11 @@ export default function SuggestionItem({
           <div className={`w-8 h-8 bg-neutral-500 ${imageClass}`} />
         )}
         <div className="flex-1">
-          <div className="font-medium text-base text-white">
-            {user.nickname}
-          </div>
+          <Link href={route.teamByUsername(user.username)}>
+            <div className="font-medium text-base text-white">
+              {user.nickname}
+            </div>
+          </Link>
 
           <button
             className="font-bold text-xs text-white rounded-full bg-neutral-700 px-4 py-2 mt-2 hover:bg-neutral-600 transition-colors"

--- a/ts-packages/web/src/app/(social)/_components/user-sidemenu.tsx
+++ b/ts-packages/web/src/app/(social)/_components/user-sidemenu.tsx
@@ -13,6 +13,7 @@ import { useUserInfo } from '@/lib/api/hooks/users';
 export default function UserSidemenu() {
   const t = useTranslations('Home');
   const { data: user, isLoading } = useUserInfo();
+
   if (
     isLoading ||
     !user ||

--- a/ts-packages/web/src/app/(social)/_hooks/use-user.ts
+++ b/ts-packages/web/src/app/(social)/_hooks/use-user.ts
@@ -36,3 +36,17 @@ export function useUserByEmail(
 
   return query;
 }
+
+export function useUserByUsername(
+  username: string,
+): UseSuspenseQueryResult<TotalUser> {
+  const { get } = useApiCall();
+
+  const query = useSuspenseQuery({
+    queryKey: [QK_GET_USER_BY_EMAIL],
+    queryFn: () => get(ratelApi.users.getUserByUsername(username)),
+    refetchOnWindowFocus: false,
+  });
+
+  return query;
+}

--- a/ts-packages/web/src/app/teams/[username]/_components/follow-button.tsx
+++ b/ts-packages/web/src/app/teams/[username]/_components/follow-button.tsx
@@ -1,0 +1,17 @@
+import { useTranslations } from 'next-intl';
+import React from 'react';
+
+export default function FollowButton({ onClick }: { onClick: () => void }) {
+  const t = useTranslations('Team');
+
+  return (
+    <div
+      className="cursor-pointer flex flex-row w-fit h-fit px-[10px] py-[5px] bg-white hover:bg-gray-300 rounded-[50px]"
+      onClick={() => {
+        onClick();
+      }}
+    >
+      <div className="font-bold text-[#000203] text-xs">{t('follow')}</div>
+    </div>
+  );
+}

--- a/ts-packages/web/src/app/teams/[username]/_components/team-profile.tsx
+++ b/ts-packages/web/src/app/teams/[username]/_components/team-profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Image from 'next/image';
 import { Team } from '@/lib/api/models/team';
 import TeamSelector from '@/app/(social)/_components/team-selector';
@@ -11,7 +11,8 @@ import {
 } from '@/lib/api/models/networks/follow';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { logger } from '@/lib/logger';
-import { useTranslations } from 'next-intl';
+import FollowButton from './follow-button';
+import UnFollowButton from './unfollow-button';
 
 export interface TeamProfileProps {
   team?: Team;
@@ -92,41 +93,6 @@ export default function TeamProfile({ team }: TeamProfileProps) {
           }}
         />
       )}
-    </div>
-  );
-}
-
-function UnFollowButton({ onClick }: { onClick: () => void }) {
-  const t = useTranslations('Team');
-  const [isHovered, setIsHovered] = useState(false);
-
-  return (
-    <div
-      className="cursor-pointer flex flex-row w-fit h-fit px-[10px] py-[5px] bg-transparent border border-neutral-700 hover:border-[#ff4d4f] hover:bg-[#ffe3e3] rounded-[50px]"
-      onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div
-        className={`font-bold  ${isHovered ? 'text-[#ff4d4f]' : 'text-neutral-700'} text-xs`}
-      >
-        {isHovered ? t('unfollow') : t('following')}
-      </div>
-    </div>
-  );
-}
-
-function FollowButton({ onClick }: { onClick: () => void }) {
-  const t = useTranslations('Team');
-
-  return (
-    <div
-      className="cursor-pointer flex flex-row w-fit h-fit px-[10px] py-[5px] bg-white hover:bg-gray-300 rounded-[50px]"
-      onClick={() => {
-        onClick();
-      }}
-    >
-      <div className="font-bold text-[#000203] text-xs">{t('follow')}</div>
     </div>
   );
 }

--- a/ts-packages/web/src/app/teams/[username]/_components/unfollow-button.tsx
+++ b/ts-packages/web/src/app/teams/[username]/_components/unfollow-button.tsx
@@ -1,0 +1,22 @@
+import { useTranslations } from 'next-intl';
+import React, { useState } from 'react';
+
+export default function UnFollowButton({ onClick }: { onClick: () => void }) {
+  const t = useTranslations('Team');
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <div
+      className="cursor-pointer flex flex-row w-fit h-fit px-[10px] py-[5px] bg-transparent border border-neutral-700 hover:border-[#ff4d4f] hover:bg-[#ffe3e3] rounded-[50px]"
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div
+        className={`font-bold  ${isHovered ? 'text-[#ff4d4f]' : 'text-neutral-700'} text-xs`}
+      >
+        {isHovered ? t('unfollow') : t('following')}
+      </div>
+    </div>
+  );
+}

--- a/ts-packages/web/src/app/teams/[username]/home/page.client.tsx
+++ b/ts-packages/web/src/app/teams/[username]/home/page.client.tsx
@@ -25,31 +25,35 @@ export default function TeamHome({
   );
   const data = posts.data;
 
-  const feeds: Post[] =
-    data?.items.map((item) => ({
-      id: item.id,
-      industry: item.industry[0].name,
-      title: item.title!,
-      contents: item.html_contents,
-      url: item.url,
-      author_id: Number(item.author[0].id),
-      author_profile_url: item.author[0].profile_url!,
-      author_name: item.author[0].nickname,
-      author_type: item.author[0].user_type,
+  const items = (data?.items ?? []).filter(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (item) => Number((item as any).feed_type) !== 2,
+  );
 
-      likes: item.likes,
-      is_liked: item.is_liked,
-      comments: item.comments,
-      rewards: item.rewards,
-      shares: item.shares,
-      created_at: item.created_at,
-      onboard: item.onboard || false,
-      spaces: item.spaces || [],
-    })) ?? [];
+  const feeds: Post[] = items.map((item) => ({
+    id: item.id,
+    industry: item.industry[0].name,
+    title: item.title!,
+    contents: item.html_contents,
+    url: item.url,
+    author_id: Number(item.author[0].id),
+    author_profile_url: item.author[0].profile_url!,
+    author_name: item.author[0].nickname,
+    author_type: item.author[0].user_type,
+
+    likes: item.likes,
+    is_liked: item.is_liked,
+    comments: item.comments,
+    rewards: item.rewards,
+    shares: item.shares,
+    created_at: item.created_at,
+    onboard: item.onboard || false,
+    spaces: item.spaces || [],
+  }));
 
   return (
     <div className="flex-1 flex max-mobile:px-[10px]">
-      {feeds.length != 0 ? (
+      {feeds.length !== 0 ? (
         <Col className="flex-1">
           {feeds.map((props) => (
             <FeedCard

--- a/ts-packages/web/src/constants.ts
+++ b/ts-packages/web/src/constants.ts
@@ -28,6 +28,7 @@ export const QK_GET_USER_BADGE = 'get-user-badge';
 export const QK_GET_PROMOTION = 'get-promotion';
 export const QK_GET_TOTAL_USER = 'get-total-users';
 export const QK_GET_USER_BY_EMAIL = 'get-user-by-emails';
+export const QK_GET_USER_BY_USERNAME = 'get-user-by-usernames';
 
 // Quiz-related query keys
 export const QK_LATEST_QUIZ_ATTEMPT = 'latest-quiz-attempt';

--- a/ts-packages/web/src/lib/api/models/user.ts
+++ b/ts-packages/web/src/lib/api/models/user.ts
@@ -93,6 +93,7 @@ export interface TotalUser {
   updated_at: number;
 
   nickname: string;
+  html_contents: string;
   username: string;
   profile_url: string;
 


### PR DESCRIPTION
- suggestions 페이지에서 user nickname 클릭 시 /teams/{username}/home 으로 가도록 추가
- comment는 포스트에 안나오게 조건 수정
- 사이드바에 팔로우 버튼 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usernames in suggestions are now clickable, taking you to the corresponding profile.
  * Team sidebar now gracefully handles non-team usernames by showing a user profile with avatar, nickname, and rich HTML bio.
  * Follow/Unfollow actions are available on user profiles, with localized labels and hover feedback.
  * Feed on team home hides certain post types for a cleaner timeline.
  * Minor UI polish in side menus; no functional changes for existing team views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->