### PR TITLE
feat(spaces): add prerequisite actions layover for space participation

### DIFF
--- a/app/ratel/js/package-lock.json
+++ b/app/ratel/js/package-lock.json
@@ -2603,21 +2603,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -4644,21 +4629,6 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",

--- a/app/ratel/src/common/run.rs
+++ b/app/ratel/src/common/run.rs
@@ -127,6 +127,9 @@ async fn event_bridge_handler(
         ("ratel.dynamodb.stream", "PopularPostUpdate") => {
             handle_popular_post_update(envelope.detail).await?;
         }
+        ("ratel.dynamodb.stream", "PopularSpaceUpdate") => {
+            handle_popular_space_update(envelope.detail).await?;
+        }
         _ => {
             tracing::warn!(
                 "Unhandled EventBridge event: source={}, detail-type={}",
@@ -245,6 +248,72 @@ async fn handle_popular_post_update(
             tracing::error!("Popular post fan-out failed: {}", e);
             lambda_runtime::Error::from(format!("Popular post fan-out failed: {}", e))
         })?;
+
+    Ok(())
+}
+
+#[cfg(feature = "lambda")]
+async fn handle_popular_space_update(
+    detail: serde_json::Value,
+) -> Result<(), lambda_runtime::Error> {
+    use crate::common::types::Partition;
+
+    let space_pk_str = detail
+        .get("space_pk")
+        .and_then(|v| v.as_str())
+        .ok_or("missing space_pk in detail")?;
+    let post_pk_str = detail
+        .get("post_pk")
+        .and_then(|v| v.as_str())
+        .ok_or("missing post_pk in detail")?;
+    let author_pk_str = detail
+        .get("author_pk")
+        .and_then(|v| v.as_str())
+        .ok_or("missing author_pk in detail")?;
+    let created_at = detail
+        .get("created_at")
+        .and_then(|v| v.as_i64())
+        .ok_or("missing created_at in detail")?;
+    let participants = detail
+        .get("participants")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    if !crate::features::timeline::services::is_popular_space(participants) {
+        return Ok(());
+    }
+
+    let space_pk: Partition = space_pk_str
+        .parse()
+        .map_err(|e| format!("invalid space_pk: {}", e))?;
+    let post_pk: Partition = post_pk_str
+        .parse()
+        .map_err(|e| format!("invalid post_pk: {}", e))?;
+    let author_pk: Partition = author_pk_str
+        .parse()
+        .map_err(|e| format!("invalid author_pk: {}", e))?;
+
+    tracing::info!(
+        "Popular space fan-out: space_pk={}, participants={}",
+        space_pk,
+        participants
+    );
+
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    crate::features::timeline::services::fan_out_popular_space(
+        cli,
+        &space_pk,
+        &post_pk,
+        &author_pk,
+        created_at,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("Popular space fan-out failed: {}", e);
+        lambda_runtime::Error::from(format!("Popular space fan-out failed: {}", e))
+    })?;
 
     Ok(())
 }

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/models/space_post.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/models/space_post.rs
@@ -207,6 +207,7 @@ impl From<(SpacePost, SpaceUserRole)>
             started_at: Some(post.started_at),
             ended_at: Some(post.ended_at),
             credits: 0,
+            prerequisite: false,
         }
     }
 }

--- a/app/ratel/src/features/spaces/pages/actions/actions/follow/models/space_follow.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/follow/models/space_follow.rs
@@ -47,6 +47,7 @@ impl From<SpaceFollowAction>
             ended_at: None,
             user_participated: false,
             credits: 0,
+            prerequisite: false,
         }
     }
 }

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/models/space_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/models/space_poll.rs
@@ -135,6 +135,7 @@ impl From<(SpacePoll, bool)>
             ended_at: Some(poll.ended_at),
             user_participated,
             credits: 0,
+            prerequisite: false,
         }
     }
 }

--- a/app/ratel/src/features/spaces/pages/actions/mod.rs
+++ b/app/ratel/src/features/spaces/pages/actions/mod.rs
@@ -1,5 +1,5 @@
 pub mod actions;
-mod components;
+pub mod components;
 pub mod controllers;
 mod menu;
 pub mod models;

--- a/app/ratel/src/features/spaces/pages/actions/types/space_action.rs
+++ b/app/ratel/src/features/spaces/pages/actions/types/space_action.rs
@@ -23,6 +23,7 @@ pub struct SpaceActionSummary {
 
     pub user_participated: bool,
     pub credits: u64,
+    pub prerequisite: bool,
 }
 
 impl From<crate::features::spaces::pages::actions::models::SpaceAction> for SpaceActionSummary {
@@ -44,6 +45,7 @@ impl From<crate::features::spaces::pages::actions::models::SpaceAction> for Spac
             ended_at: Some(action.ended_at),
             user_participated: false,
             credits: action.credits,
+            prerequisite: action.prerequisite,
         }
     }
 }

--- a/app/ratel/src/features/spaces/space_common/components/space_nav/mod.rs
+++ b/app/ratel/src/features/spaces/space_common/components/space_nav/mod.rs
@@ -6,6 +6,7 @@ mod participation_layover_header;
 mod participation_requirements_layover;
 mod participation_step_bar;
 mod participation_verification_section;
+mod prerequisite_actions_layover;
 mod space_user_login;
 mod space_user_profile;
 
@@ -17,6 +18,7 @@ pub use participation_layover_header::*;
 pub use participation_requirements_layover::*;
 pub use participation_step_bar::*;
 pub use participation_verification_section::*;
+pub use prerequisite_actions_layover::*;
 pub use space_user_login::*;
 pub use space_user_profile::*;
 

--- a/app/ratel/src/features/spaces/space_common/components/space_nav/participation_card.rs
+++ b/app/ratel/src/features/spaces/space_common/components/space_nav/participation_card.rs
@@ -76,15 +76,46 @@ pub fn ParticipationCard(
                 space_id.to_string(),
                 "PanelRequirements".to_string(),
             ];
-            if crate::features::spaces::controllers::participate_space::participate_space(space_id)
-                .await
-                .is_ok()
+            if crate::features::spaces::controllers::participate_space::participate_space(
+                space_id.clone(),
+            )
+            .await
+            .is_ok()
             {
                 current_role.set(SpaceUserRole::Participant);
                 query.invalidate(&space_detail);
                 query.invalidate(&panel_requirements_key);
                 space.restart();
                 role.restart();
+
+                // Show prerequisite actions layover if any exist
+                if let Ok(actions) =
+                    crate::features::spaces::pages::actions::controllers::list_actions(
+                        space_id.clone(),
+                    )
+                    .await
+                {
+                    let prerequisite_actions: Vec<
+                        crate::features::spaces::pages::actions::types::SpaceActionSummary,
+                    > = actions
+                        .into_iter()
+                        .filter(|a| a.prerequisite)
+                        .collect();
+                    if !prerequisite_actions.is_empty() {
+                        layover
+                            .open(
+                                "space-prerequisite-actions".to_string(),
+                                String::new(),
+                                rsx! {
+                                    PrerequisiteActionsLayover {
+                                        space_id,
+                                        actions: prerequisite_actions,
+                                    }
+                                },
+                            )
+                            .set_size(LayoverSize::Medium);
+                    }
+                }
             }
         });
     };

--- a/app/ratel/src/features/spaces/space_common/components/space_nav/prerequisite_actions_layover.rs
+++ b/app/ratel/src/features/spaces/space_common/components/space_nav/prerequisite_actions_layover.rs
@@ -1,0 +1,68 @@
+use super::*;
+use crate::features::spaces::pages::actions::components::ActionCard;
+use crate::features::spaces::pages::actions::types::SpaceActionSummary;
+
+#[component]
+pub fn PrerequisiteActionsLayover(
+    space_id: SpacePartition,
+    actions: Vec<SpaceActionSummary>,
+) -> Element {
+    let tr: PrerequisiteActionsLayoverTranslate = use_translate();
+    let mut layover = use_layover();
+
+    rsx! {
+        div { class: "flex flex-col h-full w-full bg-neutral-900 light:bg-neutral-200 text-web-font-primary",
+            // Header
+            div { class: "flex items-center gap-3 px-5 py-4 border-b border-neutral-800 light:border-neutral-300",
+                div { class: "flex flex-col gap-1",
+                    h4 { class: "font-bold text-[18px]/[22px] text-white light:text-neutral-900",
+                        {tr.title}
+                    }
+                    p { class: "text-[13px]/[18px] text-neutral-400 light:text-neutral-600",
+                        {tr.description}
+                    }
+                }
+            }
+
+            // Action list
+            div { class: "flex flex-col gap-2.5 p-5 overflow-y-auto flex-1",
+                for action in actions.iter() {
+                    ActionCard {
+                        key: "{action.action_id}",
+                        action: action.clone(),
+                        space_id: space_id.clone(),
+                    }
+                }
+            }
+
+            // Footer button
+            div { class: "flex items-center justify-end px-5 py-4 border-t border-neutral-800 light:border-neutral-300",
+                Button {
+                    style: ButtonStyle::Primary,
+                    size: ButtonSize::Small,
+                    onclick: move |_| {
+                        layover.close();
+                    },
+                    {tr.close}
+                }
+            }
+        }
+    }
+}
+
+translate! {
+    PrerequisiteActionsLayoverTranslate;
+
+    title: {
+        en: "Required Actions",
+        ko: "필수 액션",
+    },
+    description: {
+        en: "Please complete the following actions to fully participate in this space.",
+        ko: "이 스페이스에 완전히 참여하려면 다음 액션을 완료해주세요.",
+    },
+    close: {
+        en: "Close",
+        ko: "닫기",
+    },
+}

--- a/app/ratel/src/features/timeline/models/timeline_entry.rs
+++ b/app/ratel/src/features/timeline/models/timeline_entry.rs
@@ -11,6 +11,8 @@ pub enum TimelineReason {
     TeamMember,
     /// Post is trending (met popularity criteria)
     Popular,
+    /// Space associated with the post is popular (>5 participants)
+    PopularSpace,
 }
 
 impl std::fmt::Display for TimelineReason {
@@ -19,6 +21,7 @@ impl std::fmt::Display for TimelineReason {
             TimelineReason::Following => write!(f, "following"),
             TimelineReason::TeamMember => write!(f, "team_member"),
             TimelineReason::Popular => write!(f, "popular"),
+            TimelineReason::PopularSpace => write!(f, "popular_space"),
         }
     }
 }
@@ -31,6 +34,7 @@ impl std::str::FromStr for TimelineReason {
             "following" => Ok(TimelineReason::Following),
             "team_member" => Ok(TimelineReason::TeamMember),
             "popular" => Ok(TimelineReason::Popular),
+            "popular_space" => Ok(TimelineReason::PopularSpace),
             _ => Err(format!("unknown timeline reason: {}", s)),
         }
     }
@@ -41,6 +45,7 @@ pub const TIMELINE_CATEGORIES: &[TimelineReason] = &[
     TimelineReason::Following,
     TimelineReason::TeamMember,
     TimelineReason::Popular,
+    TimelineReason::PopularSpace,
 ];
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, DynamoEntity, PartialEq)]

--- a/app/ratel/src/features/timeline/services/fan_out.rs
+++ b/app/ratel/src/features/timeline/services/fan_out.rs
@@ -90,6 +90,64 @@ pub async fn fan_out_popular_post(
     write_timeline_entries(cli, post_pk, author_pk, created_at, &entries).await
 }
 
+/// Fan out a popular space to a broader audience.
+///
+/// Called asynchronously when a space crosses the popularity threshold (>5 participants).
+/// Delivers the space's associated post to followers of the space author and their
+/// 2nd-degree network who don't already have the entry.
+pub async fn fan_out_popular_space(
+    cli: &aws_sdk_dynamodb::Client,
+    space_pk: &Partition,
+    post_pk: &Partition,
+    author_pk: &Partition,
+    created_at: i64,
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    let mut entries: Vec<(Partition, TimelineReason)> = Vec::new();
+
+    // Collect direct followers first (to mark as seen — they already have it)
+    seen.insert(author_pk.to_string());
+    collect_follower_pks(cli, author_pk, &mut seen).await?;
+
+    // For each direct follower, collect their followers (2nd-degree)
+    let direct_followers = seen.clone();
+    for follower_pk_str in &direct_followers {
+        if follower_pk_str == &author_pk.to_string() {
+            continue;
+        }
+        let follower_pk: Partition = match follower_pk_str.parse() {
+            Ok(pk) => pk,
+            Err(_) => continue,
+        };
+        collect_followers_with_reason(
+            cli,
+            &follower_pk,
+            &mut seen,
+            &mut entries,
+            TimelineReason::PopularSpace,
+        )
+        .await?;
+    }
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!(
+        "fan_out_popular_space: writing {} timeline entries for popular space {} (post {})",
+        entries.len(),
+        space_pk,
+        post_pk
+    );
+
+    write_timeline_entries(cli, post_pk, author_pk, created_at, &entries).await
+}
+
+/// Returns true if a space meets the popularity threshold for broader distribution.
+pub fn is_popular_space(participants: i64) -> bool {
+    participants > 5
+}
+
 /// Returns true if a post meets the popularity threshold for broader distribution.
 pub fn is_popular(likes: i64, comments: i64, shares: i64) -> bool {
     // A post is considered popular if it meets any of these criteria:

--- a/cdk/lib/dynamo-stream-event.ts
+++ b/cdk/lib/dynamo-stream-event.ts
@@ -144,6 +144,49 @@ export class DynamoStreamEventStack extends Stack {
       },
     });
 
+    // ── Pipe 3: Participant Change → PopularSpaceUpdate ──────────────
+    // Triggers when participants field changes on a SpaceCommon entity
+    new pipes.CfnPipe(this, "PopularSpacePipe", {
+      name: `ratel-${stage}-popular-space-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["MODIFY"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: ["SPACE_COMMON"] },
+                    participants: { N: [{ exists: true }] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "PopularSpaceUpdate",
+        },
+        inputTemplate: JSON.stringify({
+          space_pk: "<$.dynamodb.NewImage.pk.S>",
+          post_pk: "<$.dynamodb.NewImage.post_pk.S>",
+          author_pk: "<$.dynamodb.NewImage.user_pk.S>",
+          created_at: "<$.dynamodb.NewImage.updated_at.N>",
+          participants: "<$.dynamodb.NewImage.participants.N>",
+        }),
+      },
+    });
+
     // ── Rule: Route TimelineUpdate events to app-shell Lambda ────────
     new events.Rule(this, "TimelineUpdateRule", {
       eventBus,
@@ -163,6 +206,18 @@ export class DynamoStreamEventStack extends Stack {
       eventPattern: {
         source: ["ratel.dynamodb.stream"],
         detailType: ["PopularPostUpdate"],
+      },
+      targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+    });
+
+    // ── Rule: Route PopularSpaceUpdate events to app-shell Lambda ────
+    new events.Rule(this, "PopularSpaceUpdateRule", {
+      eventBus,
+      description:
+        "Route popular space events to app-shell for broader fan-out",
+      eventPattern: {
+        source: ["ratel.dynamodb.stream"],
+        detailType: ["PopularSpaceUpdate"],
       },
       targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
     });


### PR DESCRIPTION
- Introduced `PrerequisiteActionsLayover` component to display required actions for space participation.
- Updated `ParticipationCard` to check and display prerequisite actions upon successful participation.
- Added `prerequisite` field to `SpaceActionSummary` and related models.
- Implemented `PopularSpaceUpdate` event handling and fan-out logic for popular spaces.
- Updated DynamoDB stream event processing to trigger `PopularSpaceUpdate` for spaces with >5 participants.
- Enhanced timeline models and services to support `PopularSpace` reason.