### PR TITLE
fix: redirect to home page after logout to reflect logged-out state

### DIFF
--- a/ts-packages/web/src/app/_providers/auth-provider.tsx
+++ b/ts-packages/web/src/app/_providers/auth-provider.tsx
@@ -160,6 +160,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const encoded_identity = encodeEd25519PrivateKeyToPkcs8Base64(identity);
 
     localStorage.setItem(SK_ANONYMOUS_IDENTITY_KEY, encoded_identity);
+
+    // Redirect to home page to reflect logged-out state
+    window.location.href = '/';
   };
 
   const setTelegramRaw = (raw: string) => {


### PR DESCRIPTION
## Summary
Fixes #765 - After logging out, the page doesn't refresh and still shows the logged-in screen

## Changes Made
- ✅ Added `window.location.href = '/'` redirect after logout cleanup
- ✅ Page now automatically refreshes and redirects to home page
- ✅ UI immediately reflects logged-out state

## Root Cause
The `logoutUser` function was clearing Firebase auth state, removing localStorage items, creating a new anonymous identity, and clearing React state - but it wasn't triggering a page refresh or redirect. This left users looking at a logged-in UI even though they were actually logged out.

## Solution
By adding `window.location.href = '/'` at the end of the logout function, the browser redirects to the home page, which triggers a full page refresh and ensures all components re-render with the logged-out state.

## Testing
- ✅ Build passes successfully
- ✅ After logout, user is redirected to home page
- ✅ UI shows logged-out state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)