### PR TITLE
ci(playwright): remove pull_request trigger to avoid duplicate CI runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,9 +6,6 @@ on:
     types:
       - completed
 
-  pull_request:
-    branches: [ dev ]
-
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Remove pull_request trigger to prevent duplicate runs on push and PR
- Reduces CI noise and shortens queue times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated end-to-end testing to run after the dev environment is deployed, rather than on pull requests to the dev branch. This streamlines the workflow and reduces redundant runs.
* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->