### PR TITLE
fix: resolve space card height inconsistency and icon color in light mode (#1232)

### DIFF
--- a/app/ratel/src/features/timeline/components/space_timeline.rs
+++ b/app/ratel/src/features/timeline/components/space_timeline.rs
@@ -90,16 +90,18 @@ pub fn SpaceTimeline() -> Element {
                                     class: "flex flex-col gap-2.5 pt-5 pb-2.5 border cursor-pointer snap-start shrink-0 w-[340px] max-mobile:w-[280px] rounded-[10px] bg-card-bg-secondary border-card-enable-border hover:bg-card-bg transition-colors no-underline",
                                     to: "{href}",
                                     Col { class: "gap-1 px-5 w-full",
-                                        if let Some(ref st) = status {
-                                            Badge {
-                                                size: BadgeSize::Small,
-                                                variant: BadgeVariant::Rounded,
-                                                color: match st {
-                                                    SpaceStatus::InProgress => BadgeColor::Blue,
-                                                    SpaceStatus::Started => BadgeColor::Green,
-                                                    _ => BadgeColor::Grey,
-                                                },
-                                                {st.translate(&lang())}
+                                        div { class: "min-h-[24px] flex items-center",
+                                            if let Some(ref st) = status {
+                                                Badge {
+                                                    size: BadgeSize::Small,
+                                                    variant: BadgeVariant::Rounded,
+                                                    color: match st {
+                                                        SpaceStatus::InProgress => BadgeColor::Blue,
+                                                        SpaceStatus::Started => BadgeColor::Green,
+                                                        _ => BadgeColor::Grey,
+                                                    },
+                                                    {st.translate(&lang())}
+                                                }
                                             }
                                         }
                                         p { class: "w-full text-base font-semibold text-text-primary truncate line-clamp-1",
@@ -124,7 +126,7 @@ pub fn SpaceTimeline() -> Element {
                                         }
                                     }
                                     div { class: "flex flex-row items-center gap-2 px-5",
-                                        lucide_dioxus::Users { size: 14, class: "[&>path]:stroke-foreground-muted" }
+                                        lucide_dioxus::Users { size: 14, class: "[&>path]:stroke-foreground-muted [&>circle]:stroke-foreground-muted" }
                                         p { class: "text-xs text-foreground-muted",
                                             "{space.participants}"
                                         }


### PR DESCRIPTION
Fixes #1232

## Problem

1. **Space card height inconsistency**: On the main page, space cards in the "My Spaces" horizontal timeline had different heights depending on whether a status badge (e.g., "In Progress", "Started") was present. Cards without a badge were shorter.

2. **Icon color wrong in light mode**: The `lucide_dioxus::Users` icon only targeted `<path>` SVG elements with `[&>path]:stroke-foreground-muted`, but the Lucide Users icon also contains `<circle>` elements. In light mode, the unstyled `<circle>` elements rendered with default (black) stroke, making the icon look wrong.

## Solution

1. Wrapped the badge area in a container with `min-h-[24px] flex items-center` to reserve consistent vertical space whether or not a badge is displayed.

2. Added `[&>circle]:stroke-foreground-muted` to the Users icon class string so all SVG child elements are properly themed.

## Changes

- `app/ratel/src/features/timeline/components/space_timeline.rs`
  - Added `min-h-[24px]` wrapper div around the optional Badge to ensure consistent card heights
  - Added `[&>circle]:stroke-foreground-muted` to the Users icon for proper light mode rendering

## Testing

1. Visit the main page (`/`) while logged in
2. Observe the "My Spaces" horizontal card row
3. Verify all cards have the same height regardless of whether they have a status badge
4. Switch to light mode and verify the Users icon color matches the muted foreground color

🤖 Generated with [Claude Code](https://claude.com/claude-code)