### PR TITLE
fix(i18n): improve language switching logic and SSR compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5688,6 +5688,7 @@ dependencies = [
  "dioxus-translate-types",
  "schemars 1.0.4",
  "serde",
+ "tokio",
  "web-sys",
 ]
 

--- a/app/shell/Makefile
+++ b/app/shell/Makefile
@@ -61,3 +61,6 @@ docker.push:
 	docker tag $(REPOSITORY):$(COMMIT) $(REPOSITORY):latest
 	docker push $(REPOSITORY):$(COMMIT)
 	docker push $(REPOSITORY):latest
+
+docker.login:
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com

--- a/app/shell/src/components/app_menu/mod.rs
+++ b/app/shell/src/components/app_menu/mod.rs
@@ -159,7 +159,7 @@ fn NavItem(href: &'static str, label: &'static str, icon: Element) -> Element {
 
 #[component]
 fn LanguageToggle() -> Element {
-    let mut lang = use_language();
+    let lang = use_language();
 
     let is_ko = lang().to_string() == "ko";
     let (flag, label) = if is_ko {
@@ -191,21 +191,7 @@ fn LanguageToggle() -> Element {
             class: "flex flex-col justify-center items-center p-2.5 font-bold cursor-pointer group text-menu-text text-[15px]",
             onclick: move |_| {
                 let next = lang().switch();
-                lang.set(next);
                 debug!("Language switched to: {}", next);
-
-                #[cfg(target_arch = "wasm32")]
-                {
-                    if let Some(window) = web_sys::window() {
-                        if let Ok(Some(storage)) = window.local_storage() {
-                            let _ = storage
-                                .set_item(
-                                    dioxus_translate::STORAGE_KEY,
-                                    next.to_string().as_str(),
-                                );
-                        }
-                    }
-                }
             },
             div { class: "flex flex-col justify-center items-center h-6 w-fit", {flag} }
             span { class: "font-medium whitespace-nowrap transition-all text-menu-text text-[15px] group-hover:text-menu-text/80",

--- a/packages/dioxus-translate/Cargo.toml
+++ b/packages/dioxus-translate/Cargo.toml
@@ -16,10 +16,11 @@ schemars.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dioxus =  { workspace = true, features = [ "server" ] }
+tokio.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus =  { workspace = true, features = [ "web" ] }
-web-sys = { version = "0.3", features = ["Window", "Storage", "Navigator"] }
+web-sys = { version = "0.3", features = ["Window", "Storage", "Navigator", "Document", "HtmlDocument"] }
 
 [features]
 ko = ["dioxus-translate-types/ko","dioxus-translate-macro/ko"]

--- a/packages/dioxus-translate/src/lib.rs
+++ b/packages/dioxus-translate/src/lib.rs
@@ -24,7 +24,6 @@ static LANGUAGE: GlobalSignal<Language> = Signal::global(|| {
     Language::default()
 });
 
-#[cfg(target_arch = "wasm32")]
 pub const STORAGE_KEY: &str = "language";
 
 pub fn use_translate<T: Translator>() -> T {
@@ -34,8 +33,43 @@ pub fn use_translate<T: Translator>() -> T {
     translate::<T>(&l)
 }
 
+#[cfg(target_arch = "wasm32")]
 pub fn use_language() -> Signal<Language> {
     LANGUAGE.signal()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn use_language() -> Signal<Language> {
+    use_signal(|| language_from_cookie())
+}
+
+/// Reads the language from the `language` cookie in the current HTTP request.
+/// Uses `FullstackContext::current()` to access request headers during SSR.
+/// Returns `Language::default()` if no context or cookie is found.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn language_from_cookie() -> Language {
+    use dioxus::fullstack::FullstackContext;
+
+    let Some(ctx) = FullstackContext::current() else {
+        return Language::default();
+    };
+    let parts = ctx.parts_mut();
+    parts
+        .headers
+        .get("cookie")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            cookies
+                .split(';')
+                .find_map(|c| c.trim().strip_prefix("language="))
+        })
+        .and_then(|v| v.parse::<Language>().ok())
+        .unwrap_or_default()
+}
+
+/// Sets the global language signal value.
+pub fn set_language(lang: Language) {
+    LANGUAGE.signal().set(lang);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -79,13 +113,33 @@ impl Default for Language {
 impl Language {
     pub fn switch(&self) -> Self {
         #[cfg(feature = "ko")]
-        match self {
-            Language::Ko => return Language::En,
-            Language::En => return Language::Ko,
+        let next = match self {
+            Language::Ko => Language::En,
+            Language::En => Language::Ko,
+        };
+
+        #[cfg(not(feature = "ko"))]
+        let next = Language::En;
+
+        LANGUAGE.signal().set(next);
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            use web_sys::wasm_bindgen::JsCast;
+
+            if let Some(window) = web_sys::window() {
+                if let Ok(Some(storage)) = window.local_storage() {
+                    let _ = storage.set_item(STORAGE_KEY, &next.to_string());
+                }
+
+                if let Some(doc) = window.document() {
+                    let html_document = doc.dyn_into::<web_sys::HtmlDocument>().unwrap();
+                    let _ = html_document.set_cookie(&format!("language={}; path=/;", next));
+                }
+            }
         }
 
-        #[allow(unreachable_code)]
-        Language::En
+        next
     }
 
     pub fn open_graph_locale(&self) -> String {


### PR DESCRIPTION
- Refactored `LanguageToggle` to remove redundant `lang.set` call.
- Enhanced `use_language` to support SSR by reading language from cookies.
- Updated `Language::switch` to persist changes in both local storage and cookies.
- Added `HtmlDocument` feature to `web-sys` dependency for cookie handling.
- Introduced `set_language` function for global language updates.
- Updated Makefile with `docker.login` target for ECR authentication.