### PR TITLE
remove theme setting

### DIFF
--- a/ts-packages/web/src/app/(social)/settings/_components/tab/my-settings.tsx
+++ b/ts-packages/web/src/app/(social)/settings/_components/tab/my-settings.tsx
@@ -65,11 +65,11 @@ export default function MySettings() {
           />
 
           {/* theme box controller */}
-          <SpecBox
+          {/* <SpecBox
             left_text="Theme"
             action_text={currentThemeLabel}
             onClick={handleChangeTheme}
-          />
+          /> */}
         </div>
       </section>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Theme option from the Appearance section in Settings; theme selection UI is no longer available.
  * The Language setting remains available and unchanged.
  * Existing theme-related dialogs will no longer be accessible from the Settings interface.
  * No other areas of the app are affected by this change.
  * Users will no longer be able to adjust theme preferences through Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->