### PR TITLE
feat(spaces): add support for blocking user participation in spaces

### DIFF
--- a/packages/main-api/src/controllers/v3/spaces/participate_space.rs
+++ b/packages/main-api/src/controllers/v3/spaces/participate_space.rs
@@ -28,6 +28,10 @@ pub async fn participate_space_handler(
     tracing::debug!("Handling request: {:?}", req);
     permissions.permitted(TeamGroupPermission::SpaceRead)?;
 
+    if space.block_participate {
+        return Err(Error::ParticipationBlocked);
+    }
+
     // TODO: Check verifiable_presentation and add user as SpaceParticipant
 
     // let is_verified = SpaceParticipant::verify_credential(&dynamo, &space_pk, user.clone()).await;

--- a/packages/main-api/src/controllers/v3/spaces/update_space.rs
+++ b/packages/main-api/src/controllers/v3/spaces/update_space.rs
@@ -38,6 +38,8 @@ pub enum UpdateSpaceRequest {
     },
     Start {
         start: bool,
+        #[serde(default)]
+        block_participate: bool,
     },
     Finish {
         finished: bool,
@@ -127,7 +129,10 @@ pub async fn update_space_handler(
         UpdateSpaceRequest::Title { title } => {
             pu = pu.with_title(title.clone());
         }
-        UpdateSpaceRequest::Start { start } => {
+        UpdateSpaceRequest::Start {
+            start,
+            block_participate,
+        } => {
             if space.status != Some(SpaceStatus::InProgress) {
                 return Err(Error::NotSupported(
                     "Start is not available for the current status.".into(),
@@ -138,9 +143,12 @@ pub async fn update_space_handler(
                 return Err(Error::NotSupported("it does not support start now".into()));
             }
 
-            su = su.with_status(SpaceStatus::Started);
+            su = su
+                .with_status(SpaceStatus::Started)
+                .with_block_participate(block_participate);
 
             space.status = Some(SpaceStatus::Started);
+            space.block_participate = block_participate;
             let _ = SpaceEmailVerification::expire_verifications(&dynamo, space_pk.clone()).await?;
         }
         UpdateSpaceRequest::Finish { finished } => {

--- a/packages/main-api/src/error.rs
+++ b/packages/main-api/src/error.rs
@@ -141,6 +141,8 @@ pub enum Error {
     InvalidSpacePartitionKey,
     #[error("Space requirements are invalid")]
     SpaceInvalidRequirements,
+    #[error("User participation is blocked for this space")]
+    ParticipationBlocked,
 
     // members feature 3050 ~
     #[rest_error(code = 3050)]

--- a/packages/main-api/src/features/spaces/models/space_common.rs
+++ b/packages/main-api/src/features/spaces/models/space_common.rs
@@ -73,6 +73,9 @@ pub struct SpaceCommon {
 
     // space pdf files
     pub files: Option<Vec<File>>,
+
+    #[serde(default)]
+    pub block_participate: bool,
 }
 
 impl SpaceCommon {

--- a/ts-packages/web/src/app/(social)/my-spaces/i18n.tsx
+++ b/ts-packages/web/src/app/(social)/my-spaces/i18n.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next';
+
+export const MySpaces = {
+  en: {
+    status: {
+      pending: 'Pending',
+      participating: 'Participating',
+      blocked: 'Expired',
+    },
+  },
+  ko: {
+    status: {
+      pending: '대기중',
+      participating: '참여중',
+      blocked: '참여기간 만료',
+    },
+  },
+};
+
+export interface MySpacesI18n {
+  status: {
+    pending: string;
+    participating: string;
+    blocked: string;
+  };
+}
+
+export function useMySpacesI18n(): MySpacesI18n {
+  const { t } = useTranslation('MySpaces');
+
+  return {
+    status: {
+      pending: t('status.pending'),
+      participating: t('status.participating'),
+      blocked: t('status.blocked'),
+    },
+  };
+}

--- a/ts-packages/web/src/app/spaces/[id]/use-space-home-controller.tsx
+++ b/ts-packages/web/src/app/spaces/[id]/use-space-home-controller.tsx
@@ -296,6 +296,7 @@ export class SpaceHomeController {
     try {
       this.startSpace.mutateAsync({
         spacePk: this.space.pk,
+        block: true,
       });
 
       showSuccessToast(this.t('success_start_space'));

--- a/ts-packages/web/src/features/spaces/hooks/use-start-mutation.ts
+++ b/ts-packages/web/src/features/spaces/hooks/use-start-mutation.ts
@@ -1,14 +1,23 @@
 import { spaceKeys } from '@/constants';
-import { startSpace } from '@/lib/api/ratel/spaces.v3';
 import { optimisticUpdate } from '@/lib/hook-utils';
 import { SpaceCommon, SpaceStatus } from '@/features/spaces/types/space-common';
 import { useMutation } from '@tanstack/react-query';
+import { call } from '@/lib/api/ratel/call';
 
 export function useStartSpaceMutation<T extends SpaceCommon>() {
   const mutation = useMutation({
     mutationKey: ['start-space'],
-    mutationFn: async ({ spacePk }: { spacePk: string }) => {
-      await startSpace(spacePk);
+    mutationFn: async ({
+      spacePk,
+      block,
+    }: {
+      spacePk: string;
+      block?: boolean;
+    }) => {
+      call('PATCH', `/v3/spaces/${encodeURIComponent(spacePk)}`, {
+        start: true,
+        block_participate: block ?? false,
+      });
     },
     onSuccess: async (_, { spacePk }) => {
       const spaceQK = spaceKeys.detail(spacePk);

--- a/ts-packages/web/src/features/spaces/types/space-common.ts
+++ b/ts-packages/web/src/features/spaces/types/space-common.ts
@@ -44,6 +44,7 @@ export interface SpaceCommon {
   files?: FileModel[];
 
   anonymous_participation: boolean;
+  block_participate?: boolean;
 }
 
 export type MySpace = SpaceCommon & {

--- a/ts-packages/web/src/features/spaces/types/space.tsx
+++ b/ts-packages/web/src/features/spaces/types/space.tsx
@@ -43,6 +43,7 @@ export class Space {
   public participantProfileUrl: string | null;
   public participantUsername: string | null;
   public requirements: SpaceRequirement[];
+  public blockParticipate: boolean;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(json: any) {
@@ -81,6 +82,7 @@ export class Space {
           .map((e) => new SpaceRequirement(e))
           .sort((a, b) => a.order - b.order)
       : [];
+    this.blockParticipate = json.block_participate || false;
   }
 
   shouldParticipateManually() {

--- a/ts-packages/web/src/i18n/config.ts
+++ b/ts-packages/web/src/i18n/config.ts
@@ -74,6 +74,7 @@ import { i18nSpaceBoardsEditor } from '@/features/spaces/boards/pages/creator/sp
 import { i18nSpaceBoardsEditorDetail } from '@/features/spaces/boards/pages/creator/detail/space-boards-editor-detail-i18n';
 import { i18nAttributeCodes } from '@/app/admin/attribute-codes/attribute-codes-page-i18n';
 import { Errors } from '@/features/errors/i18n';
+import { MySpaces } from '@/app/(social)/my-spaces/i18n';
 export const LANGUAGES = ['en', 'ko'];
 
 // NOTE: it should be migrated to namespace based code splitting later
@@ -157,6 +158,7 @@ Object.entries({
   Refund,
   SpaceSettings,
   Errors,
+  MySpaces,
 }).forEach(([key, value]) => {
   resources.en[key] = value.en;
   resources.ko[key] = value.ko;

--- a/ts-packages/web/src/lib/api/ratel/spaces.v3.ts
+++ b/ts-packages/web/src/lib/api/ratel/spaces.v3.ts
@@ -41,12 +41,6 @@ export function deleteSpace(spacePk: string): Promise<void> {
   return call('DELETE', `/v3/spaces/${encodeURIComponent(spacePk)}`);
 }
 
-export function startSpace(spacePk: string): Promise<void> {
-  return call('PATCH', `/v3/spaces/${encodeURIComponent(spacePk)}`, {
-    start: true,
-  });
-}
-
 export function updateSpaceVisibility(
   spacePk: string,
   visibility: SpaceVisibility,


### PR DESCRIPTION
- Introduced `block_participate` field in `SpaceCommon` model and API
- Updated `participate_space_handler` to handle participation blocking
- Enhanced `update_space_handler` to support `block_participate` in `Start` requests
- Added `ParticipationBlocked` error for blocked participation scenarios
- Implemented UI changes to display blocked status in "My Spaces" page
- Updated i18n configuration to include translations for blocked status
- Refactored `useStartSpaceMutation` to support `block_participate` parameter
- Removed unused `startSpace` function from `spaces.v3.ts` API module