### PR TITLE
fix(spaces): hide actions menu for viewers in not-started spaces

### DIFF
--- a/app/ratel/src/features/spaces/layout.rs
+++ b/app/ratel/src/features/spaces/layout.rs
@@ -63,12 +63,12 @@ pub fn SpaceLayout(space_id: ReadSignal<SpacePartition>) -> Element {
         && space.can_participate;
 
     let mut menus = vec![
-        crate::features::spaces::pages::dashboard::get_nav_item(space_id(), role.clone()),
-        crate::features::spaces::pages::overview::get_nav_item(space_id(), role.clone()),
-        crate::features::spaces::pages::actions::get_nav_item(space_id(), role.clone()),
-        crate::features::spaces::pages::apps::get_nav_item(space_id(), role.clone()),
-        // crate::features::spaces::pages::rewards::get_nav_item(space_id(), role.clone()),
-        // crate::features::spaces::pages::report::get_nav_item(space_id.clone(), role.clone()),
+        crate::features::spaces::pages::dashboard::get_nav_item(&space, role.clone()),
+        crate::features::spaces::pages::overview::get_nav_item(&space, role.clone()),
+        crate::features::spaces::pages::actions::get_nav_item(&space, role.clone()),
+        crate::features::spaces::pages::apps::get_nav_item(&space, role.clone()),
+        // crate::features::spaces::pages::rewards::get_nav_item(&space, role.clone()),
+        // crate::features::spaces::pages::report::get_nav_item(&space, role.clone()),
     ]
     .into_iter()
     .flatten()

--- a/app/ratel/src/features/spaces/pages/actions/menu.rs
+++ b/app/ratel/src/features/spaces/pages/actions/menu.rs
@@ -2,13 +2,25 @@ use super::*;
 use icons::game::Thunder;
 
 pub fn get_nav_item(
-    space_id: SpacePartition,
-    _role: SpaceUserRole,
+    space: &SpaceResponse,
+    role: SpaceUserRole,
 ) -> Option<(Element, SpacePage, NavigationTarget)> {
+    if role == SpaceUserRole::Viewer
+        && !matches!(
+            space.status,
+            Some(SpaceStatus::Started) | Some(SpaceStatus::Finished)
+        )
+    {
+        return None;
+    }
+
     Some((
         icon(),
         SpacePage::Actions,
-        Route::SpaceActionsPage { space_id }.into(),
+        Route::SpaceActionsPage {
+            space_id: space.id.clone(),
+        }
+        .into(),
     ))
 }
 

--- a/app/ratel/src/features/spaces/pages/apps/menu.rs
+++ b/app/ratel/src/features/spaces/pages/apps/menu.rs
@@ -2,7 +2,7 @@ use super::*;
 
 // Space Layout Menu
 pub fn get_nav_item(
-    space_id: SpacePartition,
+    space: &SpaceResponse,
     role: SpaceUserRole,
 ) -> Option<(Element, SpacePage, NavigationTarget)> {
     if role != SpaceUserRole::Creator {
@@ -17,6 +17,9 @@ pub fn get_nav_item(
             }
         },
         SpacePage::Apps,
-        Route::SpaceAppsPage { space_id }.into(),
+        Route::SpaceAppsPage {
+            space_id: space.id.clone(),
+        }
+        .into(),
     ))
 }

--- a/app/ratel/src/features/spaces/pages/dashboard/menu.rs
+++ b/app/ratel/src/features/spaces/pages/dashboard/menu.rs
@@ -1,13 +1,17 @@
 use super::*;
+use crate::features::spaces::space_common::controllers::SpaceResponse;
 
 pub fn get_nav_item(
-    space_id: SpacePartition,
+    space: &SpaceResponse,
     _role: SpaceUserRole,
 ) -> Option<(Element, SpacePage, NavigationTarget)> {
     Some((
         icon(),
         SpacePage::Dashboard,
-        Route::SpaceDashboardPage { space_id }.into(),
+        Route::SpaceDashboardPage {
+            space_id: space.id.clone(),
+        }
+        .into(),
     ))
 }
 

--- a/app/ratel/src/features/spaces/pages/overview/menu.rs
+++ b/app/ratel/src/features/spaces/pages/overview/menu.rs
@@ -1,13 +1,17 @@
 use crate::features::spaces::pages::overview::*;
+use crate::features::spaces::space_common::controllers::SpaceResponse;
 
 pub fn get_nav_item(
-    space_id: SpacePartition,
+    space: &SpaceResponse,
     _role: SpaceUserRole,
 ) -> Option<(Element, SpacePage, NavigationTarget)> {
     Some((
         icon(),
         SpacePage::Overview,
-        Route::SpaceOverviewPage { space_id }.into(),
+        Route::SpaceOverviewPage {
+            space_id: space.id.clone(),
+        }
+        .into(),
     ))
 }
 

--- a/app/ratel/src/features/spaces/pages/report/menu.rs
+++ b/app/ratel/src/features/spaces/pages/report/menu.rs
@@ -1,14 +1,17 @@
 use super::*;
+use crate::features::spaces::space_common::controllers::SpaceResponse;
 
 pub fn get_nav_item(
-    space_id: SpacePartition,
+    space: &SpaceResponse,
     _role: SpaceUserRole,
 ) -> Option<(Element, SpacePage, NavigationTarget)> {
-    // TODO: implement space status
     Some((
         icon(),
         SpacePage::Report,
-        Route::SpaceReportPage { space_id }.into(),
+        Route::SpaceReportPage {
+            space_id: space.id.clone(),
+        }
+        .into(),
     ))
 }
 

--- a/app/ratel/src/features/spaces/pages/rewards/menu.rs
+++ b/app/ratel/src/features/spaces/pages/rewards/menu.rs
@@ -1,8 +1,9 @@
 use crate::features::spaces::pages::apps::apps::rewards::controllers::list_space_rewards;
+use crate::features::spaces::space_common::controllers::SpaceResponse;
 use crate::*;
 
 pub fn get_nav_item(
-    space_id: SpacePartition,
+    space: &SpaceResponse,
     role: SpaceUserRole,
 ) -> Option<(Element, SpacePage, NavigationTarget)> {
     if role != SpaceUserRole::Participant {
@@ -18,6 +19,9 @@ pub fn get_nav_item(
             }
         },
         SpacePage::Rewards,
-        Route::SpaceRewardsPage { space_id }.into(),
+        Route::SpaceRewardsPage {
+            space_id: space.id.clone(),
+        }
+        .into(),
     ))
 }


### PR DESCRIPTION
## Summary
- Refactor `get_nav_item` across all space page menus to accept `&SpaceResponse` instead of `SpacePartition`, enabling access to space status
- Hide the Actions menu for viewers when the space has not yet started (status is not `Started` or `Finished`)
- Viewers in not-started spaces now only see Overview and Dashboard menus

Closes #1171

## Test plan
- [ ] As a space creator, verify all menus (Dashboard, Overview, Actions, Apps) are visible regardless of space status
- [ ] As a viewer, access a space in `InProgress` (published but not started) status — Actions menu should be hidden
- [ ] As a viewer, access a space in `Started` status — Actions menu should be visible
- [ ] As a participant, verify Actions menu is always visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)