### PR TITLE
fix(main-api, web): resolve post like inconsistencies and improve UX

### DIFF
--- a/packages/main-api/src/lib.rs
+++ b/packages/main-api/src/lib.rs
@@ -26,6 +26,7 @@ use controllers::v3::*;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 use types::AppState;
+use validator::Validate;
 
 #[cfg(test)]
 pub mod tests;

--- a/packages/main-api/src/types/dynamo_partition.rs
+++ b/packages/main-api/src/types/dynamo_partition.rs
@@ -80,6 +80,15 @@ impl Partition {
         }
     }
 
+    pub fn to_post_like_key(self) -> crate::Result<Partition> {
+        match self {
+            Partition::Feed(pk) => Ok(Partition::PostLike(pk)),
+            _ => Err(crate::Error::InvalidPartitionKey(
+                "PostLike key can be only extracted from Feed key".to_string(),
+            )),
+        }
+    }
+
     pub fn is_space_key(&self) -> bool {
         matches!(self, Partition::Space(_))
     }

--- a/ts-packages/web/src/app/(social)/home-page.tsx
+++ b/ts-packages/web/src/app/(social)/home-page.tsx
@@ -2,16 +2,12 @@ import FeedCard from '@/components/feed-card';
 import { Col } from '@/components/ui/col';
 
 import PromotionCard from './_components/promotion-card';
-import Suggestions from './_components/suggestions';
 import { useHomeController } from './use-home-controller';
 import {
   CreatePostButton,
   FeedEndMessage,
 } from '@/features/drafts/components/list-drafts';
 import Card from '@/components/card';
-import { useNavigate } from 'react-router';
-import { useCreatePostMutation } from '@/features/posts/hooks/use-create-post-mutation';
-import { route } from '@/route';
 
 export const SIZE = 10;
 

--- a/ts-packages/web/src/components/feed-card.tsx
+++ b/ts-packages/web/src/components/feed-card.tsx
@@ -18,7 +18,7 @@ import {
 } from './ui/dropdown-menu';
 import { Edit1 } from './icons';
 import { showSuccessToast, showErrorToast } from './custom-toast/toast';
-import { useSuspenseUserInfo } from '@/hooks/use-user-info';
+import { useSuspenseUserInfo, useUserInfo } from '@/hooks/use-user-info';
 import { Loader2 } from 'lucide-react';
 import { logger } from '@/lib/logger';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +27,8 @@ import PostResponse from '@/features/posts/dto/list-post-response';
 import { useLikePostMutation } from '@/features/posts/hooks/use-like-post-mutation';
 import { SpaceType } from '@/features/spaces/types/space-type';
 import { TiptapEditor } from './text-editor';
+import { usePopup } from '@/lib/contexts/popup-service';
+import { LoginModal } from './popup/login-popup';
 
 export interface FeedCardProps {
   post: PostResponse;
@@ -41,28 +43,25 @@ export interface FeedCardProps {
 export default function FeedCard(props: FeedCardProps) {
   const { post } = props;
 
-  const [localLikes, setLocalLikes] = useState(post.likes);
-  const [localIsLiked, setLocalIsLiked] = useState(post.liked);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [localShares, setLocalShares] = useState(post.shares);
-
+  const { data: user } = useUserInfo();
+  const isLoggedIn = user !== null;
+  const popup = usePopup();
   // const { t } = useTranslation('Feeds');
 
   const likePost = useLikePostMutation().mutateAsync;
-  // Sync with props when they change
-  useEffect(() => {
-    setLocalLikes(post.likes);
-    setLocalIsLiked(post.liked);
-    setLocalShares(post.shares);
-  }, [post.likes, post.liked, post.shares]);
 
   const handleLike = async (value: boolean) => {
+    if (!isLoggedIn) {
+      popup
+        .open(<LoginModal />)
+        .withTitle('Join the Movement')
+        .withoutBackdropClose();
+    }
     if (isProcessing) return; // Prevent multiple clicks
 
     // Set processing state and optimistic update
     setIsProcessing(true);
-    setLocalIsLiked(value);
-    setLocalLikes((prev) => (value ? prev + 1 : prev - 1));
 
     try {
       await likePost({
@@ -74,8 +73,6 @@ export default function FeedCard(props: FeedCardProps) {
       props.onLikeClick?.(value);
     } catch (error) {
       // Revert optimistic update on error
-      setLocalIsLiked(post.liked);
-      setLocalLikes(post.likes);
       console.error('Failed to update like:', error);
     } finally {
       setIsProcessing(false);
@@ -97,7 +94,6 @@ export default function FeedCard(props: FeedCardProps) {
        *   },
        * }); */
 
-      setLocalShares((prev) => prev + 1);
       showSuccessToast('Reposted successfully');
     } catch (error) {
       logger.error('Failed to repost:', error);
@@ -135,11 +131,11 @@ export default function FeedCard(props: FeedCardProps) {
         space_id={post.space_pk}
         space_type={post.space_type}
         booster_type={post.booster}
-        likes={localLikes}
+        likes={post.likes}
         comments={post.comments}
         rewards={post.rewards || 0}
-        shares={localShares}
-        is_liked={localIsLiked}
+        shares={post.shares}
+        is_liked={post.liked}
         isLikeProcessing={isProcessing}
         onLikeClick={handleLike}
         onRepostThought={handleRepostThought}


### PR DESCRIPTION
- Refactored `list_posts_handler` in `list_posts.rs` to fix incorrect
  post-like key generation and improve logging.
- Added `to_post_like_key` method in `dynamo_partition.rs` for safer
  key transformations.
- Updated `FeedCard` component to handle unauthenticated users by
  showing a login modal and removed redundant local state for likes
  and shares.
- Fixed optimistic updates in `use-like-post-mutation` to correctly
  sync `likes` and `liked` fields in post lists.
- Removed unused imports and components from `home-page.tsx` for
  better maintainability.

Fixes #794