### PR TITLE
fix(main-api, membership): handle PortOne billing errors and update logic

### DIFF
--- a/packages/main-api/src/error.rs
+++ b/packages/main-api/src/error.rs
@@ -280,6 +280,8 @@ pub enum Error {
     CardInfoRequired,
     #[error("No user purchase found for payment")]
     NoUserPurchaseFound,
+    #[error("PortOne billing key error")]
+    PortOneBillingKeyError,
 
     // Biyard API errors 10,050 ~
     #[error("Biyard error: {0}")]

--- a/packages/main-api/src/services/portone/portone.rs
+++ b/packages/main-api/src/services/portone/portone.rs
@@ -87,6 +87,12 @@ impl PortOne {
             .send()
             .await?;
 
+        if !res.status().is_success() {
+            let err_text = res.text().await?;
+            error!("PortOne get billing key error: {}", err_text);
+            return Err(Error::PortOneBillingKeyError);
+        }
+
         Ok(res.json().await?)
     }
 

--- a/ts-packages/web/src/features/membership/components/membership-plan/membership-purchase-modal.tsx
+++ b/ts-packages/web/src/features/membership/components/membership-plan/membership-purchase-modal.tsx
@@ -38,12 +38,19 @@ export function MembershipPurchaseModal({
   customer,
   t,
 }: MembershipPurchaseModalProps) {
+  let isBusiness = false;
+  if (customer.birthDate.split('-')[0].length == 3) {
+    isBusiness = true;
+  }
+
   const [customerInfo, setCustomerInfo] = useState<CustomerInfo>({
     name: customer.name,
     cardNumber: '',
     expiryMonth: '',
     expiryYear: '',
-    birthOrBiz: customer.birthDate.replaceAll('-', '').slice(0, 6),
+    birthOrBiz: isBusiness
+      ? customer.birthDate.replaceAll('-', '').slice(0, 10)
+      : customer.birthDate.replaceAll('-', '').slice(2, 8),
     cardPassword: '',
   });
 

--- a/ts-packages/web/src/features/membership/components/membership-plan/use-controller.tsx
+++ b/ts-packages/web/src/features/membership/components/membership-plan/use-controller.tsx
@@ -58,7 +58,7 @@ export class Controller {
     }
 
     if (this.i18n.language === 'ko') {
-      displayAmount = Math.round(displayAmount * 1000);
+      displayAmount = Math.round(displayAmount * 1500);
     }
 
     if (this.user.data.has_billing_key) {


### PR DESCRIPTION
- Added a new `PortOneBillingKeyError` to the `Error` enum in `main-api`.
- Implemented error handling for unsuccessful PortOne billing key requests.
- Adjusted `birthOrBiz` computation logic in `MembershipPurchaseModal` to account
  for business users based on birthdate formatting.
- Updated currency `displayAmount` calculation in `use-controller` for Korean
  language to reflect a higher multiplier.