### PR TITLE
fix: #782 - Prevent black screen when selecting dates in Space

### DIFF
--- a/ts-packages/web/src/components/calendar-dropdown/index.tsx
+++ b/ts-packages/web/src/components/calendar-dropdown/index.tsx
@@ -22,7 +22,7 @@ export default function CalendarDropdown({
   const selectedDate = value ? new Date(value) : null;
 
   return (
-    <Popover.Root open={canEdit && calendarOpen} onOpenChange={setCalendarOpen}>
+    <Popover.Root modal={false} open={canEdit && calendarOpen} onOpenChange={setCalendarOpen}>
       <Popover.Trigger asChild>
         <button className="flex flex-row justify-between items-center font-medium rounded-lg border shadow-sm focus:outline-none w-[150px] max-tablet:w-full px-[20px] py-[10.5px] text-[15px]/[22.5px] text-neutral-600 bg-select-date-bg border-select-date-border gap-[10px]">
           {selectedDate ? format(selectedDate, 'yyyy/MM/dd') : 'Selected Date'}

--- a/ts-packages/web/src/components/time-dropdown/index.tsx
+++ b/ts-packages/web/src/components/time-dropdown/index.tsx
@@ -73,7 +73,7 @@ export default function TimeDropdown({
   };
 
   return (
-    <Popover.Root open={canEdit && open} onOpenChange={setOpen}>
+    <Popover.Root modal={false} open={canEdit && open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <button
           ref={triggerRef}

--- a/ts-packages/web/src/components/timezone-dropdown/index.tsx
+++ b/ts-packages/web/src/components/timezone-dropdown/index.tsx
@@ -37,6 +37,7 @@ export default function TimezoneDropdown({
 
   return (
     <Popover.Root
+      modal={false}
       open={canEdit && dropdownOpen}
       onOpenChange={canEdit ? setDropdownOpen : undefined}
     >


### PR DESCRIPTION
## Summary

This PR fixes issue #782 where the entire screen would turn black when selecting dates in the Space date selector.

## 🎯 Issue Fixed

**Issue #782 - Screen Turns Black When Selecting a Past Date**

**Problem**: When selecting dates in the Space date selector (calendar, time, or timezone dropdowns), the entire screen would turn black, creating a confusing user experience.

**Root Cause**: Radix UI Popover components by default create a modal overlay with a backdrop that blocks interaction with the rest of the page and renders as a black background.

## 🔧 Solution

Added `modal={false}` prop to all Radix UI Popover.Root components to prevent the unwanted modal overlay/backdrop from rendering. This allows the dropdowns to open without blocking the rest of the page.

## 📝 Files Changed

### Fixed Components:
1. **calendar-dropdown/index.tsx** - Added `modal={false}` to Popover.Root
2. **time-dropdown/index.tsx** - Added `modal={false}` to Popover.Root  
3. **timezone-dropdown/index.tsx** - Added `modal={false}` to Popover.Root

## 🧪 Testing

✅ Frontend builds successfully  
✅ All TypeScript compilation passes  
✅ No breaking changes  
✅ Backward compatible

### Manual Testing Checklist:
- [ ] Open Space date selector
- [ ] Select calendar dropdown - no black screen
- [ ] Select time dropdown - no black screen
- [ ] Select timezone dropdown - no black screen
- [ ] Dropdowns still function correctly
- [ ] Can interact with page while dropdown is open

## 📸 Expected Behavior

**Before**: Black screen overlay when opening date/time pickers  
**After**: Clean dropdown opening without black background overlay

---

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>