### PR TITLE
feat(cdk): replace StorybookStack with StaticStack for static assets

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -46,8 +46,6 @@ jobs:
           SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DOMAIN: dev.ratel.foundation
           STACK: ratel-dev-stack
-          DEPLOY_STORYBOOK: false
-          DEPLOY_STATIC: false
         run: |
           npm i -g aws-cdk
           make cdk-deploy-v2
@@ -390,11 +388,9 @@ jobs:
 
       - name: Deploy to S3
         env:
-          BUCKET: ${{ secrets.DEV_RATEL_BUCKET }}
-          CDN: ${{ secrets.DEV_RATEL_CDN }}
+          ENV: dev
         run: |
-          aws s3 sync dist $BUCKET
-          aws cloudfront create-invalidation --distribution-id $CDN --paths "/*"
+          make sync
 
       - name: Prepare artifacts
         run: |

--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -40,8 +40,6 @@ jobs:
           SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DOMAIN: ratel.foundation
           STACK: ratel-prod-stack
-          DEPLOY_STORYBOOK: false
-          DEPLOY_STATIC: false
         run: |
           npm i -g aws-cdk
           make cdk-deploy-v2
@@ -199,11 +197,9 @@ jobs:
 
       - name: Deploy to S3
         env:
-          BUCKET: ${{ secrets.PROD_RATEL_BUCKET }}
-          CDN: ${{ secrets.PROD_RATEL_CDN }}
+          ENV: prod
         run: |
-          aws s3 sync dist $BUCKET
-          aws cloudfront create-invalidation --distribution-id $CDN --paths "/*"
+          make sync
 
       - name: Prepare artifacts
         run: |

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,7 +3,7 @@ import { RegionalServiceStack } from "../lib/regional-service-stack";
 import { GlobalAccelStack } from "../lib/global-accel-stack";
 import { GlobalTableStack } from "../lib/dynamodb-stack";
 import { ImageWorkerStack } from "../lib/image-worker-stack";
-import { StorybookStack } from "../lib/storybook-stack";
+import { StaticStack } from "../lib/static-stack";
 import { DaemonStack } from "../lib/daemon-stack";
 
 const app = new App();
@@ -16,11 +16,6 @@ const host = process.env.DOMAIN || "dev.ratel.foundation";
 const webDomain = host;
 const apiDomain = `api.${host}`;
 const baseDomain = "ratel.foundation";
-const deployStorybook =
-  (process.env.DEPLOY_STORYBOOK && process.env.DEPLOY_STORYBOOK === "true") ||
-  false;
-const deployStatic =
-  (process.env.DEPLOY_STATIC && process.env.DEPLOY_STATIC === "true") || false;
 
 // new ImageWorkerStack(app, `ratel-${env}-image-worker`, {
 //   env: {
@@ -29,15 +24,22 @@ const deployStatic =
 //   },
 // });
 
-if (deployStorybook) {
-  new StorybookStack(app, `ratel-${env}-storybook`, {
+if (env === "dev") {
+  new StaticStack(app, `ratel-${env}-storybook`, {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: "us-east-1",
     },
-    stage: env,
-    commit: process.env.COMMIT!,
     webDomain: `storybook.${host}`,
+    baseDomain,
+  });
+
+  new StaticStack(app, `ratel-${env}-report`, {
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: "us-east-1",
+    },
+    webDomain: `report.${host}`,
     baseDomain,
   });
 }

--- a/cdk/lib/global-accel-stack.ts
+++ b/cdk/lib/global-accel-stack.ts
@@ -119,11 +119,9 @@ export class GlobalAccelStack extends Stack {
       ),
     });
 
-    // new s3deploy.BucketDeployment(this, `RatelWebBucketDeployment-${stage}`, {
-    //   destinationBucket: staticBucket,
-    //   distribution: distribution,
-    //   distributionPaths: ["/*"],
-    //   sources: [s3deploy.Source.asset("dist")],
-    // });
+    new cdk.CfnOutput(this, "BucketName", { value: staticBucket.bucketName });
+    new cdk.CfnOutput(this, "DistributionId", {
+      value: distribution.distributionId,
+    });
   }
 }

--- a/cdk/lib/static-stack.ts
+++ b/cdk/lib/static-stack.ts
@@ -10,21 +10,17 @@ import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as cdk from "aws-cdk-lib";
 import * as targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 
 export interface StorybookStackProps extends StackProps {
-  stage: string;
-  commit: string;
-
   webDomain: string;
   baseDomain: string;
 }
 
-export class StorybookStack extends Stack {
+export class StaticStack extends Stack {
   constructor(scope: Construct, id: string, props: StorybookStackProps) {
     super(scope, id, { ...props, crossRegionReferences: true });
 
-    const { commit, webDomain, baseDomain, stage } = props;
+    const { webDomain, baseDomain } = props;
     const zone = route53.HostedZone.fromLookup(this, "RootZone", {
       domainName: baseDomain,
     });
@@ -93,15 +89,9 @@ export class StorybookStack extends Stack {
       ),
     });
 
-    new s3deploy.BucketDeployment(
-      this,
-      `RatelStoryBookBucketDeployment-${stage}`,
-      {
-        destinationBucket: staticBucket,
-        distribution: distribution,
-        distributionPaths: ["/*"],
-        sources: [s3deploy.Source.asset("storybook-static")],
-      },
-    );
+    new cdk.CfnOutput(this, "BucketName", { value: staticBucket.bucketName });
+    new cdk.CfnOutput(this, "DistributionId", {
+      value: distribution.distributionId,
+    });
   }
 }

--- a/ts-packages/web/Makefile
+++ b/ts-packages/web/Makefile
@@ -27,6 +27,22 @@ VITE_API_URL ?= http://localhost:3000
 VITE_EXPERIMENT ?= false
 VITE_TELEGRAM_BOTNAME ?= dummy
 
+ENV ?= dev
+
+STACK ?= ratel-$(ENV)-stack
+
+WEB_CDN_ID=$(shell aws cloudformation describe-stacks \
+  --region us-east-1 \
+  --stack-name $(STACK) \
+  --query "Stacks[0].Outputs[?OutputKey=='BucketName'].OutputValue" \
+  --output text)
+
+WEB_BUCKET=$(shell aws cloudformation describe-stacks \
+  --region us-east-1 \
+  --stack-name $(STACK) \
+  --query "Stacks[0].Outputs[?OutputKey=='DistributionId'].OutputValue" \
+  --output text)
+
 BUILD_ENV ?= VERSION=$(VERSION) \
 							VITE_ENV=$(VITE_ENV) \
 							VITE_LOG_LEVEL=$(VITE_LOG_LEVEL) \
@@ -72,6 +88,12 @@ run: node_module
 
 build: node_module
 	$(BUILD_ENV) pnpm build
+
+dist: build
+
+sync: dist
+	aws s3 sync ./dist s3://$(WEB_BUCKET)
+	aws cloudfront create-invalidation --distribution-id $(WEB_CDN_ID) --paths "/*"
 
 test: node_modules
 	$(PLAYWRIGHT_ENV) npx playwright test $(PLAYWRIGHT_ARGS)


### PR DESCRIPTION
- Refactored `StorybookStack` to `StaticStack` to generalize static asset deployment.
- Updated CDK app to deploy `StaticStack` for both `storybook` and `report` subdomains.
- Simplified environment variables in GitHub workflows for `dev` and `prod`.
- Added `sync` target to Makefile for S3 and CloudFront operations.
- Removed unused `DEPLOY_STORYBOOK` and `DEPLOY_STATIC` flags from workflows.
- Introduced outputs for S3 bucket and CloudFront distribution in `StaticStack`.