### PR TITLE
refactor(member): batch reads and atomic writes for add_team_member

### DIFF
--- a/app/ratel/js/package-lock.json
+++ b/app/ratel/js/package-lock.json
@@ -2605,6 +2605,21 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -5123,6 +5138,21 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",

--- a/app/ratel/src/features/social/pages/member/components/invite_member_modal.rs
+++ b/app/ratel/src/features/social/pages/member/components/invite_member_modal.rs
@@ -1,6 +1,7 @@
 use super::super::controllers::{add_team_member_handler, find_user_handler, FindUserQueryType};
 use super::super::dto::{AddTeamMemberRequest, FoundUserResponse, TeamRole};
 use super::super::*;
+use dioxus_translate::use_language;
 
 use icons::validations;
 
@@ -20,6 +21,7 @@ pub fn InviteMemberModal(
 ) -> Element {
     let _username = username;
     let tr: InviteMemberTranslate = use_translate();
+    let lang = use_language();
     let mut role_index = use_signal(|| 0usize);
     let mut selected_users = use_signal(Vec::<FoundUserResponse>::new);
     let mut search_value = use_signal(String::new);
@@ -110,8 +112,8 @@ pub fn InviteMemberModal(
                     });
                     on_close.call(());
                 }
-                Err(_) => {
-                    message.set(Some(failed_invite()));
+                Err(e) => {
+                    message.set(Some(e.translate(&lang()).to_string()));
                 }
             }
         });

--- a/app/ratel/src/features/social/pages/member/controllers/add_member.rs
+++ b/app/ratel/src/features/social/pages/member/controllers/add_member.rs
@@ -12,7 +12,10 @@ pub async fn add_team_member_handler(
 ) -> Result<AddTeamMemberResponse> {
     let common_config = crate::common::CommonConfig::default();
     let cli = common_config.dynamodb();
-    let _team_pk: Partition = team_pk.into();
+
+    if body.user_pks.len() > 100 {
+        return Err(MemberError::TooManyInvitations.into());
+    }
 
     let can_edit = permissions.contains(TeamGroupPermission::TeamAdmin)
         || permissions.contains(TeamGroupPermission::TeamEdit)
@@ -63,25 +66,33 @@ pub async fn add_team_member_handler(
         }
     }
 
-    // Batch-fetch existing UserTeam memberships to skip already-members.
+    let team_group_sk = EntityType::TeamGroup(body.role.to_string());
+    let user_team_sk = EntityType::UserTeam(team.pk.to_string());
+    let user_team_group_sk = EntityType::UserTeamGroup(team_group_sk.to_string());
+
+    // Batch-fetch existing UserTeam memberships.
     let membership_keys: Vec<(Partition, EntityType)> = found_users
         .iter()
-        .map(|u| (u.pk.clone(), EntityType::UserTeam(team.pk.to_string())))
+        .map(|u| (u.pk.clone(), user_team_sk.clone()))
         .collect();
     let existing_memberships =
         crate::features::auth::UserTeam::batch_get(cli, membership_keys).await?;
-    let already_member_pks: HashSet<String> = existing_memberships
-        .iter()
-        .map(|ut| ut.pk.to_string())
-        .collect();
 
-    // Collect users who need to be added.
+    // Batch-fetch existing UserTeamGroup records for users who already have UserTeam.
+    // Only skip users who have BOTH — UserTeam-only means a broken state that needs repair.
+    let group_keys: Vec<(Partition, EntityType)> = existing_memberships
+        .iter()
+        .map(|ut| (ut.pk.clone(), user_team_group_sk.clone()))
+        .collect();
+    let existing_groups = crate::features::auth::UserTeamGroup::batch_get(cli, group_keys).await?;
+    let already_member_pks: HashSet<String> =
+        existing_groups.iter().map(|ug| ug.pk.to_string()).collect();
+
+    // Collect users who need to be added (including broken-state repair).
     let new_members: Vec<_> = found_users
         .into_iter()
         .filter(|u| !already_member_pks.contains(&u.pk.to_string()))
         .collect();
-
-    let team_group_sk = EntityType::TeamGroup(body.role.to_string());
     let success_count = new_members.len() as i64;
 
     // Build 2 write items per user (UserTeam + UserTeamGroup).
@@ -111,7 +122,9 @@ pub async fn add_team_member_handler(
         })
         .collect();
 
-    // transact_write_all_items! auto-chunks into batches of 100 and propagates errors via ?.
+    // transact_write_all_items! chunks into batches of 100 items.
+    // Each user produces 2 items (UserTeam + UserTeamGroup), so each transaction
+    // covers at most 50 users. Atomicity is guaranteed per chunk, not across all chunks.
     crate::transact_write_all_items!(cli, transact_items);
 
     Ok(AddTeamMemberResponse {

--- a/app/ratel/src/features/social/pages/member/controllers/add_member.rs
+++ b/app/ratel/src/features/social/pages/member/controllers/add_member.rs
@@ -10,9 +10,9 @@ pub async fn add_team_member_handler(
     team_pk: TeamPartition,
     body: AddTeamMemberRequest,
 ) -> Result<AddTeamMemberResponse> {
-    let conf = super::super::config::get();
-    let cli = conf.common.dynamodb();
-    let team_pk: Partition = team_pk.into();
+    let common_config = crate::common::CommonConfig::default();
+    let cli = common_config.dynamodb();
+    let _team_pk: Partition = team_pk.into();
 
     let can_edit = permissions.contains(TeamGroupPermission::TeamAdmin)
         || permissions.contains(TeamGroupPermission::TeamEdit)
@@ -26,54 +26,93 @@ pub async fn add_team_member_handler(
         TeamRole::Member => TeamGroupPermissions::member().into(),
     };
 
-    let mut success_count = 0i64;
-    let mut failed_pks = vec![];
+    // Deduplicate requested user pks.
     let mut seen = HashSet::new();
+    let mut failed_pks = vec![];
+    let unique_pks: Vec<String> = body
+        .user_pks
+        .iter()
+        .filter_map(|pk| {
+            if seen.insert(pk.clone()) {
+                Some(pk.clone())
+            } else {
+                failed_pks.push(pk.clone());
+                None
+            }
+        })
+        .collect();
 
-    for member_pk in &body.user_pks {
-        if !seen.insert(member_pk.as_str()) {
-            failed_pks.push(member_pk.to_string());
-            continue;
-        }
-
-        let user = crate::features::auth::User::get(cli, member_pk, Some(EntityType::User)).await?;
-        let Some(user) = user else {
-            failed_pks.push(member_pk.to_string());
-            continue;
-        };
-
-        let user_team_sk = EntityType::UserTeam(team.pk.to_string());
-        if crate::features::auth::UserTeam::get(cli, &user.pk, Some(&user_team_sk))
-            .await?
-            .is_some()
-        {
-            continue;
-        }
-
-        crate::features::auth::UserTeam::new(
-            user.pk.clone(),
-            team.pk.clone(),
-            team.display_name.clone(),
-            team.profile_url.clone(),
-            team.username.clone(),
-            team.dao_address.clone(),
-        )
-        .create(cli)
-        .await?;
-
-        let team_group_sk = EntityType::TeamGroup(body.role.to_string());
-        let user_team_group_sk = EntityType::UserTeamGroup(team_group_sk.to_string());
-
-        crate::features::auth::UserTeamGroup::new(
-            user.pk.clone(),
-            team_group_sk,
-            group_permissions,
-            team.pk.clone(),
-        )
-        .create(cli)
-        .await?;
-        success_count += 1;
+    if unique_pks.is_empty() {
+        return Ok(AddTeamMemberResponse {
+            total_added: 0,
+            failed_pks,
+        });
     }
+
+    // Batch-fetch users to verify they exist.
+    let user_keys: Vec<(Partition, EntityType)> = unique_pks
+        .iter()
+        .filter_map(|pk| pk.parse::<Partition>().ok().map(|p| (p, EntityType::User)))
+        .collect();
+    let found_users = crate::features::auth::User::batch_get(cli, user_keys).await?;
+    let found_user_pks: HashSet<String> = found_users.iter().map(|u| u.pk.to_string()).collect();
+
+    for pk in &unique_pks {
+        if !found_user_pks.contains(pk.as_str()) {
+            failed_pks.push(pk.clone());
+        }
+    }
+
+    // Batch-fetch existing UserTeam memberships to skip already-members.
+    let membership_keys: Vec<(Partition, EntityType)> = found_users
+        .iter()
+        .map(|u| (u.pk.clone(), EntityType::UserTeam(team.pk.to_string())))
+        .collect();
+    let existing_memberships =
+        crate::features::auth::UserTeam::batch_get(cli, membership_keys).await?;
+    let already_member_pks: HashSet<String> = existing_memberships
+        .iter()
+        .map(|ut| ut.pk.to_string())
+        .collect();
+
+    // Collect users who need to be added.
+    let new_members: Vec<_> = found_users
+        .into_iter()
+        .filter(|u| !already_member_pks.contains(&u.pk.to_string()))
+        .collect();
+
+    let team_group_sk = EntityType::TeamGroup(body.role.to_string());
+    let success_count = new_members.len() as i64;
+
+    // Build 2 write items per user (UserTeam + UserTeamGroup).
+    // upsert (no condition check) avoids ConditionalCheckFailedException from
+    // races between our batch-read and this write.
+    let transact_items: Vec<aws_sdk_dynamodb::types::TransactWriteItem> = new_members
+        .iter()
+        .flat_map(|u| {
+            let user_team = crate::features::auth::UserTeam::new(
+                u.pk.clone(),
+                team.pk.clone(),
+                team.display_name.clone(),
+                team.profile_url.clone(),
+                team.username.clone(),
+                team.dao_address.clone(),
+            );
+            let user_team_group = crate::features::auth::UserTeamGroup::new(
+                u.pk.clone(),
+                team_group_sk.clone(),
+                group_permissions,
+                team.pk.clone(),
+            );
+            [
+                user_team.upsert_transact_write_item(),
+                user_team_group.upsert_transact_write_item(),
+            ]
+        })
+        .collect();
+
+    // transact_write_all_items! auto-chunks into batches of 100 and propagates errors via ?.
+    crate::transact_write_all_items!(cli, transact_items);
 
     Ok(AddTeamMemberResponse {
         total_added: success_count,

--- a/app/ratel/src/features/social/pages/member/types.rs
+++ b/app/ratel/src/features/social/pages/member/types.rs
@@ -5,6 +5,10 @@ pub enum MemberError {
     #[error("User not found")]
     #[translate(en = "User not found", ko = "사용자를 찾을 수 없습니다.")]
     UserNotFound,
+
+    #[error("Too many invitations")]
+    #[translate(en = "You can invite up to 100 members at once.", ko = "한번에 최대 100명까지 초대할 수 있습니다.")]
+    TooManyInvitations,
 }
 
 #[cfg(feature = "server")]
@@ -13,6 +17,7 @@ impl MemberError {
         use bdk::prelude::axum::http::StatusCode;
         match self {
             MemberError::UserNotFound => StatusCode::NOT_FOUND,
+            MemberError::TooManyInvitations => StatusCode::BAD_REQUEST,
         }
     }
 }


### PR DESCRIPTION
## Summary                                                                                   
                                                                                               
  - `User::batch_get` / `UserTeam::batch_get`으로 유저 존재 여부 및 기존 멤버 여부를 루프 내 개별 조회에서 2번의 batch 조회로 교체
  - `UserTeam` + `UserTeamGroup` write를 `transact_write_all_items!`로 묶어 원자적 처리 — partial write로 인한 깨진 상태 방지                                                          
  - `create` → `upsert` 로 변경하여 batch read / write 사이 race condition에서 `ConditionalCheckFailedException` 방지 및 재초대 가능하도록 수정                             
  - `CommonConfig::default()` 및 `transact_write_all_items!` 매크로로 컨벤션 통일
                                                                                               
  ## Test plan    
                                                                                               
  - [ ] 팀 멤버 초대 정상 동작 확인                                                            
  - [ ] 초대 실패 후 동일 유저 재초대 시 정상 처리되는지 확인
  - [ ] 여러 명 동시 초대 시 전체 성공 확인                                                    
  - [ ] 존재하지 않는 유저 pk 포함 시 `failed_pks`에 올바르게 포함되는지 확인                  
  - [ ] 이미 멤버인 유저 포함 시 skip되고 나머지 유저는 정상 초대되는지 확인                   
                                                                                               
  Closes #1355                                                                                 
  Closes #1356                                                                                 
                  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)