### PR TITLE
fix(feed-card): ensure long text breaks correctly in feed contents

### DIFF
--- a/ts-packages/web/src/components/feed-card.tsx
+++ b/ts-packages/web/src/components/feed-card.tsx
@@ -205,7 +205,7 @@ export function FeedContents({
   }, [contents]);
 
   return (
-    <div className="text-desc-text">
+    <div className="break-all text-desc-text">
       <TiptapEditor
         editable={false}
         showToolbar={false}


### PR DESCRIPTION
Fixes #756