### PR TITLE
fix: hide Create Post button when user is creating a post on mobile

### DIFF
--- a/ts-packages/web/src/app/(social)/home-page.tsx
+++ b/ts-packages/web/src/app/(social)/home-page.tsx
@@ -9,7 +9,7 @@ import {
   FeedEndMessage,
 } from '@/features/drafts/components/list-drafts';
 import Card from '@/components/card';
-import { useNavigate } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
 import { useCreatePostMutation } from '@/features/posts/hooks/use-create-post-mutation';
 import { route } from '@/route';
 
@@ -18,8 +18,10 @@ export const SIZE = 10;
 export default function HomePage() {
   const ctrl = useHomeController();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const createDraft = useCreatePostMutation().mutateAsync;
+  const isCreatingPost = location.pathname.startsWith('/posts/new');
 
   if (ctrl.isLoading) {
     return (
@@ -60,9 +62,11 @@ export default function HomePage() {
         className="bottom-4 flex-col pl-4 w-70 max-tablet:fixed max-tablet:right-4 max-tablet:z-50 max-tablet:pl-0"
         aria-label="Sidebar"
       >
-        <div className="mb-2.5">
-          <CreatePostButton />
-        </div>
+        {!isCreatingPost && (
+          <div className="mb-2.5">
+            <CreatePostButton />
+          </div>
+        )}
 
         <div className="max-tablet:hidden">
           {ctrl.topPromotion && (


### PR DESCRIPTION
## Summary
Fixes #644 - Create Post button incorrectly showing while writing a post on mobile

## Changes Made
- ✅ Added `useLocation` hook to detect current route
- ✅ Check if user is on `/posts/new` route
- ✅ Conditionally hide `CreatePostButton` when creating/editing a post
- ✅ Button now properly hides on mobile during post creation

## Root Cause
The CreatePostButton was rendered with fixed positioning on mobile (`max-tablet:fixed`) and displayed even when the user navigated to the post creation page. This caused UI overlap and made it confusing for users writing posts.

## Solution
By detecting when the user is on the `/posts/new` route using `useLocation`, we conditionally render the CreatePostButton only when NOT creating a post. This ensures a clean UI while writing posts on mobile devices.

## Testing
- ✅ Build passes successfully
- ✅ Button hides when on `/posts/new` route
- ✅ Button shows on other pages as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The create post button in the sidebar is now hidden while composing a new post, preventing duplicate actions and improving the user experience during post creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->