### PR TITLE
Split API and Web into separate ECS Fargate tasks/services

### DIFF
--- a/cdk/lib/regional-service-stack.ts
+++ b/cdk/lib/regional-service-stack.ts
@@ -65,21 +65,20 @@ export class RegionalServiceStack extends Stack {
       ),
     );
 
-    // 5) Task Definition with multiple containers
-    const taskDefinition = new ecs.TaskDefinition(this, "TaskDefinition", {
+    // --- API Task Definition ---
+    const apiTaskDefinition = new ecs.TaskDefinition(this, "ApiTaskDefinition", {
       compatibility: ecs.Compatibility.FARGATE,
       cpu: "1024",
       memoryMiB: "2048",
       executionRole: taskExecutionRole,
     });
 
-    // API Container
     const apiRepository = Repository.fromRepositoryName(
       this,
       "ApiRepository",
       apiRepoName,
     );
-    const apiContainer = taskDefinition.addContainer("ApiContainer", {
+    const apiContainer = apiTaskDefinition.addContainer("ApiContainer", {
       image: ecs.ContainerImage.fromEcrRepository(apiRepository, props.commit),
       logging: new ecs.AwsLogDriver({
         streamPrefix: "ratel-api",
@@ -95,13 +94,20 @@ export class RegionalServiceStack extends Stack {
       protocol: ecs.Protocol.TCP,
     });
 
-    // Next.js Web Container
+    // --- Web Task Definition ---
+    const webTaskDefinition = new ecs.TaskDefinition(this, "WebTaskDefinition", {
+      compatibility: ecs.Compatibility.FARGATE,
+      cpu: "1024",
+      memoryMiB: "2048",
+      executionRole: taskExecutionRole,
+    });
+
     const webRepository = Repository.fromRepositoryName(
       this,
       "WebRepository",
       webRepoName,
     );
-    const webContainer = taskDefinition.addContainer("WebContainer", {
+    const webContainer = webTaskDefinition.addContainer("WebContainer", {
       image: ecs.ContainerImage.fromEcrRepository(webRepository, props.commit),
       logging: new ecs.AwsLogDriver({
         streamPrefix: "ratel-web",
@@ -123,23 +129,43 @@ export class RegionalServiceStack extends Stack {
       protocol: ecs.Protocol.TCP,
     });
 
-    // 6) Fargate Service
-    const fargate = new ecs.FargateService(this, "Service", {
+    // 6) Fargate Services (separate services for API and Web)
+    const apiService = new ecs.FargateService(this, "ApiService", {
       cluster,
-      taskDefinition,
+      taskDefinition: apiTaskDefinition,
       desiredCount: minCapacity,
       maxHealthyPercent: 200,
       minHealthyPercent: minCapacity === 1 ? 0 : 50,
       assignPublicIp: true,
     });
 
-    // 7) Auto Scaling
-    const scaling = fargate.autoScaleTaskCount({
+    const webService = new ecs.FargateService(this, "WebService", {
+      cluster,
+      taskDefinition: webTaskDefinition,
+      desiredCount: minCapacity,
+      maxHealthyPercent: 200,
+      minHealthyPercent: minCapacity === 1 ? 0 : 50,
+      assignPublicIp: true,
+    });
+
+    // 7) Auto Scaling (separate for each service)
+    const apiScaling = apiService.autoScaleTaskCount({
       minCapacity,
       maxCapacity,
     });
 
-    scaling.scaleOnCpuUtilization("CpuScaling", {
+    apiScaling.scaleOnCpuUtilization("ApiCpuScaling", {
+      targetUtilizationPercent: 70,
+      scaleInCooldown: Duration.seconds(60),
+      scaleOutCooldown: Duration.seconds(60),
+    });
+
+    const webScaling = webService.autoScaleTaskCount({
+      minCapacity,
+      maxCapacity,
+    });
+
+    webScaling.scaleOnCpuUtilization("WebCpuScaling", {
       targetUtilizationPercent: 70,
       scaleInCooldown: Duration.seconds(60),
       scaleOutCooldown: Duration.seconds(60),
@@ -152,7 +178,7 @@ export class RegionalServiceStack extends Stack {
       "WebTargetGroup",
       {
         targets: [
-          fargate.loadBalancerTarget({
+          webService.loadBalancerTarget({
             containerName: "WebContainer",
             containerPort: 8080,
           }),
@@ -178,7 +204,7 @@ export class RegionalServiceStack extends Stack {
       "ApiTargetGroup",
       {
         targets: [
-          fargate.loadBalancerTarget({
+          apiService.loadBalancerTarget({
             containerName: "ApiContainer",
             containerPort: 3000,
           }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Separated API and Web into independent services with dedicated scaling and load balancer targets, improving resilience and isolation.
  - Enabled per-service autoscaling (CPU-based) for smoother performance under varying load.
  - Preserved existing routes, health checks, and ports; no user-visible behavior changes expected.

- Chores
  - Streamlined service naming and structure for clarity.
  - Maintained existing DNS/ALB wiring; no configuration changes required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->