### PR TITLE
fix: display dashboard actions grouped by type (#1130)

### DIFF
--- a/app/ratel/src/features/spaces/pages/dashboard/components/dashboard_card.rs
+++ b/app/ratel/src/features/spaces/pages/dashboard/components/dashboard_card.rs
@@ -114,13 +114,14 @@ pub fn DashboardCard(
             }
         }
         DashboardComponentData::ProgressList(data) => {
+            let total = data.poll_count + data.post_count + data.quiz_count + data.follow_count;
             rsx! {
                 SpaceCard {
                     fill_height: true,
                     class: "flex flex-col gap-5".to_string(),
                     CardHeader {
                         icon: data.icon.clone(),
-                        main_value: format!("{}", data.poll_count + data.post_count),
+                        main_value: format!("{total}"),
                         main_label: tr.participation_action.to_string(),
                     }
                     ProgressListContent { data, tr }
@@ -367,58 +368,72 @@ fn StatCardContent(
 
 #[component]
 fn ProgressListContent(data: ProgressListData, tr: DashboardTranslate) -> Element {
-    let total = (data.poll_count + data.post_count).max(1) as f64;
+    let total = (data.poll_count + data.post_count + data.quiz_count + data.follow_count).max(1);
+
+    let action_types: Vec<(&str, i64)> = vec![
+        (&tr.poll_completion, data.poll_count),
+        (&tr.discussion_completion, data.post_count),
+        (&tr.quiz_completion, data.quiz_count),
+        (&tr.follow_completion, data.follow_count),
+    ];
+
+    let visible_types: Vec<(&str, i64)> = action_types
+        .into_iter()
+        .filter(|(_, count)| *count > 0)
+        .collect();
 
     rsx! {
         div {
             class: "flex-1 min-h-0 pr-1 space-y-5 max-mobile:space-y-3 overflow-y-auto",
-            // Poll progress
-            div { class: "space-y-2 max-mobile:space-y-1.5",
-                div { class: "flex items-center justify-between gap-2",
-                    span { class: "min-w-0 truncate text-text-primary text-xs leading-4 font-medium font-raleway",
-                        "{tr.poll_completion}"
+            if visible_types.is_empty() {
+                div { class: "space-y-2 max-mobile:space-y-1.5",
+                    div { class: "flex items-center justify-between gap-2",
+                        span { class: "min-w-0 truncate text-text-primary text-xs leading-4 font-medium font-raleway",
+                            "{tr.poll_completion}"
+                        }
+                        span { class: "shrink-0 text-text-primary text-xs leading-4 font-semibold font-inter",
+                            "0"
+                        }
                     }
-                    span { class: "shrink-0 text-text-primary text-xs leading-4 font-semibold font-inter",
-                        "{data.poll_count}"
+                    div { class: "h-2 w-full overflow-hidden rounded-full bg-popover",
+                        div {
+                            class: "h-full rounded-full transition-all duration-300 bg-primary",
+                            style: "width: 0%;",
+                        }
+                    }
+                    div { class: "flex items-center gap-1 text-xs text-web-font-neutral",
+                        span { class: "text-xs leading-4 font-medium font-inter",
+                            "0 / 0"
+                        }
+                        span { class: "text-xs leading-4 font-medium font-raleway", "{tr.completed}" }
                     }
                 }
-                div { class: "h-2 w-full overflow-hidden rounded-full bg-popover",
-                    div {
-                        class: "h-full rounded-full transition-all duration-300 bg-primary",
-                        style: "width: {(data.poll_count as f64 / total * 100.0).min(100.0):.1}%;",
+            } else {
+                for (label , count) in visible_types.iter() {
+                    div { class: "space-y-2 max-mobile:space-y-1.5",
+                        div { class: "flex items-center justify-between gap-2",
+                            span { class: "min-w-0 truncate text-text-primary text-xs leading-4 font-medium font-raleway",
+                                "{label}"
+                            }
+                            span { class: "shrink-0 text-text-primary text-xs leading-4 font-semibold font-inter",
+                                "{count}"
+                            }
+                        }
+                        div { class: "h-2 w-full overflow-hidden rounded-full bg-popover",
+                            div {
+                                class: "h-full rounded-full transition-all duration-300 bg-primary",
+                                style: "width: {(*count as f64 / total as f64 * 100.0).min(100.0):.1}%;",
+                            }
+                        }
+                        div { class: "flex items-center gap-1 text-xs text-web-font-neutral",
+                            span { class: "text-xs leading-4 font-medium font-inter",
+                                "{count} / {total}"
+                            }
+                            span { class: "text-xs leading-4 font-medium font-raleway", "{tr.completed}" }
+                        }
                     }
-                }
-                div { class: "flex items-center gap-1 text-xs text-web-font-neutral",
-                    span { class: "text-xs leading-4 font-medium font-inter",
-                        "{data.poll_count} / {data.poll_count + data.post_count}"
-                    }
-                    span { class: "text-xs leading-4 font-medium font-raleway", "{tr.completed}" }
                 }
             }
-        
-        // Discussion progress
-        // div { class: "space-y-2 max-mobile:space-y-1.5",
-        //     div { class: "flex items-center justify-between gap-2",
-        //         span { class: "min-w-0 truncate text-text-primary text-xs leading-4 font-medium font-raleway",
-        //             "{tr.discussion_completion}"
-        //         }
-        //         span { class: "shrink-0 text-text-primary text-xs leading-4 font-semibold font-inter",
-        //             "{data.post_count}"
-        //         }
-        //     }
-        //     div { class: "h-2 w-full overflow-hidden rounded-full bg-popover",
-        //         div {
-        //             class: "h-full rounded-full transition-all duration-300 bg-primary",
-        //             style: "width: {(data.post_count as f64 / total * 100.0).min(100.0):.1}%;",
-        //         }
-        //     }
-        //     div { class: "flex items-center gap-1 text-xs text-web-font-neutral",
-        //         span { class: "text-xs leading-4 font-medium font-inter",
-        //             "{data.post_count} / {data.poll_count + data.post_count}"
-        //         }
-        //         span { class: "text-xs leading-4 font-medium font-raleway", "{tr.completed}" }
-        //     }
-        // }
         }
     }
 }

--- a/app/ratel/src/features/spaces/pages/dashboard/controllers/list_dashboard_data.rs
+++ b/app/ratel/src/features/spaces/pages/dashboard/controllers/list_dashboard_data.rs
@@ -6,7 +6,9 @@ pub async fn list_dashboard_data_handler(
     space_id: SpacePartition,
 ) -> Result<Vec<crate::features::spaces::space_common::types::dashboard::DashboardComponentData>> {
     use crate::features::spaces::space_common::models::dashboard::aggregate::DashboardAggregate;
-    use crate::features::spaces::space_common::models::dashboard::recalculate::build_dashboard_components;
+    use crate::features::spaces::space_common::models::dashboard::recalculate::{
+        build_dashboard_components, ActionTypeCounts,
+    };
     use crate::features::spaces::space_common::models::space_reward::SpaceReward;
     use crate::features::spaces::space_common::types::dashboard::*;
 
@@ -16,7 +18,28 @@ pub async fn list_dashboard_data_handler(
 
     let agg = DashboardAggregate::get_or_default(cli, &space_pk).await?;
 
-    let mut components = build_dashboard_components(&agg, space.participants);
+    // Query SpaceActions to get per-type counts
+    let action_counts = {
+        use crate::features::spaces::pages::actions::models::SpaceAction;
+        use crate::features::spaces::pages::actions::types::SpaceActionType;
+
+        let (actions, _) = SpaceAction::find_by_space(cli, &space_pk, SpaceAction::opt())
+            .await
+            .unwrap_or_default();
+
+        let mut counts = ActionTypeCounts::default();
+        for action in &actions {
+            match action.space_action_type {
+                SpaceActionType::Poll => counts.poll_count += 1,
+                SpaceActionType::TopicDiscussion => counts.discussion_count += 1,
+                SpaceActionType::Quiz => counts.quiz_count += 1,
+                SpaceActionType::Follow => counts.follow_count += 1,
+            }
+        }
+        counts
+    };
+
+    let mut components = build_dashboard_components(&agg, space.participants, action_counts);
 
     // InfoCard: populate with SpaceReward data
     let rewards = SpaceReward::list_by_action(cli, space_id.clone(), None)

--- a/app/ratel/src/features/spaces/pages/dashboard/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/dashboard/i18n.rs
@@ -107,4 +107,14 @@ translate! {
         en: "Discussion Completion",
         ko: "토론 완료",
     },
+
+    quiz_completion: {
+        en: "Quiz Completion",
+        ko: "퀴즈 완료",
+    },
+
+    follow_completion: {
+        en: "Follow Completion",
+        ko: "팔로우 완료",
+    },
 }

--- a/app/ratel/src/features/spaces/space_common/models/dashboard/recalculate.rs
+++ b/app/ratel/src/features/spaces/space_common/models/dashboard/recalculate.rs
@@ -1,24 +1,39 @@
 use super::aggregate::DashboardAggregate;
 use crate::features::spaces::space_common::types::dashboard::*;
 
+/// Counts of actions per type, used to build per-type progress bars on the dashboard.
+#[derive(Debug, Clone, Default)]
+pub struct ActionTypeCounts {
+    pub poll_count: i64,
+    pub discussion_count: i64,
+    pub quiz_count: i64,
+    pub follow_count: i64,
+}
+
 /// Pure function: aggregate → base dashboard components.
 /// InfoCard (with reward items), StatCard, and RankingTable are added by the caller.
 pub fn build_dashboard_components(
     agg: &DashboardAggregate,
     participants: i64,
+    action_counts: ActionTypeCounts,
 ) -> Vec<DashboardComponentData> {
+    let total_actions =
+        action_counts.poll_count + action_counts.discussion_count + action_counts.quiz_count + action_counts.follow_count;
+
     vec![
         DashboardComponentData::StatSummary(StatSummaryData {
             icon: DashboardIcon::BarChart,
             participants,
             likes: agg.like_count,
             comments: agg.comment_count,
-            total_actions: agg.poll_count + agg.post_count,
+            total_actions,
         }),
         DashboardComponentData::ProgressList(ProgressListData {
             icon: DashboardIcon::Action,
-            poll_count: agg.poll_count,
-            post_count: agg.post_count,
+            poll_count: action_counts.poll_count,
+            post_count: action_counts.discussion_count,
+            quiz_count: action_counts.quiz_count,
+            follow_count: action_counts.follow_count,
         }),
         DashboardComponentData::TabChart(TabChartData {
             icon: DashboardIcon::Participants,

--- a/app/ratel/src/features/spaces/space_common/types/dashboard.rs
+++ b/app/ratel/src/features/spaces/space_common/types/dashboard.rs
@@ -73,6 +73,10 @@ pub struct ProgressListData {
     pub icon: DashboardIcon,
     pub poll_count: i64,
     pub post_count: i64,
+    #[serde(default)]
+    pub quiz_count: i64,
+    #[serde(default)]
+    pub follow_count: i64,
 }
 
 fn default_color() -> String {


### PR DESCRIPTION
## Summary

- Fixes the dashboard "Participation's Action" card to display actions grouped by type (Poll, Discussion, Quiz, Follow) with individual progress bars, matching the Figma design
- Queries `SpaceAction` records at dashboard load time and counts them by `SpaceActionType` instead of relying solely on the aggregate's combined `poll_count`/`post_count`
- Only action types with count > 0 are shown; when no actions exist, a zero-state is displayed

Fixes #1130

## Changes

| File | Change |
|------|--------|
| `space_common/types/dashboard.rs` | Added `quiz_count` and `follow_count` fields to `ProgressListData` |
| `space_common/models/dashboard/recalculate.rs` | Added `ActionTypeCounts` struct; updated `build_dashboard_components` to accept per-type counts |
| `pages/dashboard/controllers/list_dashboard_data.rs` | Query `SpaceAction` records and count by `SpaceActionType` |
| `pages/dashboard/components/dashboard_card.rs` | Updated `ProgressListContent` to render per-type progress bars |
| `pages/dashboard/i18n.rs` | Added `quiz_completion` and `follow_completion` translation keys |

## Test plan

- [ ] Navigate to a space dashboard page
- [ ] Verify the "Participation's Action" card shows separate progress bars for each action type that has at least one action
- [ ] Create a Poll action, verify "Poll Completion" appears with correct count
- [ ] Create a Quiz action, verify "Quiz Completion" appears with correct count
- [ ] Create a Discussion action, verify "Discussion Completion" appears
- [ ] Create a Follow action, verify "Follow Completion" appears
- [ ] Verify the header total count sums all action types
- [ ] Verify empty state shows "0 / 0 Completed" for Poll Completion when no actions exist
- [ ] Verify both `cargo check -p app-shell --features web` and `--features server` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)