### PR TITLE
remove mock data

### DIFF
--- a/ts-packages/web/src/app/(social)/my-network/page.client.tsx
+++ b/ts-packages/web/src/app/(social)/my-network/page.client.tsx
@@ -1,8 +1,8 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useNetwork } from '../_hooks/use-network';
 import { logger } from '@/lib/logger';
-import { Industry } from '@/lib/api/models/industry';
+// import { Industry } from '@/lib/api/models/industry';
 import { Follower } from '@/lib/api/models/network';
 import { UserType } from '@/lib/api/models/user';
 import Image from 'next/image';
@@ -13,7 +13,7 @@ import { followRequest } from '@/lib/api/models/networks/follow';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { useSuspenseUserInfo } from '@/lib/api/hooks/users';
 import { checkString } from '@/lib/string-filter-utils';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+// import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 export default function MyNetwork() {
   const { post } = useApiCall();
@@ -38,9 +38,9 @@ export default function MyNetwork() {
   logger.debug('query response of networks', networkData);
   return (
     <div className="flex flex-col w-full gap-3">
-      <SelectedIndustry
+      {/* <SelectedIndustry
         industries={networkData ? networkData.industries : []}
-      />
+      /> */}
       <FollowingContents
         label="Suggested teams"
         users={
@@ -180,73 +180,73 @@ function FollowingContents({
   );
 }
 
-function SelectedIndustry({ industries }: { industries: Industry[] }) {
-  const PAGE_SIZE = 5;
-  const [selectedIndustry, setSelectedIndustry] = useState('ALL');
-  const [page, setPage] = useState(0);
+// function SelectedIndustry({ industries }: { industries: Industry[] }) {
+//   const PAGE_SIZE = 5;
+//   const [selectedIndustry, setSelectedIndustry] = useState('ALL');
+//   const [page, setPage] = useState(0);
 
-  const totalPages = Math.ceil(industries.length / PAGE_SIZE);
-  const visibleItems = industries.slice(
-    page * PAGE_SIZE,
-    (page + 1) * PAGE_SIZE,
-  );
+//   const totalPages = Math.ceil(industries.length / PAGE_SIZE);
+//   const visibleItems = industries.slice(
+//     page * PAGE_SIZE,
+//     (page + 1) * PAGE_SIZE,
+//   );
 
-  return (
-    <div className="flex items-center gap-2">
-      {page > 0 && (
-        <ChevronLeft
-          className="cursor-pointer stroke-neutral-500"
-          onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
-        ></ChevronLeft>
-      )}
+//   return (
+//     <div className="flex items-center gap-2">
+//       {page > 0 && (
+//         <ChevronLeft
+//           className="cursor-pointer stroke-neutral-500"
+//           onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+//         ></ChevronLeft>
+//       )}
 
-      <div className="flex gap-2 flex-1 flex-wrap">
-        <IndustryLabel
-          name="ALL"
-          selected={selectedIndustry === 'ALL'}
-          setSelectedIndustry={() => setSelectedIndustry('ALL')}
-        />
-        {visibleItems.map((industry) => {
-          const name = industry.name.toUpperCase();
-          return (
-            <IndustryLabel
-              key={name}
-              name={name}
-              selected={selectedIndustry === name}
-              setSelectedIndustry={() => setSelectedIndustry(name)}
-            />
-          );
-        })}
-      </div>
+//       <div className="flex gap-2 flex-1 flex-wrap">
+//         <IndustryLabel
+//           name="ALL"
+//           selected={selectedIndustry === 'ALL'}
+//           setSelectedIndustry={() => setSelectedIndustry('ALL')}
+//         />
+//         {visibleItems.map((industry) => {
+//           const name = industry.name.toUpperCase();
+//           return (
+//             <IndustryLabel
+//               key={name}
+//               name={name}
+//               selected={selectedIndustry === name}
+//               setSelectedIndustry={() => setSelectedIndustry(name)}
+//             />
+//           );
+//         })}
+//       </div>
 
-      {page < totalPages - 1 && (
-        <ChevronRight
-          className="cursor-pointer stroke-neutral-500"
-          onClick={() => setPage((prev) => Math.min(prev + 1, totalPages - 1))}
-        ></ChevronRight>
-      )}
-    </div>
-  );
-}
+//       {page < totalPages - 1 && (
+//         <ChevronRight
+//           className="cursor-pointer stroke-neutral-500"
+//           onClick={() => setPage((prev) => Math.min(prev + 1, totalPages - 1))}
+//         ></ChevronRight>
+//       )}
+//     </div>
+//   );
+// }
 
-function IndustryLabel({
-  name,
-  selected,
-  setSelectedIndustry,
-}: {
-  name: string;
-  selected: boolean;
-  setSelectedIndustry: (name: string) => void;
-}) {
-  return (
-    <div
-      className="cursor-pointer flex flex-row w-fit h-fit px-2.5 py-2 rounded-lg font-semibold text-white text-sm/[20px] whitespace-nowrap border border-neutral-700 bg-transparent hover:bg-neutral-700 aria-selected:border-none aria-selected:bg-neutral-700"
-      aria-selected={selected}
-      onClick={() => {
-        setSelectedIndustry(name);
-      }}
-    >
-      {name}
-    </div>
-  );
-}
+// function IndustryLabel({
+//   name,
+//   selected,
+//   setSelectedIndustry,
+// }: {
+//   name: string;
+//   selected: boolean;
+//   setSelectedIndustry: (name: string) => void;
+// }) {
+//   return (
+//     <div
+//       className="cursor-pointer flex flex-row w-fit h-fit px-2.5 py-2 rounded-lg font-semibold text-white text-sm/[20px] whitespace-nowrap border border-neutral-700 bg-transparent hover:bg-neutral-700 aria-selected:border-none aria-selected:bg-neutral-700"
+//       aria-selected={selected}
+//       onClick={() => {
+//         setSelectedIndustry(name);
+//       }}
+//     >
+//       {name}
+//     </div>
+//   );
+// }

--- a/ts-packages/web/src/app/(social)/my-network/page.client.tsx
+++ b/ts-packages/web/src/app/(social)/my-network/page.client.tsx
@@ -13,6 +13,8 @@ import { followRequest } from '@/lib/api/models/networks/follow';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { useSuspenseUserInfo } from '@/lib/api/hooks/users';
 import { checkString } from '@/lib/string-filter-utils';
+import Link from 'next/link';
+import { route } from '@/route';
 // import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 export default function MyNetwork() {
@@ -99,7 +101,7 @@ function FollowButton({ onClick }: { onClick: () => void }) {
         onClick();
       }}
     >
-      <Add className="w-[15px] h-[15px]" />
+      <Add className="w-[15px] h-[15px] [&>path]:stroke-neutral-800 [&>path]:stroke-1" />
       <div className="font-bold text-[#000203] text-xs">Follow</div>
     </div>
   );
@@ -150,12 +152,11 @@ function FollowingContents({
                 )}
 
                 <div className="flex flex-col">
-                  <div className="font-semibold text-white text-sm/[20px]">
-                    {user.nickname}
-                  </div>
-                  <div className="font-medium text-neutral-500 text-[12px]">
-                    @{user.username}
-                  </div>
+                  <Link href={route.teamByUsername(user.username)}>
+                    <div className="font-semibold text-white text-sm/[20px]">
+                      {user.nickname}
+                    </div>
+                  </Link>
                 </div>
               </div>
 

--- a/ts-packages/web/src/app/spaces/[id]/_components/header/index.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/_components/header/index.tsx
@@ -236,7 +236,7 @@ export default function SpaceHeader({
 
       <div className="flex flex-row w-full justify-between items-center">
         <div className="flex flex-row w-fit gap-2.5 items-center">
-          <SpaceType />
+          {/* <SpaceType /> */}
           {status == SpaceStatus.InProgress ? <Onboard /> : <></>}
         </div>
 
@@ -351,10 +351,10 @@ function Onboard() {
   );
 }
 
-function SpaceType() {
-  return (
-    <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
-      Crypto
-    </div>
-  );
-}
+// function SpaceType() {
+//   return (
+//     <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
+//       Crypto
+//     </div>
+//   );
+// }

--- a/ts-packages/web/src/app/spaces/[id]/_components/space-header.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/_components/space-header.tsx
@@ -37,7 +37,7 @@ export default function SpaceHeader({
     <div className="flex flex-col w-full gap-2.5">
       <div className="flex flex-col gap-2.5">
         <div className="flex flex-row w-full justify-start items-center gap-2.5">
-          <SpaceType />
+          {/* <SpaceType /> */}
           {status == SpaceStatus.InProgress ? <Onboard /> : <></>}
         </div>
         <div className="flex flex-row w-full justify-between items-center">
@@ -95,10 +95,10 @@ function Onboard() {
   );
 }
 
-function SpaceType() {
-  return (
-    <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
-      Crypto
-    </div>
-  );
-}
+// function SpaceType() {
+//   return (
+//     <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
+//       Crypto
+//     </div>
+//   );
+// }

--- a/ts-packages/web/src/app/spaces/[id]/notice/_components/quiz-builder-ui.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/notice/_components/quiz-builder-ui.tsx
@@ -725,7 +725,7 @@ export default function QuizBuilderUI({
           </div>
         )}
 
-        {!isEditMode && questions.length > 0 && onSubmitQuiz && (
+        {!isEditMode && questions.length > 0 && onSubmitQuiz && !isOwner && (
           <div className="flex justify-end mt-4">
             {latestAttempt && latestAttempt.is_successful ? (
               <div className="px-6 py-[14.5px] bg-green-600/20 border border-green-500/30 font-semibold text-green-400 text-base rounded-[10px]">

--- a/ts-packages/web/src/app/spaces/[id]/notice/_components/space_header.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/notice/_components/space_header.tsx
@@ -167,7 +167,7 @@ export default function SpaceHeader({
 
       <div className="flex flex-row w-full justify-between items-center">
         <div className="flex flex-row w-fit gap-2.5 items-center">
-          <SpaceType />
+          {/* <SpaceType /> */}
           {status == SpaceStatus.InProgress ? <Onboard /> : <></>}
         </div>
 
@@ -294,10 +294,10 @@ function Onboard() {
   );
 }
 
-function SpaceType() {
-  return (
-    <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
-      Crypto
-    </div>
-  );
-}
+// function SpaceType() {
+//   return (
+//     <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
+//       Crypto
+//     </div>
+//   );
+// }

--- a/ts-packages/web/src/app/spaces/[id]/notice/provider.client.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/notice/provider.client.tsx
@@ -172,7 +172,11 @@ export default function ClientProviders({
   const status = space?.status ?? SpaceStatus.Draft;
 
   const handleGoBack = () => {
-    window.history.back();
+    if (isEdit) {
+      setIsEdit(false);
+    } else {
+      window.history.back();
+    }
   };
 
   const handleLike = () => {

--- a/ts-packages/web/src/components/post-header/index.tsx
+++ b/ts-packages/web/src/components/post-header/index.tsx
@@ -102,7 +102,7 @@ export function PostInfoSection({
   return (
     <div className="flex flex-row w-full justify-between items-center">
       <div className="flex flex-row w-fit gap-2.5 items-center">
-        <SpaceType />
+        {/* <SpaceType /> */}
         {!isDraft ? <Onboard /> : <></>}
       </div>
       <div className="flex flex-row w-fit gap-5 [&>*>svg>*]:stroke-neutral-500 [&>*>svg]:size-5">
@@ -206,10 +206,10 @@ function Onboard() {
 }
 
 // FIXME: use Industry ID.
-function SpaceType() {
-  return (
-    <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
-      Crypto
-    </div>
-  );
-}
+// function SpaceType() {
+//   return (
+//     <div className="flex flex-row w-fit h-fit px-2 bg-transparent rounded-sm border border-c-wg-70 font-semibold text-white text-xs/[25px]">
+//       Crypto
+//     </div>
+//   );
+// }


### PR DESCRIPTION
- crypto space mock tag 제거
- my network 페이지 내 tag slider 제거
- 이외 버그 로직 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Back action in notices now exits edit mode before navigating away.
  - User nicknames on My Network now link to the user’s team page (username line removed).

- Bug Fixes
  - Owners no longer see quiz submission/attempt controls when not in edit mode.

- Style
  - Removed SpaceType/Crypto badges from space headers, notice headers, and post headers.
  - Industry selection UI temporarily disabled on My Network; follow button icon styling updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->