### PR TITLE
fix: correct mobile margins by removing gap on mobile screens

### DIFF
--- a/ts-packages/web/src/app/(social)/layout.tsx
+++ b/ts-packages/web/src/app/(social)/layout.tsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router';
 
 export default function SocialLayout() {
   return (
-    <div className="flex min-h-screen gap-5 justify-between max-w-desktop mx-auto text-white py-3 max-tablet:px-2.5 overflow-x-hidden">
+    <div className="flex min-h-screen max-mobile:gap-0 gap-5 justify-between max-w-desktop mx-auto text-white py-3 max-tablet:px-2.5 overflow-x-hidden">
       <UserSidemenu />
       <div className="flex grow">
         <Outlet />


### PR DESCRIPTION
## Summary
Fixes #645 - Incorrect left and right margins of posts on mobile devices

## Changes Made
- ✅ Added `max-mobile:gap-0` to layout container
- ✅ Gap between sidebar and content now only applies on tablet and desktop
- ✅ Ensures equal left and right margins on mobile devices

## Root Cause
The social layout had `gap-5` applied at all screen sizes, creating asymmetric spacing between the UserSidemenu and content area on mobile. This resulted in uneven left/right margins for post cards.

## Solution
By adding `max-mobile:gap-0`, the gap is removed on mobile screens while maintaining the `gap-5` spacing on tablet and desktop views. This ensures consistent and equal margins on both sides of posts on mobile devices.

## Testing
- ✅ Build passes successfully
- ✅ Mobile view now has equal left/right margins
- ✅ Tablet/desktop layouts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing on mobile devices by adjusting layout padding to provide a more compact view on smaller screens while maintaining proper spacing on larger displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->