### PR TITLE
fix team selector to scroll

### DIFF
--- a/ts-packages/web/src/app/(social)/_components/team-selector.tsx
+++ b/ts-packages/web/src/app/(social)/_components/team-selector.tsx
@@ -10,7 +10,6 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { usePopup } from '@/lib/contexts/popup-service';
-import { logger } from '@/lib/logger';
 import { ChevronDown } from 'lucide-react';
 import React, { useContext, useEffect } from 'react';
 import TeamCreationPopup from '../_popups/team-creation-popup';
@@ -64,68 +63,65 @@ export default function TeamSelector({ onSelect, team }: TeamSelectorProps) {
         <DropdownMenuLabel className="text-text-primary">
           {t('teams')}
         </DropdownMenuLabel>
-        <DropdownMenuGroup>
-          {teams.map((team, index) => {
-            return team.nickname != '' ? (
-              <DropdownMenuItem
-                className="focus:bg-accent focus:text-text-primary data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-text-primary relative cursor-default rounded-sm text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 w-full flex flex-row items-center gap-2 px-2 py-2 hover:bg-hover"
-                key={`team-select-menu-${team.id}`}
-                asChild
-              >
-                <Link
-                  href={
-                    index === 0
-                      ? route.home()
-                      : route.teamByUsername(team.username)
-                  }
-                  className="flex items-center gap-2"
-                  onClick={() => {
-                    setSelectedTeam(index);
-                    onSelect!(index);
-                  }}
+
+        <div className="max-h-[300px] overflow-y-auto pr-1 -mr-1">
+          <DropdownMenuGroup>
+            {teams.map((team, index) =>
+              team.nickname !== '' ? (
+                <DropdownMenuItem
+                  key={`team-select-menu-${team.id}`}
+                  className="focus:bg-accent focus:text-text-primary [&_svg:not([class*='size-'])]:size-4 w-full flex flex-row items-center gap-2 px-2 py-2 hover:bg-hover"
+                  asChild
                 >
-                  {team.profile_url && team.profile_url !== '' ? (
-                    <Image
-                      src={team.profile_url}
-                      alt={team.nickname}
-                      width={24}
-                      height={24}
-                      className="w-6 h-6 rounded-full object-cover object-top"
-                    />
-                  ) : (
-                    <div className="w-6 h-6 rounded-full border border-neutral-600 bg-neutral-600" />
-                  )}
-                  <span className="text-text-primary">{team.nickname}</span>
-                </Link>
-              </DropdownMenuItem>
-            ) : (
-              <></>
-            );
-          })}
-        </DropdownMenuGroup>
+                  <Link
+                    href={
+                      index === 0
+                        ? route.home()
+                        : route.teamByUsername(team.username)
+                    }
+                    className="flex items-center gap-2"
+                    onClick={() => {
+                      setSelectedTeam(index);
+                      onSelect?.(index);
+                    }}
+                  >
+                    {team.profile_url ? (
+                      <Image
+                        src={team.profile_url}
+                        alt={team.nickname}
+                        width={24}
+                        height={24}
+                        className="w-6 h-6 rounded-full object-cover object-top"
+                      />
+                    ) : (
+                      <div className="w-6 h-6 rounded-full border border-neutral-600 bg-neutral-600" />
+                    )}
+                    <span className="text-text-primary">{team.nickname}</span>
+                  </Link>
+                </DropdownMenuItem>
+              ) : null,
+            )}
+          </DropdownMenuGroup>
+        </div>
+
         <DropdownMenuSeparator />
+
         <DropdownMenuGroup>
           <DropdownMenuItem
-            onClick={() => {
-              logger.debug('Create team clicked');
-              popup.open(<TeamCreationPopup />).withTitle(t('create_new_team'));
-            }}
+            onClick={() =>
+              popup.open(<TeamCreationPopup />).withTitle(t('create_new_team'))
+            }
           >
-            <span className="text-text-primary hover:bg-hover">
-              {t('create_team')}
-            </span>
+            <span className="text-text-primary">{t('create_team')}</span>
           </DropdownMenuItem>
 
           <DropdownMenuItem
             onClick={() => {
-              logger.debug('Create team clicked');
               logout();
               userInfo.refetch();
             }}
           >
-            <span className="text-text-primary hover:bg-hover">
-              {t('logout')}
-            </span>
+            <span className="text-text-primary">{t('logout')}</span>
           </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/ts-packages/web/src/components/profile.tsx
+++ b/ts-packages/web/src/components/profile.tsx
@@ -16,7 +16,6 @@ import {
 } from '@radix-ui/react-dropdown-menu';
 import Link from 'next/link';
 import { route } from '@/route';
-import { logger } from '@/lib/logger';
 import TeamCreationPopup from '@/app/(social)/_popups/team-creation-popup';
 import { useTranslations } from 'next-intl';
 
@@ -57,7 +56,6 @@ export default function Profile({ profileUrl, name }: ProfileProps) {
             ) : (
               <div className="w-6 h-6 bg-neutral-500 rounded-full" />
             )}
-
             <span className="text-menu-text group-hover:text-menu-text/80 text-[15px] font-medium transition-colors">
               {name || 'Unknown User'}
             </span>
@@ -73,52 +71,53 @@ export default function Profile({ profileUrl, name }: ProfileProps) {
           {t('teams')}
         </DropdownMenuLabel>
 
-        <DropdownMenuGroup>
-          {teams.map((team, index) => (
-            <DropdownMenuItem
-              key={`team-select-menu-${team.id}`}
-              asChild
-              className="w-full px-2 py-1.5 hover:bg-hover rounded-md cursor-pointer focus-visible:outline-none"
-            >
-              <Link
-                href={
-                  index === 0
-                    ? route.home()
-                    : route.teamByUsername(team.username)
-                }
-                className="flex items-center gap-2 w-full"
-                onClick={() => {
-                  setSelectedTeam(index);
-                  handleTeamSelect(index);
-                }}
+        <div className="max-h-[300px] overflow-y-auto pr-2 -mr-2">
+          <DropdownMenuGroup>
+            {teams.map((team, index) => (
+              <DropdownMenuItem
+                key={`team-select-menu-${team.id}`}
+                asChild
+                className="w-full px-2 py-1.5 hover:bg-hover rounded-md cursor-pointer focus-visible:outline-none"
               >
-                {team.profile_url && team.profile_url !== '' ? (
-                  <Image
-                    src={team.profile_url}
-                    alt={team.nickname}
-                    width={24}
-                    height={24}
-                    className="w-6 h-6 rounded-full object-cover object-top"
-                  />
-                ) : (
-                  <div className="w-6 h-6 bg-neutral-600 rounded-full" />
-                )}
-                <span className="text-sm text-text-primary-muted truncate">
-                  {team.nickname}
-                </span>
-              </Link>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuGroup>
+                <Link
+                  href={
+                    index === 0
+                      ? route.home()
+                      : route.teamByUsername(team.username)
+                  }
+                  className="flex items-center gap-2 w-full"
+                  onClick={() => {
+                    setSelectedTeam(index);
+                    handleTeamSelect(index);
+                  }}
+                >
+                  {team.profile_url ? (
+                    <Image
+                      src={team.profile_url}
+                      alt={team.nickname}
+                      width={24}
+                      height={24}
+                      className="w-6 h-6 rounded-full object-cover object-top"
+                    />
+                  ) : (
+                    <div className="w-6 h-6 bg-neutral-600 rounded-full" />
+                  )}
+                  <span className="text-sm text-text-primary-muted truncate">
+                    {team.nickname}
+                  </span>
+                </Link>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        </div>
 
         <DropdownMenuSeparator className="my-2 bg-neutral-700 light:bg-[#e5e5e5] h-px" />
 
         <DropdownMenuGroup>
           <DropdownMenuItem
-            onClick={() => {
-              logger.debug('Create team clicked');
-              popup.open(<TeamCreationPopup />).withTitle('Create a new team');
-            }}
+            onClick={() =>
+              popup.open(<TeamCreationPopup />).withTitle('Create a new team')
+            }
             className="w-full px-2 py-1.5 hover:bg-hover rounded-md text-sm text-text-primary-muted cursor-pointer focus-visible:outline-none"
           >
             <span>{t('create_team')}</span>


### PR DESCRIPTION
- team select 가 길어질 시 scroll 형태로 수정하여 ui 깨짐 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UX Improvements**
  * Team lists in profile and team selector are now scrollable for long rosters.
  * Clearer team items: avatar shown when available, placeholder when not; names truncated to fit.
  * More consistent styling for menu items and smoother, unified selection/navigation behavior.
  * “Create team” action has a cleaner presentation.

* **Refactor**
  * Simplified item rendering and click handling for team selection.
  * Removed extraneous logging from menu actions for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->