### PR TITLE
fix(ecs-cluster-stack): assign PrivateDnsNamespace to class property

### DIFF
--- a/cdk/lib/ecs-cluster-stack.ts
+++ b/cdk/lib/ecs-cluster-stack.ts
@@ -23,7 +23,7 @@ export class EcsClusterStack extends Stack {
     this.vpc = ec2.Vpc.fromLookup(this, "Vpc", { isDefault: true });
     this.cluster = new ecs.Cluster(this, "Cluster", { vpc: this.vpc });
 
-    new sd.PrivateDnsNamespace(this, "Namespace", {
+    this.namespace = new sd.PrivateDnsNamespace(this, "Namespace", {
       name: "ratel-svc.local",
       vpc: this.vpc,
     });


### PR DESCRIPTION
- Updated `PrivateDnsNamespace` instantiation to assign it to `this.namespace`
- Ensures the namespace is accessible as a class property for further use