### PR TITLE
Fix(social): post list spacing, color tokens, icon cleanup, and logout redirect fix

### DIFF
--- a/app/ratel/src/components/app_menu/mod.rs
+++ b/app/ratel/src/components/app_menu/mod.rs
@@ -276,7 +276,6 @@ fn ProfileButton(collapsed: bool) -> Element {
     let team_ctx = use_team_context();
     let mut open = use_signal(|| false);
     let mut popup = use_popup();
-    let nav = use_navigator();
 
     let user = user_ctx().user.clone();
     let Some(user) = user else {
@@ -393,7 +392,6 @@ fn ProfileButton(collapsed: bool) -> Element {
                             open.set(false);
                             spawn(async move {
                                 let _ = crate::features::auth::controllers::logout_handler().await;
-                                nav.push("/");
                                 #[cfg(target_arch = "wasm32")]
                                 {
                                     if let Some(window) = web_sys::window() {

--- a/app/ratel/src/features/social/components/user_sidemenu.rs
+++ b/app/ratel/src/features/social/components/user_sidemenu.rs
@@ -88,7 +88,6 @@ fn SelfSidemenu(username: String) -> Element {
     let user_ctx = crate::features::auth::hooks::use_user_context();
     let mut team_ctx = crate::common::contexts::use_team_context();
     let mut popup = use_popup();
-    let nav = use_navigator();
     let user = user_ctx().user.clone().unwrap_or_default();
     let teams = team_ctx.teams.read().clone();
 
@@ -115,7 +114,6 @@ fn SelfSidemenu(username: String) -> Element {
                     on_logout: move |_| {
                         spawn(async move {
                             let _ = crate::features::auth::controllers::logout_handler().await;
-                            nav.push("/");
                             #[cfg(target_arch = "wasm32")]
                             {
                                 if let Some(window) = web_sys::window() {

--- a/app/ratel/src/features/social/layout.rs
+++ b/app/ratel/src/features/social/layout.rs
@@ -73,7 +73,6 @@ fn TeamSidemenu(username: String, logged_in: bool) -> Element {
     let tr: TeamMenuTranslate = use_translate();
     let user_ctx = crate::features::auth::hooks::use_user_context();
     let team_ctx = crate::common::contexts::use_team_context();
-    let nav = use_navigator();
     let current_route = use_route::<Route>();
     let user = user_ctx().user.clone().unwrap_or_default();
 
@@ -337,7 +336,6 @@ fn TeamSidemenu(username: String, logged_in: bool) -> Element {
                                                 show_user_menu.set(false);
                                                 spawn(async move {
                                                     let _ = crate::features::auth::controllers::logout_handler().await;
-                                                    nav.push("/");
                                                     #[cfg(target_arch = "wasm32")]
                                                     {
                                                         if let Some(window) = web_sys::window() {

--- a/app/ratel/src/features/social/pages/home/components/team_posts_panel.rs
+++ b/app/ratel/src/features/social/pages/home/components/team_posts_panel.rs
@@ -102,7 +102,7 @@ fn TeamPostCard(post: PostResponse, #[props(default = false)] full_width: bool) 
             onclick: move |_| {
                 nav.push(post_url.clone());
             },
-            div { class: "flex h-full flex-col gap-4 border-b border-[#262626] py-6",
+            div { class: "flex h-full flex-col gap-4 border-b border-white light:border-black py-3",
                 div { class: "flex min-h-[25px] items-start",
                     if !post_categories.is_empty() {
                         div { class: "flex min-w-0 items-center gap-2 flex-wrap",

--- a/app/ratel/src/features/social/pages/home/components/team_posts_panel.rs
+++ b/app/ratel/src/features/social/pages/home/components/team_posts_panel.rs
@@ -102,22 +102,18 @@ fn TeamPostCard(post: PostResponse, #[props(default = false)] full_width: bool) 
             onclick: move |_| {
                 nav.push(post_url.clone());
             },
-            div { class: "flex h-full flex-col gap-4 border-b border-white light:border-black py-3",
-                div { class: "flex min-h-[25px] items-start",
-                    if !post_categories.is_empty() {
-                        div { class: "flex min-w-0 items-center gap-2 flex-wrap",
-                            for cat in post_categories.iter() {
-                                div {
-                                    key: "{cat}",
-                                    class: "flex h-[25px] items-center justify-center rounded-[8px] border border-tag-stroke px-2 py-[3px]",
-                                    span { class: "font-bold font-raleway text-[12px]/[14px] tracking-[-0.12px] text-text-primary",
-                                        "{cat}"
-                                    }
+            div { class: "flex h-full flex-col gap-4 border-b border-post-divider py-3",
+                if !post_categories.is_empty() {
+                    div { class: "flex min-w-0 items-center gap-2 flex-wrap",
+                        for cat in post_categories.iter() {
+                            div {
+                                key: "{cat}",
+                                class: "flex h-[25px] items-center justify-center rounded-[8px] border border-tag-stroke px-2 py-[3px]",
+                                span { class: "font-bold font-raleway text-[12px]/[14px] tracking-[-0.12px] text-text-primary",
+                                    "{cat}"
                                 }
                             }
                         }
-                    } else {
-                        div { class: "h-[25px]" }
                     }
                 }
 
@@ -184,7 +180,7 @@ fn TeamPostListItem(post: PostResponse) -> Element {
             onclick: move |_| {
                 nav.push(post_url.clone());
             },
-            div { class: "flex w-full flex-col border-b border-white light:border-black py-6",
+            div { class: "flex w-full flex-col border-b border-post-divider py-6",
                 div { class: "flex items-start justify-between gap-6",
                     if !post_categories.is_empty() {
                         div { class: "flex min-w-0 items-center gap-2 flex-wrap",

--- a/app/ratel/src/features/social/pages/home/components/team_posts_panel.rs
+++ b/app/ratel/src/features/social/pages/home/components/team_posts_panel.rs
@@ -48,7 +48,7 @@ pub fn TeamPostsPanel(
             {
                 match view_mode {
                     HomeViewMode::Card => rsx! {
-                        div { class: "grid grid-cols-2 max-mobile:grid-cols-1 items-stretch gap-10 max-tablet:gap-4",
+                        div { class: "grid grid-cols-2 max-mobile:grid-cols-1 items-stretch gap-5 max-tablet:gap-4",
                             for (idx, post) in items.iter().cloned().enumerate() {
                                 TeamPostCard {
                                     key: "card-{post.pk}",
@@ -109,7 +109,7 @@ fn TeamPostCard(post: PostResponse, #[props(default = false)] full_width: bool) 
                             for cat in post_categories.iter() {
                                 div {
                                     key: "{cat}",
-                                    class: "flex h-[25px] items-center justify-center rounded-[8px] border border-[#A1A1A1] px-2 py-[3px]",
+                                    class: "flex h-[25px] items-center justify-center rounded-[8px] border border-tag-stroke px-2 py-[3px]",
                                     span { class: "font-bold font-raleway text-[12px]/[14px] tracking-[-0.12px] text-text-primary",
                                         "{cat}"
                                     }
@@ -126,7 +126,7 @@ fn TeamPostCard(post: PostResponse, #[props(default = false)] full_width: bool) 
                 }
 
                 div { class: "flex items-center justify-between",
-                    span { class: "font-inter text-[15px]/[22px] text-[#8C8C8C]",
+                    span { class: "font-inter text-[15px]/[22px] text-foreground-muted",
                         {format_post_date(created_at)}
                     }
                     div { class: "flex items-center gap-[10px]",
@@ -154,7 +154,7 @@ fn TeamPostCard(post: PostResponse, #[props(default = false)] full_width: bool) 
                 }
 
                 div {
-                    class: "min-h-0 flex-1 overflow-hidden font-raleway text-[15px]/[22px] text-[#D4D4D4]",
+                    class: "min-h-0 flex-1 overflow-hidden font-raleway text-[15px]/[22px] text-foreground",
                     style: "display: -webkit-box; -webkit-line-clamp: 12; -webkit-box-orient: vertical;",
                     dangerous_inner_html: html_contents,
                 }
@@ -184,14 +184,14 @@ fn TeamPostListItem(post: PostResponse) -> Element {
             onclick: move |_| {
                 nav.push(post_url.clone());
             },
-            div { class: "flex w-full flex-col border-b border-[#262626] py-6",
+            div { class: "flex w-full flex-col border-b border-white light:border-black py-6",
                 div { class: "flex items-start justify-between gap-6",
                     if !post_categories.is_empty() {
                         div { class: "flex min-w-0 items-center gap-2 flex-wrap",
                             for cat in post_categories.iter() {
                                 div {
                                     key: "{cat}",
-                                    class: "flex h-[25px] items-center justify-center rounded-[8px] border border-[#A1A1A1] px-2 py-[3px]",
+                                    class: "flex h-[25px] items-center justify-center rounded-[8px] border border-tag-stroke px-2 py-[3px]",
                                     span { class: "font-bold font-raleway text-[12px]/[14px] tracking-[-0.12px] text-text-primary",
                                         "{cat}"
                                     }
@@ -203,12 +203,12 @@ fn TeamPostListItem(post: PostResponse) -> Element {
                     }
                 }
 
-                h2 { class: "font-bold font-raleway text-[26px]/[30px] text-text-primary line-clamp-2 mb-2.5",
+                h2 { class: "font-bold font-raleway text-[26px]/[30px] text-text-primary line-clamp-2 mt-3 mb-2.5",
                     "{title}"
                 }
 
                 div { class: "flex items-center justify-between gap-4 max-mobile:flex-col max-mobile:items-start",
-                    span { class: "font-inter text-[15px]/[22px] text-[#8C8C8C]",
+                    span { class: "font-inter text-[15px]/[22px] text-foreground-muted",
                         {format_post_date(created_at)}
                     }
                     div { class: "flex shrink-0 items-center gap-6",

--- a/app/ratel/src/features/social/pages/user_reward/components/points_summary_card.rs
+++ b/app/ratel/src/features/social/pages/user_reward/components/points_summary_card.rs
@@ -24,11 +24,6 @@ pub fn points_summary_card(
                 h2 { class: "text-base font-semibold text-text-primary tracking-[0.5px]",
                     "{tr.title}"
                 }
-                icons::arrows::ArrowUp {
-                    width: "20",
-                    height: "20",
-                    class: "-rotate-90 [&>path]:stroke-white",
-                }
             }
 
             div { class: "flex justify-between items-start mb-5",

--- a/app/ratel/src/features/social/pages/user_reward/components/transaction_item.rs
+++ b/app/ratel/src/features/social/pages/user_reward/components/transaction_item.rs
@@ -51,14 +51,8 @@ pub fn transaction_item(
                         }
                     }
                 }
-                div { class: "flex items-center gap-1",
-                    span { class: "text-sm font-medium text-foreground-muted tracking-[0.5px]",
-                        "{time_ago_label}"
-                    }
-                    lucide_dioxus::ExternalLink {
-                        size: 18,
-                        class: "[&>path]:stroke-foreground-muted [&>polyline]:stroke-foreground-muted [&>line]:stroke-foreground-muted",
-                    }
+                span { class: "text-sm font-medium text-foreground-muted tracking-[0.5px]",
+                    "{time_ago_label}"
                 }
             }
         }

--- a/app/ratel/src/features/social/user_views/home/user_posts_panel.rs
+++ b/app/ratel/src/features/social/user_views/home/user_posts_panel.rs
@@ -74,25 +74,23 @@ fn UserPostCard(post: PostResponse) -> Element {
         Link {
             to: "{post_url}",
             class: "block",
-            div { class: "flex flex-col gap-4 py-6 border-b border-separator",
-                div { class: "flex items-center justify-between",
-                    if !category.is_empty() {
+            div { class: "flex flex-col gap-5 py-6 border-b border-separator",
+                if !category.is_empty() {
+                    div { class: "flex items-center justify-between",
                         div { class: "flex items-center border border-tag-stroke rounded-[8px] px-2 py-0.5",
                             span { class: "text-[12px] font-bold text-text-primary leading-[14px] tracking-[-0.12px]",
                                 "{category}"
                             }
                         }
-                    } else {
-                        div {}
-                    }
-                    div { class: "flex items-center gap-2",
-                        icons::edit::Edit1 {
-                            class: "w-5 h-5 [&>path]:stroke-icon-primary cursor-pointer",
+                        div { class: "flex items-center gap-2",
+                            icons::edit::Edit1 {
+                                class: "w-5 h-5 [&>path]:stroke-icon-primary cursor-pointer",
+                            }
                         }
                     }
                 }
 
-                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2 mt-2",
+                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2",
                     "{title}"
                 }
 
@@ -143,6 +141,11 @@ fn UserPostListItem(post: PostResponse) -> Element {
     let likes = post.likes;
     let comments = post.comments;
     let category = post.categories.first().cloned().unwrap_or_default();
+    let title_class = if category.is_empty() {
+        "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2"
+    } else {
+        "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2 mt-2"
+    };
 
     rsx! {
         Link {
@@ -157,7 +160,7 @@ fn UserPostListItem(post: PostResponse) -> Element {
                     }
                 }
 
-                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2 mt-4",
+                h2 { class: "{title_class}",
                     "{title}"
                 }
 

--- a/app/ratel/src/features/social/user_views/home/user_posts_panel.rs
+++ b/app/ratel/src/features/social/user_views/home/user_posts_panel.rs
@@ -1,9 +1,9 @@
+use super::HomeViewMode;
 use crate::common::hooks::use_infinite_query;
 use crate::common::*;
 use crate::features::posts::controllers::dto::PostResponse;
 use crate::features::posts::controllers::list_user_posts::list_user_posts_handler;
 use dioxus::prelude::*;
-use super::HomeViewMode;
 
 #[component]
 pub fn UserPostsPanel(username: String, view_mode: HomeViewMode) -> Element {
@@ -92,7 +92,7 @@ fn UserPostCard(post: PostResponse) -> Element {
                     }
                 }
 
-                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2",
+                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2 mt-2",
                     "{title}"
                 }
 
@@ -157,7 +157,7 @@ fn UserPostListItem(post: PostResponse) -> Element {
                     }
                 }
 
-                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2",
+                h2 { class: "text-[20px] font-bold text-text-primary tracking-[0.5px] leading-[25px] line-clamp-2 mt-4",
                     "{title}"
                 }
 

--- a/app/ratel/src/features/social/user_views/home/user_posts_panel.rs
+++ b/app/ratel/src/features/social/user_views/home/user_posts_panel.rs
@@ -148,7 +148,7 @@ fn UserPostListItem(post: PostResponse) -> Element {
         Link {
             to: "{post_url}",
             class: "block",
-            div { class: "flex flex-col gap-3 py-5 border-b border-separator",
+            div { class: "flex flex-col gap-4 py-5 border-b border-separator",
                 if !category.is_empty() {
                     div { class: "flex items-center border border-tag-stroke rounded-[8px] px-2 py-0.5 w-fit",
                         span { class: "text-[12px] font-bold text-text-primary leading-[14px] tracking-[-0.12px]",

--- a/app/ratel/tailwind.css
+++ b/app/ratel/tailwind.css
@@ -138,6 +138,7 @@ html[data-theme="light"] {
     var(--light, var(--table-light-border));
   --border-separator: var(--dark, var(--gray-800)) var(--light, #e5e5e5);
   --border-subtle: var(--dark, #464646) var(--light, var(--gray-700));
+  --border-post-divider: var(--dark, #ffffff) var(--light, #000000);
 
   /* Table styles */
   --table-bg: var(--dark, var(--bg-dark)) var(--light, var(--gray-50));
@@ -669,6 +670,9 @@ a {
   }
   .border-subtle {
     border-color: var(--border-subtle);
+  }
+  .border-post-divider {
+    border-color: var(--border-post-divider);
   }
 
   /* Panel delete icon color override */


### PR DESCRIPTION
## Summary
  - 팀/유저 포스트 패널 간격 및 border 색상 시멘틱 토큰으로 교체 (#1361)
  - 유저 리워드 페이지에서 비동작 아이콘 제거 (#1364)
  - 팀 사이드메뉴 로그아웃 시 홈으로 리다이렉트되던 문제 수정 (#1366)

  ## Changes

  ### fix(social): post list/card spacing & semantic color tokens (#1361)
  - 포스트 리스트 아이템 간 수직 패딩/간격 축소
  - 카드 그리드 gap 조정, 카테고리 태그와 타이틀 사이 margin 추가
  - `team_posts_panel`, `user_posts_panel`의 하드코딩 hex 색상 → 시멘틱 토큰(`border-separator` 등)으로 교체

  ### fix(user-reward): remove non-functional icons (#1364)
  - `transaction_item`에서 `ExternalLink` 아이콘 제거
  - `points_summary_card`에서 `ArrowUp` 아이콘 제거

  ### fix(team): stay on team page after logout (#1366)
  - 로그아웃 후 `nav.push("/")` 제거 — 현재 페이지(팀 페이지)에 머물도록 수정
  - `window.location().reload()`만 실행하여 비로그인 상태 반영
  - 적용 위치: `TeamSidemenu`, `UserSidemenu`, `ProfileButton`

  ## Test plan
  - [ ] 팀 포스트 리스트/카드 뷰 간격 및 border 색상 확인 (라이트/다크 모드)
  - [ ] 유저 리워드 페이지에서 불필요한 아이콘 미노출 확인
  - [ ] 팀 페이지에서 로그아웃 후 팀 페이지 URL 유지 + 로그인/회원가입 버튼 노출 확인

  Closes #1361, #1364, #1366