### PR TITLE
fix: redirect to home page after email login to reflect logged-in state

### DIFF
--- a/ts-packages/web/src/components/popup/login-popup.tsx
+++ b/ts-packages/web/src/components/popup/login-popup.tsx
@@ -134,9 +134,13 @@ export const LoginModal = ({
       });
       await updateTelegramId();
       network.refetch();
-    }
+      popup.close();
 
-    popup.close();
+      // Redirect to home page to reflect logged-in state
+      window.location.href = '/';
+    } else {
+      popup.close();
+    }
   };
 
   const handleContinue = async () => {


### PR DESCRIPTION
## Summary
Fixes #661 - Email login requires page refresh to reflect login status

## Changes Made
- ✅ Added `window.location.href = '/'` redirect after successful email login
- ✅ Moved popup.close() inside successful login branch
- ✅ Page now automatically refreshes and shows logged-in state

## Root Cause
The `handleSignIn` function in login-popup.tsx was invalidating queries and closing the popup after email/password login, but wasn't triggering a page refresh or redirect. This left the UI showing the logged-out state even though the user was actually logged in.

## Solution
By adding `window.location.href = '/'` after successful login and moving `popup.close()` before the redirect, the browser navigates to the home page with a full page refresh. This ensures all components re-render with the logged-in state immediately visible.

## Testing
- ✅ Build passes successfully
- ✅ After email login, user is redirected to home page
- ✅ UI shows logged-in state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)