### PR TITLE
fix(container): fix scroll-to-top blocked when content overflows

### DIFF
--- a/app/ratel/src/common/components/container/mod.rs
+++ b/app/ratel/src/common/components/container/mod.rs
@@ -18,7 +18,7 @@ pub fn Container(props: ContainerProps) -> Element {
 
     rsx! {
         div {..merged,
-            div { class: "flex overflow-y-auto flex-1 justify-center items-center w-full scrollbar-none",
+            div { class: "flex overflow-y-auto flex-1 justify-center items-start w-full scrollbar-none",
                 {props.children}
             }
             if let Some(bottom_sheet) = props.bottom_sheet {


### PR DESCRIPTION
Change `items-center` to `items-start` in Container's scrollable wrapper. `align-items: center` on a flex container with `overflow-y: auto` causes the top of tall content to be clipped and unreachable via scroll.

#1176