### PR TITLE
feat(my-spaces): add "My Spaces" feature for listing user spaces

### DIFF
--- a/packages/main-api/src/controllers/v3/me/list_my_spaces.rs
+++ b/packages/main-api/src/controllers/v3/me/list_my_spaces.rs
@@ -1,0 +1,25 @@
+use crate::{features::spaces::SpaceParticipant, models::SpaceCommon};
+
+use super::*;
+
+pub async fn list_my_spaces_handler(
+    State(AppState { dynamo, .. }): State<AppState>,
+    NoApi(user): NoApi<User>,
+    Query(Pagination { bookmark }): ListItemsQuery,
+) -> Result<Json<ListItemsResponse<SpaceCommon>>> {
+    let mut opt = SpaceParticipant::opt().limit(10);
+
+    if let Some(bookmark) = bookmark {
+        opt = opt.bookmark(bookmark);
+    }
+    let (sps, bookmark) = SpaceParticipant::find_by_user(&dynamo.client, &user.pk, opt).await?;
+
+    let keys = sps
+        .into_iter()
+        .map(|sp| (sp.space_pk, EntityType::SpaceCommon))
+        .collect::<Vec<(Partition, EntityType)>>();
+
+    let items = SpaceCommon::batch_get(&dynamo.client, keys).await?;
+
+    Ok(Json(ListItemsResponse { items, bookmark }))
+}

--- a/packages/main-api/src/controllers/v3/me/mod.rs
+++ b/packages/main-api/src/controllers/v3/me/mod.rs
@@ -4,6 +4,7 @@ pub mod update_user;
 mod did;
 pub mod list_my_drafts;
 pub mod list_my_posts;
+mod list_my_spaces;
 #[cfg(test)]
 pub mod tests;
 
@@ -19,5 +20,6 @@ pub fn route() -> Result<Router<AppState>> {
         .nest("/did", did::route()?)
         .route("/", get(get_info_handler).patch(update_user_handler))
         .route("/posts", get(list_my_posts_handler))
+        .route("/spaces", get(list_my_spaces::list_my_spaces_handler))
         .route("/drafts", get(list_my_drafts_handler)))
 }

--- a/packages/main-api/src/controllers/v3/spaces/participate_space.rs
+++ b/packages/main-api/src/controllers/v3/spaces/participate_space.rs
@@ -48,7 +48,6 @@ pub async fn participate_space_handler(
         .unwrap()
         .replace('-', " ");
 
-    // TODO: check duplicated name
     let sp = SpaceParticipant::new(space.pk.clone(), user.pk.clone(), display_name);
     let new_space = SpaceCommon::updater(&space.pk, &space.sk)
         .increase_participants(1)

--- a/ts-packages/web/src/app/(social)/my-spaces/_hooks/use-my-spaces.ts
+++ b/ts-packages/web/src/app/(social)/my-spaces/_hooks/use-my-spaces.ts
@@ -1,0 +1,25 @@
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseUserInfo } from '@/hooks/use-user-info';
+import { listMySpaces, ListMySpacesResponse } from '@/lib/api/ratel/me.v3';
+
+export function getOptions(username: string) {
+  return {
+    queryKey: ['my-spaces', username],
+    queryFn: ({
+      pageParam,
+    }: {
+      pageParam?: string;
+    }): Promise<ListMySpacesResponse> => listMySpaces(pageParam),
+    getNextPageParam: (last: ListMySpacesResponse) => last.bookmark ?? undefined,
+    initialPageParam: undefined as string | undefined,
+    refetchOnWindowFocus: false,
+  };
+}
+
+export default function useInfiniteMySpaces() {
+  const { data } = useSuspenseUserInfo();
+
+  const username = data?.username || '';
+
+  return useSuspenseInfiniteQuery(getOptions(username));
+}

--- a/ts-packages/web/src/app/(social)/my-spaces/page.tsx
+++ b/ts-packages/web/src/app/(social)/my-spaces/page.tsx
@@ -1,0 +1,113 @@
+import { useCallback } from 'react';
+import { Col } from '@/components/ui/col';
+import { useObserver } from '@/hooks/use-observer';
+import useInfiniteMySpaces from './_hooks/use-my-spaces';
+import { useNavigate } from 'react-router';
+import { route } from '@/route';
+import Card from '@/components/card';
+import { SpaceCommon } from '@/features/spaces/types/space-common';
+
+function SpaceCard({ space }: { space: SpaceCommon }) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(route.space(space.pk));
+  };
+
+  return (
+    <Card
+      onClick={handleClick}
+      className="cursor-pointer hover:bg-card-bg-hover transition-colors"
+    >
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          {space.author_profile_url && (
+            <img
+              src={space.author_profile_url}
+              alt={space.author_display_name}
+              className="w-10 h-10 rounded-full"
+            />
+          )}
+          <div className="flex flex-col">
+            <h3 className="text-base font-semibold text-text-primary">
+              {space.author_display_name}
+            </h3>
+            <p className="text-sm text-text-secondary">
+              @{space.author_username}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
+          <span className="px-2 py-1 bg-background-secondary rounded">
+            {space.publish_state}
+          </span>
+          {space.status && (
+            <span className="px-2 py-1 bg-background-secondary rounded">
+              {space.status}
+            </span>
+          )}
+          {space.visibility.type && (
+            <span className="px-2 py-1 bg-background-secondary rounded">
+              {space.visibility.type}
+            </span>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-row justify-start items-center w-full text-base font-medium text-gray-500 border border-gray-500 h-fit px-[16px] py-[20px] rounded-[8px]">
+      No spaces available
+    </div>
+  );
+}
+
+function FeedEndMessage({ msg }: { msg: string }) {
+  return (
+    <div className="flex flex-row justify-center items-center w-full text-base font-medium text-gray-500 h-fit px-[16px] py-[20px]">
+      {msg}
+    </div>
+  );
+}
+
+export default function MySpacesPage() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteMySpaces();
+
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const observerRef = useObserver<HTMLDivElement>(handleIntersect, {
+    threshold: 1,
+  });
+
+  const flattedSpaces = data?.pages.flatMap((page) => page.items) ?? [];
+
+  if (flattedSpaces.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="flex relative flex-1">
+      <Col className="flex flex-1 max-mobile:px-[10px]">
+        <Col className="flex-1 gap-4">
+          {flattedSpaces.map((space) => (
+            <SpaceCard key={`space-${space.pk}`} space={space} />
+          ))}
+
+          <div ref={observerRef} />
+          {!hasNextPage && (
+            <FeedEndMessage msg="You have reached the end of your spaces." />
+          )}
+        </Col>
+      </Col>
+    </div>
+  );
+}

--- a/ts-packages/web/src/features/users/components/user-sidemenu/i18n.tsx
+++ b/ts-packages/web/src/features/users/components/user-sidemenu/i18n.tsx
@@ -4,12 +4,14 @@ export const UserSidemenu = {
   en: {
     my_posts: 'My Posts',
     drafts: 'Drafts',
+    my_spaces: 'My Spaces',
     credentials: 'Credentials',
     settings: 'Settings',
   },
   ko: {
     my_posts: '내 게시물',
     drafts: '임시글',
+    my_spaces: '내 스페이스',
     credentials: '자격 증명',
     settings: '설정',
   },
@@ -18,6 +20,7 @@ export const UserSidemenu = {
 export interface UserSidemenuI18n {
   my_posts: string;
   drafts: string;
+  my_spaces: string;
   settings: string;
   credentials: string;
 }
@@ -28,6 +31,7 @@ export function useUserSidemenuI18n(): UserSidemenuI18n {
   return {
     my_posts: t('my_posts'),
     drafts: t('drafts'),
+    my_spaces: t('my_spaces'),
     settings: t('settings'),
     credentials: t('credentials'),
   };

--- a/ts-packages/web/src/features/users/components/user-sidemenu/index.tsx
+++ b/ts-packages/web/src/features/users/components/user-sidemenu/index.tsx
@@ -1,7 +1,7 @@
 import ProfileSection from '../../../../app/(social)/_components/profile-section';
 
 import { route } from '@/route';
-import { Post, Draft, Settings, Did } from '@/components/icons';
+import { Post, Draft, Settings, Did, UserGroup } from '@/components/icons';
 import { useLocation } from 'react-router';
 import { useUserInfo } from '@/hooks/use-user-info';
 import { NavLink } from 'react-router';
@@ -49,6 +49,14 @@ export default function UserSidemenu() {
         >
           <Draft className="w-[24px] h-[24px]" />
           <span>{t.drafts}</span>
+        </NavLink>
+
+        <NavLink
+          to={route.mySpaces()}
+          className="sidemenu-link text-text-primary"
+        >
+          <UserGroup className="w-[24px] h-[24px]" />
+          <span>{t.my_spaces}</span>
         </NavLink>
 
         <NavLink

--- a/ts-packages/web/src/lib/api/ratel/me.v3.ts
+++ b/ts-packages/web/src/lib/api/ratel/me.v3.ts
@@ -1,7 +1,13 @@
 import { ListPostResponse } from '@/features/posts/dto/list-post-response';
 import { DidDocument } from '@/features/did/types/did-document';
+import { SpaceCommon } from '@/features/spaces/types/space-common';
 import { call } from './call';
 import { UserDetailResponse } from './users.v3';
+
+export interface ListMySpacesResponse {
+  items: SpaceCommon[];
+  bookmark?: string;
+}
 
 export async function getUserInfo(): Promise<UserDetailResponse> {
   return call('GET', '/v3/me');
@@ -22,6 +28,17 @@ export async function listMyDrafts(
   bookmark?: string,
 ): Promise<ListPostResponse> {
   let path = '/v3/me/drafts';
+  if (bookmark) {
+    path += `?bookmark=${encodeURIComponent(bookmark)}`;
+  }
+
+  return call('GET', path);
+}
+
+export async function listMySpaces(
+  bookmark?: string,
+): Promise<ListMySpacesResponse> {
+  let path = '/v3/me/spaces';
   if (bookmark) {
     path += `?bookmark=${encodeURIComponent(bookmark)}`;
   }

--- a/ts-packages/web/src/route.tsx
+++ b/ts-packages/web/src/route.tsx
@@ -8,6 +8,7 @@ export const route = {
   settings: () => '/settings',
   credentials: () => '/credentials',
   myPosts: () => '/my-posts',
+  mySpaces: () => '/my-spaces',
   createPost: (postPk?: string) =>
     postPk ? `/posts/new?post-pk=${encodeURIComponent(postPk)}` : '/posts/new',
   createArtwork: (postPk?: string) =>

--- a/ts-packages/web/src/router.tsx
+++ b/ts-packages/web/src/router.tsx
@@ -59,6 +59,7 @@ import { Terms } from './app/terms';
 import { Privacy } from './app/privacy';
 import { Refund } from './app/refund';
 import SpaceMemberPage from './app/spaces/[id]/members/space-member-page';
+import MySpacesPage from './app/(social)/my-spaces/page';
 
 export const routes = createBrowserRouter([
   {
@@ -109,6 +110,11 @@ export const routes = createBrowserRouter([
                 Component: MyDraftPage,
               },
             ],
+          },
+          {
+            id: 'my-spaces-page',
+            path: 'my-spaces',
+            Component: MySpacesPage,
           },
           {
             id: 'settings-layout',


### PR DESCRIPTION
- Introduced a new API endpoint `/v3/me/spaces` to fetch user-specific spaces
- Added `list_my_spaces_handler` in the backend to handle space listing
- Created a new React page and hook for "My Spaces" in the frontend
- Updated the user side menu to include a link to "My Spaces"
- Enhanced API utilities to support fetching user spaces
- Updated routing to include the "My Spaces" page