### PR TITLE
fix(posts): correct timestamp precision and add test assertion

### DIFF
--- a/packages/main-api/src/controllers/v3/posts/tests.rs
+++ b/packages/main-api/src/controllers/v3/posts/tests.rs
@@ -366,6 +366,7 @@ async fn test_list_posts() {
         first["html_contents"],
         format!("<p>Updated Content {} 10</p>", now)
     );
+    assert_eq!(items.length().unwrap_or_default(), 10);
 
     let (status, _headers, body) = get! {
         app: app,

--- a/packages/main-api/src/controllers/v3/posts/update_post.rs
+++ b/packages/main-api/src/controllers/v3/posts/update_post.rs
@@ -58,7 +58,7 @@ pub async fn update_post_handler(
         return Err(Error::NoPermission);
     }
 
-    let now = chrono::Utc::now().timestamp();
+    let now = chrono::Utc::now().timestamp_millis();
     let updater = Post::updater(&post.pk, &post.sk).with_updated_at(now);
     post.updated_at = now;
 


### PR DESCRIPTION
- Updated `update_post_handler` to use `timestamp_millis` for higher precision
- Added a missing assertion in `test_list_posts` to validate item count