### PR TITLE
fix(polls): prevent linear scale viewer from expanding screen width (#741)

### DIFF
--- a/ts-packages/web/src/features/spaces/components/survey/viewer/linear-scale-viewer.tsx
+++ b/ts-packages/web/src/features/spaces/components/survey/viewer/linear-scale-viewer.tsx
@@ -66,14 +66,14 @@ export default function LinearScaleViewer(props: LinearScaleViewerProps) {
 
       <div
         ref={wrapRef}
-        className="w-full select-none max-tablet:overflow-x-auto no-scrollbar touch-pan-x md:cursor-grab"
+        className="w-full select-none overflow-x-auto no-scrollbar touch-pan-x md:cursor-grab"
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerEnd}
         onPointerCancel={onPointerEnd}
         onPointerLeave={onPointerEnd}
       >
-        <div className="flex flex-row gap-5 justify-start items-center px-2 w-max">
+        <div className="flex flex-row gap-5 justify-start items-center px-2 w-fit">
           <div className="text-sm font-medium text-center break-words text-neutral-400 shrink-0">
             {min_label ?? ''}
           </div>


### PR DESCRIPTION
## Summary
Fixes #741 - Inconsistent screen width in Space pages, specifically Poll items expanding unexpectedly.

## Problem
When viewing a Poll with linear scale questions in a Space, the screen width would expand beyond the viewport, making it inconsistent with other pages like Overview and Analyze.

## Root Cause
The LinearScaleViewer component had `w-max` class on the inner scale container (line 76), which forced it to expand to fit all content width rather than staying within the container bounds. This caused the entire page to expand horizontally when polls had many scale options.

## Changes
### LinearScaleViewer (`linear-scale-viewer.tsx`)
**Before:**
```tsx
<div className="w-full ... max-tablet:overflow-x-auto ...">
  <div className="... w-max">
```

**After:**
```tsx
<div className="w-full ... overflow-x-auto ...">
  <div className="... w-fit">
```

### Specific changes:
1. **Inner container**: Changed from `w-max` to `w-fit`
   - `w-max` = `max-content` width (expands container)
   - `w-fit` = `fit-content` width (contained within parent)

2. **Outer container**: Changed from `max-tablet:overflow-x-auto` to `overflow-x-auto`
   - Enables horizontal scrolling on all screen sizes for long scales
   - Prevents content from forcing page width expansion
   - More consistent behavior across breakpoints

## Benefits
- ✅ Poll page width now matches Overview and Analyze pages
- ✅ No more horizontal page scrolling on desktop
- ✅ Linear scales with many options scroll within their container
- ✅ Consistent user experience across all Space page types
- ✅ Touch-friendly drag-to-scroll still works (maintained existing pointer events)

## Testing
- Build passes successfully
- Linear scale questions remain fully interactive
- Horizontal scrolling works for long scales
- Page width stays consistent across all Space pages