### PR TITLE
feat(theme): add Tailwind CSS theme tokens for light and dark modes

### DIFF
--- a/app/common/assets/tailwind-colors.css
+++ b/app/common/assets/tailwind-colors.css
@@ -1,0 +1,334 @@
+/* ==========================================================================
+   FIGMA DESIGN TOKENS - Auto-generated from Dark.tokens.json / Light.tokens.json
+   ========================================================================== */
+
+/* ----------------------------
+   DARK THEME (Default)
+   ---------------------------- */
+@theme static {
+  /* ---- Top-level ---- */
+  --color-line-default: #262626;
+  --color-font-default: #A1A1A1;
+  --color-wh: #FFFFFF;
+  --color-component-card: #35343F;
+  --color-special-bg: #FCB3000D;
+  --color-component-bg: #1A1A1A;
+  --color-ratel: #1E1E1E;
+
+  /* ---- Mobile: Divider ---- */
+  --color-mobile-divider: #262626;
+
+  /* ---- Mobile: Icon ---- */
+  --color-mobile-icon-secondary: #737373;
+  --color-mobile-icon-absolute: #FFFFFF;
+  --color-mobile-icon-primary: #737373;
+  --color-mobile-icon-bk-ab: #101010;
+  --color-mobile-icon-point: #FCB300;
+
+  /* ---- Mobile: Effect ---- */
+  --color-mobile-effect-blur: #26262666;
+
+  /* ---- Mobile: Logo ---- */
+  --color-mobile-logo-border: #1E1E1E;
+
+  /* ---- Mobile: Header ---- */
+  --color-mobile-header-stroke: #262626;
+  --color-mobile-header-bottom-line: #464646;
+
+  /* ---- Mobile: Font ---- */
+  --color-mobile-font-link: #FCB300;
+  --color-mobile-font-placeholder: #404040;
+  --color-mobile-font-secondary: #FFFFFF;
+  --color-mobile-font-third: #D4D4D4;
+  --color-mobile-font-disabled: #737373;
+  --color-mobile-font-neutral: #8C8C8C;
+  --color-mobile-font-primary: #FCB300;
+  --color-mobile-font-absolute-wh: #FFFFFF;
+  --color-mobile-font-absolute-bk: #1D1D1D;
+  --color-mobile-font-tag: #FFFFFF;
+  --color-mobile-font-tag2: #262626;
+  --color-mobile-font-secondary-op: #262626;
+
+  /* ---- Mobile: Button ---- */
+  --color-mobile-button-line-third: #262626;
+  --color-mobile-button-trans-bg: #FFFFFF26;
+  --color-mobile-button-disabled: #262626;
+  --color-mobile-button-line-primary: #FCB300;
+  --color-mobile-button-line-secondary: #FFFFFF;
+  --color-mobile-button-pressed: #737373;
+  --color-mobile-button-fill-primary: #1D1D1D;
+  --color-mobile-button-bg: #FFFFFF;
+
+  /* ---- Mobile: Pop ---- */
+  --color-mobile-pop-bg: #171717;
+
+  /* ---- Mobile: Component ---- */
+  --color-mobile-component-bg: #35343F;
+  --color-mobile-component-card-line: #2D2D2D;
+  --color-mobile-component-card-bg: #171717;
+  --color-mobile-component-card-bg2: #262626;
+
+  /* ---- Mobile: Separator ---- */
+  --color-mobile-separator: #2A2A2A;
+
+  /* ---- Mobile: Notification ---- */
+  --color-mobile-notification-error: #FF6467;
+  --color-mobile-notification-info: #51A2FF;
+  --color-mobile-notification-warn: #FC8200;
+
+  /* ---- Mobile: Panel ---- */
+  --color-mobile-panel-bg: #29292F;
+  --color-mobile-panel-bar: #6B6B6D;
+  --color-mobile-panel-line: #3E3E4A;
+
+  /* ---- Mobile: Form ---- */
+  --color-mobile-form-input-bg: #101010;
+  --color-mobile-form-foam-line: #2A2A2A;
+
+  /* ---- Mobile: Tag ---- */
+  --color-mobile-tag-bg: #262626;
+  --color-mobile-tag-line: #A1A1A1;
+  --color-mobile-tag-bg2: #FCB300;
+
+  /* ---- Mobile: Common ---- */
+  --color-mobile-common-bg: #1D1D1D;
+  --color-mobile-common-bg2: #FCB300;
+
+  /* ---- Mobile: Tab ---- */
+  --color-mobile-tab-bg: #FFFFFF;
+  --color-mobile-tab-bg2: #1D1D1D;
+
+  /* ---- Mobile: Card ---- */
+  --color-mobile-card-stroke: #FCB300;
+  --color-mobile-card-bg-sp: #FCB3000D;
+  --color-mobile-card-stroke2: #404040;
+
+  /* ---- Web: Top-level ---- */
+  --color-web-bg: #1D1D1D;
+  --color-web-primary: #FCB300;
+  --color-web-bg-20: #26262633;
+  --color-web-error: #F87171;
+  --color-web-blank: #262626;
+
+  /* ---- Web: Font ---- */
+  --color-web-font-primary: #FFFFFF;
+  --color-web-font-neutral: #8C8C8C;
+  --color-web-font-body: #D4D4D4;
+  --color-web-font-tag: #FFFFFF;
+  --color-web-font-tag2: #262626;
+  --color-web-font-tag3: #A1A1A1;
+  --color-web-font-ab-white: #FFFFFF;
+  --color-web-font-btn2: #0A0A0A;
+  --color-web-font-secondary: #171717;
+  --color-web-font-point: #FCB300;
+  --color-web-font-btn3: #8C8C8C;
+  --color-web-font-ab-bk: #0A0A0A;
+  --color-web-font-header: #8C8C8C;
+  --color-web-font-ab-wh: #FFFFFF;
+  --color-web-font-disable: #404040;
+
+  /* ---- Web: Icon ---- */
+  --color-web-icon-primary: #FCB300;
+  --color-web-icon-neutral: #737373;
+  --color-web-icon-disable: #00000033;
+  --color-web-icon-bg: #737373;
+  --color-web-icon-disable2: #404040;
+  --color-web-icon-bg3: #262626;
+  --color-web-icon-primary2: #FCB300;
+  --color-web-icon-secondary: #FFFFFF;
+
+  /* ---- Web: Tag ---- */
+  --color-web-tag-bg: #262626;
+  --color-web-tag-bg2: #FCB300;
+  --color-web-tag-bg3: #262626;
+  --color-web-tag-stroke: #A1A1A1;
+
+  /* ---- Web: Button ---- */
+  --color-web-btn-bg2: #FCB300;
+  --color-web-btn-bg: #FFFFFF;
+  --color-web-btn-bg-disabled: #212121;
+  --color-web-btn-selected: #262626;
+  --color-web-btn-bg3: #000203;
+  --color-web-btn-bg4: #FFFFFF;
+  --color-web-btn-storke: #FFFFFF;
+  --color-web-btn-bg5: #191919;
+
+  /* ---- Web: Card ---- */
+  --color-web-card-bg: #1A1A1A;
+  --color-web-card-stroke: #404040;
+  --color-web-card-bg2: #262626;
+  --color-web-card-bg3: #1A1A1A;
+  --color-web-card-stroke3: #404040;
+  --color-web-card-divider: #262626;
+  --color-web-card-header-stroke: #262626;
+  --color-web-card-stroke2: #262626;
+  --color-web-card-bg4: #171717;
+  --color-web-card-active: #FCB300;
+  --color-web-card-active2: #FFFFFF;
+
+  /* ---- Web: Input ---- */
+  --color-web-input: #101010;
+  --color-web-input-bg2: #262626;
+  --color-web-input-placeholder: #A1A1A1;
+  --color-web-input-storke: #404040;
+  --color-web-input-stroke2: #FCB300;
+  --color-web-input-placeholder2: #525252;
+  --color-web-input-bg: #101010;
+  --color-web-input-bg1: #171717;
+
+  /* ---- Web: Tab ---- */
+  --color-web-tab-bg3: #262626;
+  --color-web-tab-bg: #FFFFFF;
+
+  /* ---- Web: Graph ---- */
+  --color-web-graph-bg: #262626;
+  --color-web-graph-bar: #FCB300;
+
+  /* ---- Web: Tooltip ---- */
+  --color-web-tooltip-bg: #464646;
+
+  /* ---- Web: Dropdown ---- */
+  --color-web-drop-storke: #404040;
+
+  /* ---- Web: Side Menu ---- */
+  --color-web-s-menu-bg: #404040;
+  --color-web-s-menu-hover-bg: #525252;
+
+  /* ---- Web: Pop ---- */
+  --color-web-pop-bg: #1A1A1A;
+}
+
+/* ----------------------------
+   LIGHT THEME OVERRIDES
+   ---------------------------- */
+[data-theme="light"] {
+  /* ---- Top-level ---- */
+  --color-line-default: #E5E5E5;
+  --color-font-default: #262626;
+  --color-wh: #262626;
+  --color-component-bg: #FAFAFA;
+
+  /* ---- Mobile: Icon ---- */
+  --color-mobile-icon-secondary: #2A2A2A;
+  --color-mobile-icon-primary: #979797;
+  --color-mobile-icon-point: #00000033;
+
+  /* ---- Mobile: Header ---- */
+  --color-mobile-header-stroke: #E5E5E5;
+  --color-mobile-header-bottom-line: #979797;
+
+  /* ---- Mobile: Font ---- */
+  --color-mobile-font-link: #FF7F0F;
+  --color-mobile-font-placeholder: #BABABA;
+  --color-mobile-font-secondary: #262626;
+  --color-mobile-font-third: #595959;
+  --color-mobile-font-disabled: #868686;
+  --color-mobile-font-primary: #FC9300;
+  --color-mobile-font-tag: #595959;
+  --color-mobile-font-tag2: #595959;
+  --color-mobile-font-secondary-op: #FFFFFF;
+
+  /* ---- Mobile: Button ---- */
+  --color-mobile-button-line-third: #FFFFFF;
+  --color-mobile-button-trans-bg: #FFFFFF33;
+  --color-mobile-button-disabled: #E0E0E0;
+  --color-mobile-button-line-secondary: #1D1D1D;
+  --color-mobile-button-pressed: #9E9E9E;
+  --color-mobile-button-bg: #404040;
+
+  /* ---- Mobile: Pop ---- */
+  --color-mobile-pop-bg: #FFFFFF;
+
+  /* ---- Mobile: Component ---- */
+  --color-mobile-component-bg: #E8E8E8;
+  --color-mobile-component-card-line: #D8D8D8;
+  --color-mobile-component-card-bg: #FFFFFF;
+
+  /* ---- Mobile: Panel ---- */
+  --color-mobile-panel-bg: #FFFFFF;
+  --color-mobile-panel-bar: #D2D1DE;
+  --color-mobile-panel-line: #EAEAEA;
+
+  /* ---- Mobile: Form ---- */
+  --color-mobile-form-input-bg: #FFFFFF;
+  --color-mobile-form-foam-line: #EAEAEA;
+
+  /* ---- Mobile: Tag ---- */
+  --color-mobile-tag-bg: #E5E6F3;
+  --color-mobile-tag-line: #616161;
+  --color-mobile-tag-bg2: #FCB30040;
+
+  /* ---- Mobile: Common ---- */
+  --color-mobile-common-bg: #F1F1F1;
+
+  /* ---- Mobile: Tab ---- */
+  --color-mobile-tab-bg: #1D1D1D;
+  --color-mobile-tab-bg2: #FFFFFF;
+
+  /* ---- Web: Top-level ---- */
+  --color-web-bg: #F1F1F1;
+
+  /* ---- Web: Font ---- */
+  --color-web-font-primary: #171717;
+  --color-web-font-body: #525252;
+  --color-web-font-tag: #525252;
+  --color-web-font-tag2: #525252;
+  --color-web-font-tag3: #A1A1A1;
+  --color-web-font-btn2: #FFFFFF;
+  --color-web-font-secondary: #FFFFFF;
+  --color-web-font-point: #F79800;
+  --color-web-font-btn3: #D4D4D4;
+  --color-web-font-header: #525252;
+  --color-web-font-disable: #404040;
+
+  /* ---- Web: Icon ---- */
+  --color-web-icon-disable2: #A3A3A3;
+  --color-web-icon-bg3: var(--color-web-icon-primary);
+  --color-web-icon-primary2: #262626;
+  --color-web-icon-secondary: #171717;
+
+  /* ---- Web: Tag ---- */
+  --color-web-tag-bg: #E5E6F3;
+  --color-web-tag-bg2: #FCB30040;
+  --color-web-tag-bg3: #E5E6F3;
+
+  /* ---- Web: Button ---- */
+  --color-web-btn-bg: #404040;
+  --color-web-btn-bg-disabled: #E5E5E5;
+  --color-web-btn-selected: #FAFAFA;
+  --color-web-btn-bg4: #FCB300;
+  --color-web-btn-storke: #A3A3A3;
+  --color-web-btn-bg5: #FFFFFF;
+
+  /* ---- Web: Card ---- */
+  --color-web-card-bg: #FFFFFF;
+  --color-web-card-stroke: #DDDDDD;
+  --color-web-card-bg2: #E5E6F3;
+  --color-web-card-bg3: #FFFFFF;
+  --color-web-card-stroke3: #E5E5E5;
+  --color-web-card-divider: #E5E5E5;
+  --color-web-card-header-stroke: #E5E5E5;
+  --color-web-card-stroke2: #E5E5E5;
+  --color-web-card-bg4: #FCB30040;
+  --color-web-card-active2: var(--color-web-card-active);
+
+  /* ---- Web: Input ---- */
+  --color-web-input: #171717;
+  --color-web-input-bg2: #EFEFEF;
+  --color-web-input-storke: #262626;
+  --color-web-input-stroke2: #D4D4D4;
+  --color-web-input-bg1: #E5E5E5;
+
+  /* ---- Web: Tab ---- */
+  --color-web-tab-bg3: #E5E5E5;
+
+  /* ---- Web: Graph ---- */
+  --color-web-graph-bg: #F5F5F5;
+  --color-web-graph-bar: #FCB300;
+
+  /* ---- Web: Tooltip ---- */
+  --color-web-tooltip-bg: #FFFFFF;
+
+  /* ---- Web: Pop ---- */
+  --color-web-pop-bg: #1A1A1A;
+}

--- a/app/common/tailwind.css
+++ b/app/common/tailwind.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "./assets/tailwind-colors.css";
 
 @import url("https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700;800&family=Inter:wght@400;500;700&display=swap");
 


### PR DESCRIPTION
- Introduced `tailwind-colors.css` containing design tokens for light and
  dark themes, auto-generated from Figma design files.
- Updated `tailwind.css` to import the new `tailwind-colors.css` file.