### PR TITLE
fix(posts): replace nav.push with nav.replace after post publish

### DIFF
--- a/app/ratel/src/features/posts/views/post_edit/mod.rs
+++ b/app/ratel/src/features/posts/views/post_edit/mod.rs
@@ -205,7 +205,7 @@ pub fn PostEdit(post_id: FeedPartition) -> Element {
             .await
             {
                 Ok(_) => {
-                    nav.push(format!("/posts/{post_id}"));
+                    nav.replace(format!("/posts/{post_id}"));
                 }
                 Err(e) => {
                     dioxus::logger::tracing::error!("Publish failed: {:?}", e);


### PR DESCRIPTION
After publishing a post, using nav.push left the editor in the browser history stack, causing go_back() from the post detail page to return to the editor instead of the originating page.

close #1377 