### PR TITLE
feat(mcp): add MCP oneshot support and tool handler generation

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -240,6 +240,7 @@ jobs:
           PORTONE_API_SECRET: ${{ secrets.DEV_PORTONE_API_SECRET }}
           PORTONE_KPN_CHANNEL_KEY: ${{ secrets.DEV_PORTONE_KPN_CHANNEL_KEY }}
 
+          QDRANT_URL: ${{ secrets.DEV_QDRANT_URL }}
           QDRANT_API_KEY: ${{secrets.DEV_QDRANT_API_KEY }}
 
           ECR: ${{ steps.ratel-ecr.outputs.registry }}/ratel/app-shell

--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -185,6 +185,7 @@ jobs:
           PORTONE_STORE_ID: ${{ secrets.PORTONE_STORE_ID }}
           PORTONE_INICIS_CHANNEL_KEY: ${{ secrets.PROD_PORTONE_INICIS_CHANNEL_KEY }}
 
+          QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{secrets.QDRANT_API_KEY }}
 
           ECR: ${{ steps.ratel-ecr.outputs.registry }}/ratel/app-shell

--- a/app/ratel/Cargo.toml
+++ b/app/ratel/Cargo.toml
@@ -38,6 +38,7 @@ rand = { version = "0.10" }
 futures = { version = "0.3", optional = true }
 urlencoding = { version = "2" }
 tokio = { workspace = true, optional = true }
+tower = { version = "0.5", features = ["util"], optional = true }
 
 web-sys = { workspace = true, features = [
   "Blob",
@@ -149,6 +150,7 @@ server = [
   "sha3",
   "ssi",
   "tokio",
+  "tower",
   "tower-sessions",
   "url",
   "uuid",

--- a/app/ratel/js/package-lock.json
+++ b/app/ratel/js/package-lock.json
@@ -2605,21 +2605,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -5138,21 +5123,6 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",

--- a/app/ratel/src/app.rs
+++ b/app/ratel/src/app.rs
@@ -8,6 +8,11 @@ use dioxus::prelude::*;
 pub const MAIN_CSS: Asset = asset!("/assets/main.css");
 pub const MAIN_JS: Asset = asset!("/assets/ratel-app-shell.js");
 
+#[cfg(feature = "server")]
+pub fn app() -> by_axum::axum::AxumRouter {
+    dioxus::server::router(App)
+}
+
 #[component]
 pub fn App() -> Element {
     use_context_provider(|| PopupService::new());

--- a/app/ratel/src/common/mcp/mod.rs
+++ b/app/ratel/src/common/mcp/mod.rs
@@ -1,5 +1,9 @@
 #[cfg(feature = "server")]
+mod oneshot;
+#[cfg(feature = "server")]
 mod server;
 
+#[cfg(feature = "server")]
+pub use oneshot::*;
 #[cfg(feature = "server")]
 pub use server::*;

--- a/app/ratel/src/common/mcp/oneshot.rs
+++ b/app/ratel/src/common/mcp/oneshot.rs
@@ -1,0 +1,71 @@
+use std::sync::OnceLock;
+
+use dioxus::server::axum::{self, Router};
+
+static APP_ROUTER: OnceLock<Router> = OnceLock::new();
+
+pub fn set_app_router(router: Router) {
+    APP_ROUTER.set(router).ok();
+}
+
+pub fn get_app_router() -> Router {
+    APP_ROUTER
+        .get()
+        .expect("MCP app router not initialized. Call set_app_router() in run.rs")
+        .clone()
+}
+
+/// Send an HTTP request through the Axum router via `tower::ServiceExt::oneshot`.
+/// Used by `#[mcp_tool]`-generated `_mcp_impl` functions.
+pub async fn mcp_oneshot<T: serde::de::DeserializeOwned>(
+    method: &str,
+    path: &str,
+    mcp_secret: &str,
+    body: Option<Vec<u8>>,
+) -> crate::common::Result<T> {
+    use tower::ServiceExt;
+
+    let router = get_app_router();
+    let encoded_path = path.replace("#", "%23");
+
+    let mut builder = axum::http::Request::builder()
+        .uri(format!("http://localhost{}", encoded_path))
+        .method(method)
+        .header("authorization", format!("McpSecret {}", mcp_secret));
+
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+
+    let req = builder
+        .body(axum::body::Body::from(body.unwrap_or_default()))
+        .map_err(|e| {
+            crate::common::Error::InternalServerError(format!(
+                "Failed to build MCP oneshot request: {e}"
+            ))
+        })?;
+
+    let res = router.oneshot(req).await.map_err(|e| {
+        crate::common::Error::InternalServerError(format!("MCP oneshot failed: {e}"))
+    })?;
+
+    let (parts, body) = res.into_parts();
+    let bytes = axum::body::to_bytes(body, 10 * 1024 * 1024)
+        .await
+        .map_err(|e| {
+            crate::common::Error::InternalServerError(format!(
+                "Failed to read MCP oneshot response: {e}"
+            ))
+        })?;
+
+    if !parts.status.is_success() {
+        let msg = String::from_utf8_lossy(&bytes).to_string();
+        return Err(crate::common::Error::InternalServerError(msg));
+    }
+
+    serde_json::from_slice(&bytes).map_err(|e| {
+        crate::common::Error::InternalServerError(format!(
+            "Failed to parse MCP oneshot response: {e}"
+        ))
+    })
+}

--- a/app/ratel/src/common/mcp/server.rs
+++ b/app/ratel/src/common/mcp/server.rs
@@ -16,34 +16,14 @@ use rmcp::{
 use tokio::sync::RwLock;
 
 use crate::common::config::ServerConfig;
-use crate::common::models::auth::OptionalUser;
-use crate::common::models::space::{SpaceAdmin, SpaceAuthor, SpaceCommon, SpaceParticipant};
 use crate::common::models::McpClientSecret;
-use crate::common::models::User;
-use crate::common::types::FeedPartition;
-use crate::common::types::TeamPartition;
-use crate::common::types::{
-    CompositePartition, EntityType, Partition, SpaceActionFollowEntityType, SpacePartition,
-    SpacePollEntityType, SpacePostEntityType, SpaceQuizEntityType, UserType,
-};
-use crate::common::SpaceUserRole;
+use crate::common::types::{EntityType, FeedPartition, TeamPartition};
 use crate::features::auth::controllers::get_me_handler_mcp_impl;
-use crate::features::auth::{UserTeam, UserTeamQueryOption};
 use crate::features::posts::controllers::{
     create_post_handler_mcp_impl, create_space_handler_mcp_impl, delete_post_handler_mcp_impl,
     get_post_handler_mcp_impl, like_post_handler_mcp_impl, list_posts_handler_mcp_impl,
     update_post_handler_mcp_impl, CreateSpaceRequest, UpdatePostRequest,
 };
-use crate::features::posts::models::{Post, Team};
-use crate::features::posts::types::PostStatus;
-use crate::features::spaces::pages::actions::actions::discussion::{SpaceCategory, SpacePost};
-use crate::features::spaces::pages::actions::actions::follow::SpaceFollowAction;
-use crate::features::spaces::pages::actions::actions::poll::SpacePoll;
-use crate::features::spaces::pages::actions::actions::quiz::{SpaceQuiz, SpaceQuizAnswer};
-use crate::features::spaces::pages::actions::models::SpaceAction;
-use crate::features::spaces::pages::actions::types::SpaceActionType;
-// UpdateSpaceRequest is pub-re-exported from the general app controller module.
-use crate::features::spaces::pages::apps::apps::general::UpdateSpaceRequest;
 
 pub type McpResult = Result<CallToolResult, ErrorData>;
 
@@ -69,11 +49,11 @@ impl<T: serde::Serialize> IntoMcpResult for crate::common::Result<T> {
 
 #[derive(Clone)]
 pub struct RatelMcpServer {
-    user: User,
+    mcp_secret: String,
     tool_router: ToolRouter<Self>,
 }
 
-// ── MCP Tool Request Types ──────────────────────────────────────────
+// ── MCP Tool Request Types (post-related, kept because they are hand-written) ──
 
 #[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
 pub struct CreatePostMcpRequest {
@@ -133,107 +113,13 @@ pub struct CreateSpaceMcpRequest {
     pub post_id: FeedPartition,
 }
 
-// ── Space MCP Request Types ─────────────────────────────────────────
-
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct GetSpaceMcpRequest {
-    #[schemars(description = "Space partition key (e.g. 'SPACE#<uuid>' or '<uuid>')")]
-    pub space_id: SpacePartition,
-}
-
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct UpdateSpaceMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(
-        description = "Update data as JSON. Supported variants: {\"visibility\": \"Public\"}, {\"anonymous_participation\": true}, {\"join_anytime\": true}, {\"start\": true}, {\"finished\": true}, {\"quotas\": 100}, {\"title\": \"...\"}, {\"content\": \"...\"}, {\"publish\": true, \"visibility\": \"Public\"}, {\"logo\": \"url\"}"
-    )]
-    pub update: serde_json::Value,
-}
-
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct DeleteSpaceMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-}
-
-// Poll
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct SpaceActionMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-}
-
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct UpdatePollMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(description = "Poll sort key (e.g. 'SpacePoll#<uuid>')")]
-    pub poll_id: String,
-    #[schemars(
-        description = "Poll update data as JSON. Supported variants: {\"title\": \"...\"}, {\"started_at\": <ms>, \"ended_at\": <ms>}, {\"questions\": [...]}, {\"response_editable\": true}"
-    )]
-    pub update: serde_json::Value,
-}
-
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct DeletePollMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(description = "Poll sort key (e.g. 'SpacePoll#<uuid>')")]
-    pub poll_id: String,
-}
-
-// Quiz
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct UpdateQuizMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(description = "Quiz sort key (e.g. 'SpaceQuiz#<uuid>')")]
-    pub quiz_id: String,
-    #[schemars(
-        description = "Quiz update data as JSON. Fields: title, description, started_at, ended_at, retry_count, pass_score, questions, answers, files (all optional)"
-    )]
-    pub update: serde_json::Value,
-}
-
-// Discussion
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct UpdateDiscussionMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
-    pub discussion_id: String,
-    #[schemars(
-        description = "Discussion update data as JSON. Fields: title, html_contents, category_name, started_at, ended_at (all optional)"
-    )]
-    pub update: serde_json::Value,
-}
-
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct DeleteDiscussionMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
-    pub discussion_id: String,
-}
-
-// Apps
-#[derive(Debug, serde::Deserialize, rmcp::schemars::JsonSchema)]
-pub struct SpaceAppMcpRequest {
-    #[schemars(description = "Space partition key")]
-    pub space_id: SpacePartition,
-    #[schemars(description = "App type: 'General', 'File', 'Analyzes', or 'Panels'")]
-    pub app_type: String,
-}
-
 // ── MCP Tool Implementations ────────────────────────────────────────
 
 #[tool_router]
 impl RatelMcpServer {
-    pub fn new(user: User) -> Result<Self, std::io::Error> {
+    pub fn new(mcp_secret: String) -> Result<Self, std::io::Error> {
         Ok(Self {
-            user,
+            mcp_secret,
             tool_router: Self::tool_router(),
         })
     }
@@ -243,7 +129,7 @@ impl RatelMcpServer {
         description = "Create a new draft post in Ratel. Returns the post partition key."
     )]
     async fn create_post(&self, Parameters(req): Parameters<CreatePostMcpRequest>) -> McpResult {
-        create_post_handler_mcp_impl(self.user.clone(), req.team_id)
+        create_post_handler_mcp_impl(self.mcp_secret.clone(), req.team_id)
             .await
             .into_mcp()
     }
@@ -253,22 +139,19 @@ impl RatelMcpServer {
         description = "Get current user info and membership details."
     )]
     async fn get_me(&self) -> McpResult {
-        let user = OptionalUser(Some(self.user.clone()));
-        get_me_handler_mcp_impl(user).await.into_mcp()
+        get_me_handler_mcp_impl(self.mcp_secret.clone()).await.into_mcp()
     }
 
     #[rmcp::tool(name = "get_post", description = "Get post details by ID.")]
     async fn get_post(&self, Parameters(req): Parameters<GetPostMcpRequest>) -> McpResult {
-        let user = OptionalUser(Some(self.user.clone()));
-        get_post_handler_mcp_impl(user, req.post_id)
+        get_post_handler_mcp_impl(self.mcp_secret.clone(), req.post_id)
             .await
             .into_mcp()
     }
 
     #[rmcp::tool(name = "list_posts", description = "List posts from the feed.")]
     async fn list_posts(&self, Parameters(req): Parameters<ListPostsMcpRequest>) -> McpResult {
-        let user = OptionalUser(Some(self.user.clone()));
-        list_posts_handler_mcp_impl(user, req.bookmark)
+        list_posts_handler_mcp_impl(self.mcp_secret.clone(), req.bookmark)
             .await
             .into_mcp()
     }
@@ -300,21 +183,21 @@ impl RatelMcpServer {
             visibility,
             categories: req.categories,
         };
-        update_post_handler_mcp_impl(self.user.clone(), req.post_id, update_req)
+        update_post_handler_mcp_impl(self.mcp_secret.clone(), req.post_id, update_req)
             .await
             .into_mcp()
     }
 
     #[rmcp::tool(name = "delete_post", description = "Delete a post by ID.")]
     async fn delete_post(&self, Parameters(req): Parameters<DeletePostMcpRequest>) -> McpResult {
-        delete_post_handler_mcp_impl(self.user.clone(), req.post_id, req.force)
+        delete_post_handler_mcp_impl(self.mcp_secret.clone(), req.post_id, req.force)
             .await
             .into_mcp()
     }
 
     #[rmcp::tool(name = "like_post", description = "Like or unlike a post.")]
     async fn like_post(&self, Parameters(req): Parameters<LikePostMcpRequest>) -> McpResult {
-        like_post_handler_mcp_impl(self.user.clone(), req.post_id, req.like)
+        like_post_handler_mcp_impl(self.mcp_secret.clone(), req.post_id, req.like)
             .await
             .into_mcp()
     }
@@ -325,7 +208,7 @@ impl RatelMcpServer {
     )]
     async fn create_space(&self, Parameters(req): Parameters<CreateSpaceMcpRequest>) -> McpResult {
         create_space_handler_mcp_impl(
-            self.user.clone(),
+            self.mcp_secret.clone(),
             CreateSpaceRequest {
                 post_id: req.post_id,
             },
@@ -340,26 +223,33 @@ impl RatelMcpServer {
         name = "get_space",
         description = "Get space details by ID, including status, visibility, participation info."
     )]
-    async fn get_space(&self, Parameters(req): Parameters<GetSpaceMcpRequest>) -> McpResult {
-        get_space_impl(&self.user, req.space_id).await.into_mcp()
+    async fn get_space(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::space_common::controllers::GetSpaceMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::space_common::controllers::get_space_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
         name = "update_space",
         description = "Update a space (publish, change visibility, content, title, start, finish, quota, etc.). Requires creator role."
     )]
-    async fn update_space(&self, Parameters(req): Parameters<UpdateSpaceMcpRequest>) -> McpResult {
-        update_space_impl(&self.user, req.space_id, req.update)
-            .await
-            .into_mcp()
+    async fn update_space(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::space_common::controllers::UpdateSpaceMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::space_common::controllers::update_space_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
         name = "delete_space",
         description = "Delete a space and unlink its post. Requires creator role."
     )]
-    async fn delete_space(&self, Parameters(req): Parameters<DeleteSpaceMcpRequest>) -> McpResult {
-        delete_space_impl(&self.user, req.space_id).await.into_mcp()
+    async fn delete_space(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::apps::apps::general::controllers::DeleteSpaceMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::apps::apps::general::controllers::delete_space_mcp_handler(&self.mcp_secret, req).await
     }
 
     // ── Poll tools ──────────────────────────────────────────────────
@@ -368,28 +258,33 @@ impl RatelMcpServer {
         name = "create_poll",
         description = "Create a new poll action in a space. Requires creator role."
     )]
-    async fn create_poll(&self, Parameters(req): Parameters<SpaceActionMcpRequest>) -> McpResult {
-        create_poll_impl(&self.user, req.space_id).await.into_mcp()
+    async fn create_poll(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::poll::controllers::CreatePollMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::poll::controllers::create_poll_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
         name = "update_poll",
         description = "Update a poll (title, time range, questions, response_editable). Requires creator role."
     )]
-    async fn update_poll(&self, Parameters(req): Parameters<UpdatePollMcpRequest>) -> McpResult {
-        update_poll_impl(&self.user, req.space_id, req.poll_id, req.update)
-            .await
-            .into_mcp()
+    async fn update_poll(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::poll::controllers::UpdatePollMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::poll::controllers::update_poll_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
         name = "delete_poll",
         description = "Delete a poll from a space. Requires creator role."
     )]
-    async fn delete_poll(&self, Parameters(req): Parameters<DeletePollMcpRequest>) -> McpResult {
-        delete_poll_impl(&self.user, req.space_id, req.poll_id)
-            .await
-            .into_mcp()
+    async fn delete_poll(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::poll::controllers::DeletePollMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::poll::controllers::delete_poll_mcp_handler(&self.mcp_secret, req).await
     }
 
     // ── Quiz tools ──────────────────────────────────────────────────
@@ -398,18 +293,22 @@ impl RatelMcpServer {
         name = "create_quiz",
         description = "Create a new quiz action in a space. Requires creator role."
     )]
-    async fn create_quiz(&self, Parameters(req): Parameters<SpaceActionMcpRequest>) -> McpResult {
-        create_quiz_impl(&self.user, req.space_id).await.into_mcp()
+    async fn create_quiz(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::quiz::controllers::CreateQuizMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::quiz::controllers::create_quiz_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
         name = "update_quiz",
         description = "Update a quiz (title, description, time, questions, answers, pass_score, retry_count, files). Requires creator role."
     )]
-    async fn update_quiz(&self, Parameters(req): Parameters<UpdateQuizMcpRequest>) -> McpResult {
-        update_quiz_impl(&self.user, req.space_id, req.quiz_id, req.update)
-            .await
-            .into_mcp()
+    async fn update_quiz(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::quiz::controllers::UpdateQuizMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::quiz::controllers::update_quiz_mcp_handler(&self.mcp_secret, req).await
     }
 
     // ── Discussion tools ────────────────────────────────────────────
@@ -420,11 +319,11 @@ impl RatelMcpServer {
     )]
     async fn create_discussion(
         &self,
-        Parameters(req): Parameters<SpaceActionMcpRequest>,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::discussion::controllers::CreateDiscussionMcpRequest>,
     ) -> McpResult {
-        create_discussion_impl(&self.user, req.space_id)
-            .await
-            .into_mcp()
+        crate::features::spaces::pages::actions::actions::discussion::controllers::create_discussion_mcp_handler(
+            &self.mcp_secret, req,
+        ).await
     }
 
     #[rmcp::tool(
@@ -433,11 +332,9 @@ impl RatelMcpServer {
     )]
     async fn update_discussion(
         &self,
-        Parameters(req): Parameters<UpdateDiscussionMcpRequest>,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::discussion::controllers::UpdateDiscussionMcpRequest>,
     ) -> McpResult {
-        update_discussion_impl(&self.user, req.space_id, req.discussion_id, req.update)
-            .await
-            .into_mcp()
+        crate::features::spaces::pages::actions::actions::discussion::controllers::update_discussion_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
@@ -446,11 +343,9 @@ impl RatelMcpServer {
     )]
     async fn delete_discussion(
         &self,
-        Parameters(req): Parameters<DeleteDiscussionMcpRequest>,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::discussion::controllers::DeleteDiscussionMcpRequest>,
     ) -> McpResult {
-        delete_discussion_impl(&self.user, req.space_id, req.discussion_id)
-            .await
-            .into_mcp()
+        crate::features::spaces::pages::actions::actions::discussion::controllers::delete_discussion_mcp_handler(&self.mcp_secret, req).await
     }
 
     // ── Follow tools ────────────────────────────────────────────────
@@ -459,10 +354,11 @@ impl RatelMcpServer {
         name = "create_follow",
         description = "Create a follow action in a space. Requires creator role."
     )]
-    async fn create_follow(&self, Parameters(req): Parameters<SpaceActionMcpRequest>) -> McpResult {
-        create_follow_impl(&self.user, req.space_id)
-            .await
-            .into_mcp()
+    async fn create_follow(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::follow::controllers::CreateFollowMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::follow::controllers::create_follow_mcp_handler(&self.mcp_secret, req).await
     }
 
     // ── App tools ───────────────────────────────────────────────────
@@ -473,11 +369,9 @@ impl RatelMcpServer {
     )]
     async fn install_space_app(
         &self,
-        Parameters(req): Parameters<SpaceAppMcpRequest>,
+        Parameters(req): Parameters<crate::features::spaces::pages::apps::controllers::InstallSpaceAppMcpRequest>,
     ) -> McpResult {
-        install_space_app_impl(&self.user, req.space_id, &req.app_type)
-            .await
-            .into_mcp()
+        crate::features::spaces::pages::apps::controllers::install_space_app_mcp_handler(&self.mcp_secret, req).await
     }
 
     #[rmcp::tool(
@@ -486,21 +380,152 @@ impl RatelMcpServer {
     )]
     async fn uninstall_space_app(
         &self,
-        Parameters(req): Parameters<SpaceAppMcpRequest>,
+        Parameters(req): Parameters<crate::features::spaces::pages::apps::controllers::UninstallSpaceAppMcpRequest>,
     ) -> McpResult {
-        uninstall_space_app_impl(&self.user, req.space_id, &req.app_type)
-            .await
-            .into_mcp()
+        crate::features::spaces::pages::apps::controllers::uninstall_space_app_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    // ── Poll participant tools ───────────────────────────────────────
+
+    #[rmcp::tool(
+        name = "get_poll",
+        description = "Get poll details including questions and the current user's response."
+    )]
+    async fn get_poll(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::poll::controllers::GetPollMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::poll::controllers::get_poll_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    #[rmcp::tool(
+        name = "respond_poll",
+        description = "Submit answers to a poll. Requires participant role and space in Ongoing status."
+    )]
+    async fn respond_poll(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::poll::controllers::RespondPollMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::poll::controllers::respond_poll_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    // ── Quiz participant tools ──────────────────────────────────────
+
+    #[rmcp::tool(
+        name = "get_quiz",
+        description = "Get quiz details including questions, attempt count, and the current user's score."
+    )]
+    async fn get_quiz(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::quiz::controllers::GetQuizMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::quiz::controllers::get_quiz_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    #[rmcp::tool(
+        name = "respond_quiz",
+        description = "Submit answers to a quiz. Requires participant role. Returns score."
+    )]
+    async fn respond_quiz(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::quiz::controllers::RespondQuizMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::quiz::controllers::respond_quiz_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    // ── Discussion participant tools ────────────────────────────────
+
+    #[rmcp::tool(
+        name = "get_discussion",
+        description = "Get discussion details by ID."
+    )]
+    async fn get_discussion(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::discussion::controllers::GetDiscussionMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::discussion::controllers::get_discussion_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    #[rmcp::tool(
+        name = "add_comment",
+        description = "Add a comment to a discussion. Requires participant role and discussion in progress."
+    )]
+    async fn add_comment(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::discussion::controllers::AddCommentMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::discussion::controllers::add_comment_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    #[rmcp::tool(
+        name = "list_comments",
+        description = "List comments on a discussion, sorted by likes. Supports pagination."
+    )]
+    async fn list_comments(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::discussion::controllers::ListCommentsMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::discussion::controllers::list_comments_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    // ── Follow participant tools ────────────────────────────────────
+
+    #[rmcp::tool(
+        name = "get_follow",
+        description = "Get follow action details including the target user to follow."
+    )]
+    async fn get_follow(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::follow::controllers::GetFollowMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::follow::controllers::get_follow_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    #[rmcp::tool(
+        name = "follow_user",
+        description = "Follow a user as part of a space follow action. Requires participant role."
+    )]
+    async fn follow_user(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::actions::follow::controllers::FollowUserMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::actions::follow::controllers::follow_user_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    // ── Action listing tools ────────────────────────────────────────
+
+    #[rmcp::tool(
+        name = "list_actions",
+        description = "List all actions in a space (polls, quizzes, discussions, follow). Shows action type, title, and status."
+    )]
+    async fn list_actions(
+        &self,
+        Parameters(req): Parameters<crate::features::spaces::pages::actions::controllers::ListActionsMcpRequest>,
+    ) -> McpResult {
+        crate::features::spaces::pages::actions::controllers::list_actions_mcp_handler(&self.mcp_secret, req).await
+    }
+
+    // ── AI Moderator tools ───────────────────────────────────────────
+
+    #[rmcp::tool(
+        name = "update_ai_moderator",
+        description = "Configure AI moderator for a discussion. Sets enabled state, reply interval, and guidelines. Requires creator role and premium membership."
+    )]
+    async fn update_ai_moderator(
+        &self,
+        Parameters(req): Parameters<crate::features::ai_moderator::controllers::UpdateAiModeratorConfigMcpRequest>,
+    ) -> McpResult {
+        crate::features::ai_moderator::controllers::update_ai_moderator_config_mcp_handler(&self.mcp_secret, req).await
     }
 
     // ── Team tools ──────────────────────────────────────────────────
 
     #[rmcp::tool(
         name = "list_teams",
-        description = "List all teams the user belongs to with their role and permissions. Permissions include: PostRead, PostWrite, PostEdit, PostDelete, SpaceRead, SpaceWrite, SpaceEdit, SpaceDelete, TeamAdmin, TeamEdit, GroupEdit. Use team_id from the result as the team_id parameter in create_post to post under a team."
+        description = "List all teams the user belongs to with their role and permissions. Use team_id from the result as the team_id parameter in create_post to post under a team."
     )]
     async fn list_teams(&self) -> McpResult {
-        list_teams_impl(&self.user).await.into_mcp()
+        crate::features::social::controllers::get_user_teams_handler_mcp_handler(&self.mcp_secret).await
     }
 }
 
@@ -528,900 +553,6 @@ impl ServerHandler for RatelMcpServer {
     }
 }
 
-// ── Implementation helpers ──────────────────────────────────────────
-
-/// Resolve the user's role in a space. Simplified version for MCP context.
-/// Checks: creator (individual), team admin, space admin. Otherwise Viewer.
-async fn resolve_space_user_role(
-    cli: &aws_sdk_dynamodb::Client,
-    user: &User,
-    space: &SpaceCommon,
-) -> crate::common::Result<SpaceUserRole> {
-    // Direct creator check
-    if user.pk == space.user_pk {
-        return Ok(SpaceUserRole::Creator);
-    }
-
-    // Team admin check
-    if matches!(&space.user_pk, Partition::Team(_)) {
-        use crate::features::posts::types::TeamGroupPermission;
-        if Team::has_permission(
-            cli,
-            &space.user_pk,
-            &user.pk,
-            TeamGroupPermission::TeamAdmin,
-        )
-        .await
-        .unwrap_or(false)
-        {
-            return Ok(SpaceUserRole::Creator);
-        }
-    }
-
-    // Space admin check
-    let space_admin_sk = EntityType::SpaceAdmin(user.pk.to_string());
-    if SpaceAdmin::get(cli, &space.pk, Some(&space_admin_sk))
-        .await
-        .ok()
-        .flatten()
-        .is_some()
-    {
-        return Ok(SpaceUserRole::Creator);
-    }
-
-    Ok(SpaceUserRole::Viewer)
-}
-
-/// Fetch space and verify the user has creator role.
-async fn require_space_creator(
-    cli: &aws_sdk_dynamodb::Client,
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<SpaceCommon> {
-    let space_pk: Partition = space_id.into();
-    let space = SpaceCommon::get(cli, &space_pk, Some(&EntityType::SpaceCommon))
-        .await?
-        .ok_or_else(|| crate::common::Error::NotFound("Space not found".to_string()))?;
-    let role = resolve_space_user_role(cli, user, &space).await?;
-    if role != SpaceUserRole::Creator {
-        return Err(crate::common::Error::NoPermission);
-    }
-    Ok(space)
-}
-
-// ── get_space ───────────────────────────────────────────────────────
-
-async fn get_space_impl(
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let space_pk: Partition = space_id.into();
-    let space = SpaceCommon::get(cli, &space_pk, Some(&EntityType::SpaceCommon))
-        .await?
-        .ok_or_else(|| crate::common::Error::NotFound("Space not found".to_string()))?;
-
-    let post_pk = space.pk.clone().to_post_key()?;
-    let post = Post::get(cli, &post_pk, Some(EntityType::Post))
-        .await?
-        .ok_or_else(|| crate::common::Error::NotFound("Post not found".to_string()))?;
-
-    let permissions: i64 = post.get_permissions(cli, Some(user.clone())).await?.into();
-    let liked = post.is_liked(cli, &user.pk).await?;
-
-    let (participant_pk, participant_sk) =
-        SpaceParticipant::keys(space.pk.clone(), user.pk.clone());
-    let participant = SpaceParticipant::get(cli, &participant_pk, Some(&participant_sk)).await?;
-    let is_participation_open = space.is_participation_open();
-    let can_participate = participant.is_none() && is_participation_open;
-
-    let (participated, participant_display_name, participant_profile_url, participant_username) =
-        if let Some(p) = participant {
-            (
-                true,
-                Some(p.display_name),
-                Some(p.profile_url),
-                Some(p.username),
-            )
-        } else {
-            (false, None, None, None)
-        };
-
-    Ok(serde_json::json!({
-        "id": space.pk.to_string(),
-        "post_id": post_pk.to_string(),
-        "sk": space.sk.to_string(),
-        "title": post.title,
-        "content": if space.content.is_empty() { &post.html_contents } else { &space.content },
-        "created_at": space.created_at,
-        "updated_at": space.updated_at,
-        "status": format!("{:?}", space.status),
-        "permissions": permissions,
-        "author_display_name": post.author_display_name,
-        "author_username": post.author_username,
-        "author_profile_url": post.author_profile_url,
-        "likes": post.likes,
-        "comments": post.comments,
-        "shares": post.shares,
-        "liked": liked,
-        "reports": space.reports,
-        "rewards": space.rewards,
-        "visibility": format!("{:?}", space.visibility),
-        "publish_state": format!("{:?}", space.publish_state),
-        "anonymous_participation": space.anonymous_participation,
-        "join_anytime": space.join_anytime,
-        "can_participate": can_participate,
-        "participated": participated,
-        "participant_display_name": participant_display_name,
-        "participant_profile_url": participant_profile_url,
-        "participant_username": participant_username,
-        "remains": space.remains,
-        "quota": space.quota,
-        "logo": space.logo,
-    }))
-}
-
-// ── update_space ────────────────────────────────────────────────────
-
-async fn update_space_impl(
-    user: &User,
-    space_id: SpacePartition,
-    update: serde_json::Value,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let space = require_space_creator(cli, user, space_id.clone()).await?;
-    let req: UpdateSpaceRequest = serde_json::from_value(update)
-        .map_err(|_| crate::common::McpServerError::InvalidUpdateData)?;
-
-    let space_pk: Partition = space_id.into();
-    let now = chrono::Utc::now().timestamp_millis();
-    let mut su = SpaceCommon::updater(&space.pk, &space.sk).with_updated_at(now);
-    let mut pu: Option<_> = None;
-    let mut updated_space = space.clone();
-
-    match req {
-        UpdateSpaceRequest::Publish {
-            publish,
-            visibility,
-        } => {
-            let post_pk = space_pk.clone().to_post_key()?;
-            if !publish {
-                return Err(crate::common::McpServerError::UnpublishNotSupported.into());
-            }
-            su = su
-                .with_publish_state(crate::common::SpacePublishState::Published)
-                .with_status(crate::common::SpaceStatus::Open)
-                .with_visibility(visibility.clone());
-            let post_updater = Post::updater(post_pk, EntityType::Post)
-                .with_updated_at(now)
-                .with_space_visibility(visibility.clone())
-                .with_visibility(visibility.clone().into())
-                .with_status(PostStatus::Published);
-            pu = Some(post_updater);
-            updated_space.publish_state = crate::common::SpacePublishState::Published;
-            updated_space.visibility = visibility;
-        }
-        UpdateSpaceRequest::Visibility { visibility } => {
-            su = su.with_visibility(visibility.clone());
-            let post_pk = space_pk.clone().to_post_key()?;
-            let post_updater = Post::updater(post_pk, EntityType::Post)
-                .with_updated_at(now)
-                .with_space_visibility(visibility.clone())
-                .with_visibility(visibility.clone().into());
-            pu = Some(post_updater);
-            updated_space.visibility = visibility;
-        }
-        UpdateSpaceRequest::Content { content } => {
-            su = su.with_content(content.clone());
-            updated_space.content = content;
-        }
-        UpdateSpaceRequest::Title { title } => {
-            let post_pk = space_pk.clone().to_post_key()?;
-            let post_updater = Post::updater(post_pk, EntityType::Post)
-                .with_updated_at(now)
-                .with_title(title);
-            pu = Some(post_updater);
-        }
-        UpdateSpaceRequest::Start { start } => {
-            if updated_space.status != Some(crate::common::SpaceStatus::Open) {
-                return Err(crate::common::McpServerError::StartNotAvailable.into());
-            }
-            if !start {
-                return Err(crate::common::McpServerError::CannotUndoStart.into());
-            }
-            su = su.with_status(crate::common::SpaceStatus::Ongoing);
-            updated_space.status = Some(crate::common::SpaceStatus::Ongoing);
-        }
-        UpdateSpaceRequest::Finish { finished } => {
-            if updated_space.status != Some(crate::common::SpaceStatus::Ongoing) {
-                return Err(crate::common::McpServerError::FinishNotAvailable.into());
-            }
-            if !finished {
-                return Err(crate::common::McpServerError::CannotUndoFinish.into());
-            }
-            su = su.with_status(crate::common::SpaceStatus::Finished);
-            updated_space.status = Some(crate::common::SpaceStatus::Finished);
-        }
-        UpdateSpaceRequest::Anonymous {
-            anonymous_participation,
-        } => {
-            su = su.with_anonymous_participation(anonymous_participation);
-            updated_space.anonymous_participation = anonymous_participation;
-        }
-        UpdateSpaceRequest::JoinAnytime { join_anytime } => {
-            su = su.with_join_anytime(join_anytime);
-            updated_space.join_anytime = join_anytime;
-        }
-        UpdateSpaceRequest::ChangeVisibility { .. } => {
-            return Err(crate::common::McpServerError::DeprecatedOperation.into());
-        }
-        UpdateSpaceRequest::Logo { logo } => {
-            su = su.with_logo(logo.clone());
-            updated_space.logo = logo;
-        }
-        UpdateSpaceRequest::Quota { quotas } => {
-            let remains = updated_space.remains + (quotas - updated_space.quota);
-            if remains < 0 {
-                return Err(crate::common::McpServerError::InvalidPanelQuota.into());
-            }
-            su = su.with_quota(quotas).with_remains(remains);
-            updated_space.quota = quotas;
-            updated_space.remains = remains;
-        }
-    }
-
-    if let Some(pu) = pu {
-        crate::transact_write!(cli, su.transact_write_item(), pu.transact_write_item())?;
-    } else {
-        su.execute(cli).await?;
-    }
-
-    Ok(serde_json::json!({
-        "pk": updated_space.pk.to_string(),
-        "sk": updated_space.sk.to_string(),
-        "status": format!("{:?}", updated_space.status),
-        "publish_state": format!("{:?}", updated_space.publish_state),
-        "visibility": format!("{:?}", updated_space.visibility),
-        "content": updated_space.content,
-        "anonymous_participation": updated_space.anonymous_participation,
-        "join_anytime": updated_space.join_anytime,
-        "quota": updated_space.quota,
-        "remains": updated_space.remains,
-        "logo": updated_space.logo,
-    }))
-}
-
-// ── delete_space ────────────────────────────────────────────────────
-
-async fn delete_space_impl(
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let space_pk: Partition = space.pk.clone();
-    let post_pk = space_pk.clone().to_post_key()?;
-
-    SpaceCommon::delete(cli, &space.pk, Some(space.sk)).await?;
-    SpacePoll::delete_one(cli, &space_pk).await.ok();
-
-    if Post::get(cli, &post_pk, Some(EntityType::Post))
-        .await?
-        .is_some()
-    {
-        Post::updater(post_pk, EntityType::Post)
-            .remove_space_pk()
-            .remove_space_type()
-            .remove_space_visibility()
-            .execute(cli)
-            .await?;
-    }
-
-    Ok(serde_json::json!({
-        "message": format!("Space '{}' deleted", space_id)
-    }))
-}
-
-// ── create_poll ─────────────────────────────────────────────────────
-
-async fn create_poll_impl(
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let poll = SpacePoll::new(space_id.clone())?;
-    let space_action = SpaceAction::new(
-        space_id.clone(),
-        SpacePollEntityType::from(poll.sk.clone()).to_string(),
-        SpaceActionType::Poll,
-    );
-
-    let items = vec![
-        poll.create_transact_write_item(),
-        space_action.create_transact_write_item(),
-    ];
-    crate::transact_write_items!(cli, items)
-        .map_err(|e| crate::common::Error::Unknown(format!("Failed to create poll: {e}")))?;
-
-    Ok(serde_json::json!({
-        "pk": poll.pk.to_string(),
-        "sk": poll.sk.to_string(),
-        "message": "Poll created"
-    }))
-}
-
-// ── update_poll ─────────────────────────────────────────────────────
-
-async fn update_poll_impl(
-    user: &User,
-    space_id: SpacePartition,
-    poll_id: String,
-    update: serde_json::Value,
-) -> crate::common::Result<String> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    use crate::features::spaces::pages::actions::actions::poll::controllers::UpdatePollRequest;
-    let req: UpdatePollRequest = serde_json::from_value(update)
-        .map_err(|_| crate::common::McpServerError::InvalidUpdateData)?;
-
-    let space_pk: Partition = space_id.clone().into();
-    let poll_sk_type: SpacePollEntityType = poll_id.into();
-    let poll_sk: EntityType = poll_sk_type.clone().into();
-
-    let now = crate::common::utils::time::get_now_timestamp_millis();
-    let mut poll_updater = SpacePoll::updater(&space_pk, &poll_sk).with_updated_at(now);
-
-    let action_pk =
-        CompositePartition::<SpacePartition, String>(space_id, poll_sk_type.to_string());
-    let mut action_updater =
-        SpaceAction::updater(&action_pk, &EntityType::SpaceAction).with_updated_at(now);
-    let mut update_action = false;
-
-    match req {
-        UpdatePollRequest::Title { title } => {
-            poll_updater = poll_updater.with_title(title.clone());
-            action_updater = action_updater.with_title(title);
-            update_action = true;
-        }
-        UpdatePollRequest::Time {
-            started_at,
-            ended_at,
-        } => {
-            if started_at >= ended_at {
-                return Err(crate::common::McpServerError::InvalidTimeRange.into());
-            }
-            poll_updater = poll_updater
-                .with_started_at(started_at)
-                .with_ended_at(ended_at);
-        }
-        UpdatePollRequest::Question { questions } => {
-            if questions.is_empty() {
-                return Err(crate::common::McpServerError::EmptyQuestions.into());
-            }
-            let description = questions
-                .first()
-                .map(|q| q.title().to_string())
-                .unwrap_or_default();
-            poll_updater = poll_updater
-                .with_questions(questions)
-                .with_description(description.clone());
-            action_updater = action_updater.with_description(description);
-            update_action = true;
-        }
-        UpdatePollRequest::ResponseEditable { response_editable } => {
-            poll_updater = poll_updater.with_response_editable(response_editable);
-        }
-        UpdatePollRequest::CanisterUploadEnabled {
-            canister_upload_enabled,
-        } => {
-            poll_updater = poll_updater.with_canister_upload_enabled(canister_upload_enabled);
-            if canister_upload_enabled {
-                poll_updater = poll_updater.with_response_editable(false);
-            }
-        }
-    }
-
-    poll_updater.execute(cli).await?;
-    if update_action {
-        action_updater.execute(cli).await?;
-    }
-
-    Ok("success".to_string())
-}
-
-// ── delete_poll ─────────────────────────────────────────────────────
-
-async fn delete_poll_impl(
-    user: &User,
-    space_id: SpacePartition,
-    poll_id: String,
-) -> crate::common::Result<String> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let space_pk: Partition = space_id.into();
-    let poll_sk_type: SpacePollEntityType = poll_id.into();
-    let poll_sk: EntityType = poll_sk_type.into();
-
-    let _poll = SpacePoll::get(cli, &space_pk, Some(poll_sk.clone()))
-        .await?
-        .ok_or(crate::common::Error::NotFound("Poll not found".into()))?;
-
-    SpacePoll::delete(cli, &space_pk, Some(poll_sk)).await?;
-
-    Ok("success".to_string())
-}
-
-// ── create_quiz ─────────────────────────────────────────────────────
-
-async fn create_quiz_impl(
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let quiz = SpaceQuiz::new(space_id.clone())?;
-    let space_action = SpaceAction::new(
-        space_id.clone(),
-        SpaceQuizEntityType::from(quiz.sk.clone()).to_string(),
-        SpaceActionType::Quiz,
-    );
-    let items = vec![
-        quiz.create_transact_write_item(),
-        space_action.create_transact_write_item(),
-    ];
-    crate::transact_write_items!(cli, items)
-        .map_err(|e| crate::common::Error::Unknown(format!("Failed to create quiz: {e}")))?;
-
-    let quiz_id: SpaceQuizEntityType = match &quiz.sk {
-        EntityType::SpaceQuiz(id) => id.clone().into(),
-        _ => SpaceQuizEntityType::default(),
-    };
-    let answers = quiz
-        .questions
-        .iter()
-        .map(
-            crate::features::spaces::pages::actions::actions::quiz::QuizCorrectAnswer::for_question,
-        )
-        .collect::<Vec<_>>();
-    let answer = SpaceQuizAnswer::new(space_id, quiz_id, answers);
-    answer.create(cli).await?;
-
-    Ok(serde_json::json!({
-        "pk": quiz.pk.to_string(),
-        "sk": quiz.sk.to_string(),
-        "message": "Quiz created"
-    }))
-}
-
-// ── update_quiz ─────────────────────────────────────────────────────
-
-async fn update_quiz_impl(
-    user: &User,
-    space_id: SpacePartition,
-    quiz_id: String,
-    update: serde_json::Value,
-) -> crate::common::Result<String> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    use crate::features::spaces::pages::actions::actions::quiz::controllers::update_quiz::UpdateQuizRequest;
-    let req: UpdateQuizRequest = serde_json::from_value(update)
-        .map_err(|_| crate::common::McpServerError::InvalidUpdateData)?;
-
-    let space_pk: Partition = space_id.clone().into();
-    let quiz_sk_type: SpaceQuizEntityType = quiz_id.clone().into();
-    let quiz_sk: EntityType = quiz_sk_type.clone().into();
-
-    let _existing = SpaceQuiz::get(cli, &space_pk, Some(quiz_sk.clone()))
-        .await?
-        .ok_or(crate::common::Error::NotFound("Quiz not found".into()))?;
-
-    let now = crate::common::utils::time::get_now_timestamp_millis();
-    let mut updater = SpaceQuiz::updater(&space_pk, &quiz_sk).with_updated_at(now);
-    let action_pk = CompositePartition(space_id, quiz_sk_type.to_string());
-    let action_sk = EntityType::SpaceAction;
-    let mut action_updater = SpaceAction::updater(&action_pk, &action_sk).with_updated_at(now);
-    let mut should_update_action = false;
-
-    if let Some(title) = req.title {
-        action_updater = action_updater.with_title(title);
-        should_update_action = true;
-    }
-    if let Some(description) = req.description {
-        action_updater = action_updater.with_description(description);
-        should_update_action = true;
-    }
-    if req.started_at.is_some() || req.ended_at.is_some() {
-        let started_at = req
-            .started_at
-            .ok_or(crate::common::McpServerError::RequiredFieldMissing)?;
-        let ended_at = req
-            .ended_at
-            .ok_or(crate::common::McpServerError::RequiredFieldMissing)?;
-        if started_at >= ended_at {
-            return Err(crate::common::Error::BadRequest(
-                "Invalid time range".into(),
-            ));
-        }
-        action_updater = action_updater
-            .with_started_at(started_at)
-            .with_ended_at(ended_at);
-        should_update_action = true;
-    }
-    if let Some(retry_count) = req.retry_count {
-        updater = updater.with_retry_count(retry_count);
-    }
-    if let Some(questions) = req.questions {
-        updater = updater.with_questions(questions);
-    }
-    if let Some(pass_score) = req.pass_score {
-        updater = updater.with_pass_score(pass_score);
-    }
-    if let Some(mut files) = req.files {
-        for file in &mut files {
-            if file.id.is_empty() {
-                file.id = crate::common::uuid::Uuid::now_v7().to_string();
-            }
-        }
-        updater = updater.with_files(files);
-    }
-
-    updater.execute(cli).await?;
-    if should_update_action {
-        action_updater.execute(cli).await?;
-    }
-
-    if let Some(answers) = req.answers {
-        let answer_sk = EntityType::SpaceQuizAnswer(quiz_id);
-        let answer_updater = SpaceQuizAnswer::updater(&space_pk, &answer_sk)
-            .with_created_at(now)
-            .with_updated_at(now)
-            .with_space_pk(space_pk.clone())
-            .with_answers(answers);
-        answer_updater.execute(cli).await?;
-    }
-
-    Ok("success".to_string())
-}
-
-// ── create_discussion ───────────────────────────────────────────────
-
-async fn create_discussion_impl(
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let author = SpaceAuthor::from(user.clone());
-    let post = SpacePost::new(
-        space_id.clone(),
-        String::new(),
-        String::new(),
-        String::new(),
-        &author,
-        None,
-        None,
-    );
-
-    let space_action = SpaceAction::new(
-        space_id.clone(),
-        SpacePostEntityType::from(post.sk.clone()).to_string(),
-        SpaceActionType::TopicDiscussion,
-    );
-
-    let items = vec![
-        post.create_transact_write_item(),
-        space_action.create_transact_write_item(),
-    ];
-    crate::transact_write_items!(cli, items)
-        .map_err(|e| crate::common::Error::Unknown(format!("Failed to create discussion: {e}")))?;
-
-    Ok(serde_json::json!({
-        "pk": post.pk.to_string(),
-        "sk": post.sk.to_string(),
-        "message": "Discussion created"
-    }))
-}
-
-// ── update_discussion ───────────────────────────────────────────────
-
-async fn update_discussion_impl(
-    user: &User,
-    space_id: SpacePartition,
-    discussion_id: String,
-    update: serde_json::Value,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    use crate::features::spaces::pages::actions::actions::discussion::controllers::UpdateDiscussionRequest;
-    let req: UpdateDiscussionRequest = serde_json::from_value(update)
-        .map_err(|_| crate::common::McpServerError::InvalidUpdateData)?;
-
-    let space_pk: Partition = space_id.clone().into();
-    let discussion_sk_type: SpacePostEntityType = discussion_id.into();
-    let discussion_sk: EntityType = discussion_sk_type.clone().into();
-
-    let now = crate::common::utils::time::get_now_timestamp_millis();
-    let mut updater = SpacePost::updater(&space_pk, &discussion_sk).with_updated_at(now);
-
-    let action_pk = CompositePartition::<SpacePartition, String>(
-        space_id.clone(),
-        discussion_sk_type.to_string(),
-    );
-    let mut action_updater =
-        SpaceAction::updater(&action_pk, &EntityType::SpaceAction).with_updated_at(now);
-    let mut update_action = false;
-
-    if let Some(title) = req.title {
-        updater = updater.with_title(title.clone());
-        action_updater = action_updater.with_title(title);
-        update_action = true;
-    }
-    if let Some(html_contents) = req.html_contents {
-        updater = updater.with_html_contents(html_contents.clone());
-        action_updater = action_updater.with_description(html_contents);
-        update_action = true;
-    }
-    if let Some(ref category_name) = req.category_name {
-        updater = updater.with_category_name(category_name.clone());
-    }
-    if let Some(started_at) = req.started_at {
-        updater = updater.with_started_at(started_at);
-    }
-    if let Some(ended_at) = req.ended_at {
-        updater = updater.with_ended_at(ended_at);
-    }
-
-    let updated_post = updater.execute(cli).await?;
-
-    if update_action {
-        action_updater.execute(cli).await?;
-    }
-
-    if let Some(category_name) = req.category_name {
-        if !category_name.is_empty() {
-            let cat = SpaceCategory::new(space_id, category_name);
-            let _ = cat.upsert(cli).await;
-        }
-    }
-
-    Ok(serde_json::json!({
-        "pk": updated_post.pk.to_string(),
-        "sk": updated_post.sk.to_string(),
-        "message": "Discussion updated"
-    }))
-}
-
-// ── delete_discussion ───────────────────────────────────────────────
-
-async fn delete_discussion_impl(
-    user: &User,
-    space_id: SpacePartition,
-    discussion_id: String,
-) -> crate::common::Result<String> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let space_pk: Partition = space_id.into();
-    let discussion_sk_type: SpacePostEntityType = discussion_id.into();
-    let discussion_sk: EntityType = discussion_sk_type.into();
-
-    SpacePost::delete(cli, &space_pk, Some(discussion_sk)).await?;
-
-    Ok("success".to_string())
-}
-
-// ── create_follow ───────────────────────────────────────────────────
-
-async fn create_follow_impl(
-    user: &User,
-    space_id: SpacePartition,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let pk: Partition = space_id.clone().into();
-    let sk = EntityType::SpaceSubscription;
-
-    if let Some(existing) = SpaceFollowAction::get(cli, &pk, Some(sk.clone())).await? {
-        return Ok(serde_json::json!({
-            "pk": existing.pk.to_string(),
-            "sk": existing.sk.to_string(),
-            "message": "Follow action already exists"
-        }));
-    }
-
-    let follow = SpaceFollowAction::new(space_id.clone());
-    let mut space_action = SpaceAction::new(
-        space_id.clone(),
-        SpaceActionFollowEntityType::from(follow.sk.clone()).to_string(),
-        SpaceActionType::Follow,
-    );
-    space_action.title = if space.author_display_name.is_empty() {
-        space.author_username
-    } else {
-        space.author_display_name
-    };
-    let items = vec![
-        follow.create_transact_write_item(),
-        space_action.create_transact_write_item(),
-    ];
-    crate::transact_write_items!(cli, items)
-        .map_err(|e| crate::common::Error::Unknown(format!("Failed to create follow: {e}")))?;
-
-    Ok(serde_json::json!({
-        "pk": follow.pk.to_string(),
-        "sk": follow.sk.to_string(),
-        "message": "Follow action created"
-    }))
-}
-
-// ── install_space_app ───────────────────────────────────────────────
-
-async fn install_space_app_impl(
-    user: &User,
-    space_id: SpacePartition,
-    app_type_str: &str,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let space_pk_partition: Partition = space_id.into();
-    let sk = EntityType::SpaceApp(app_type_str.to_string());
-    let now = crate::common::utils::time::get_now_timestamp_millis();
-
-    // Build the item attributes directly since SpaceApp/SpaceAppType are in private modules.
-    use aws_sdk_dynamodb::types::AttributeValue;
-    let table = crate::common::models::space::SpaceCommon::table_name();
-    cli.put_item()
-        .table_name(table)
-        .item("pk", AttributeValue::S(space_pk_partition.to_string()))
-        .item("sk", AttributeValue::S(sk.to_string()))
-        .item("app_type", AttributeValue::S(app_type_str.to_string()))
-        .item("created_at", AttributeValue::N(now.to_string()))
-        .item("updated_at", AttributeValue::N(now.to_string()))
-        .send()
-        .await
-        .map_err(|e| crate::common::Error::Unknown(format!("Failed to install app: {e}")))?;
-
-    Ok(serde_json::json!({
-        "pk": space_pk_partition.to_string(),
-        "sk": sk.to_string(),
-        "app_type": app_type_str,
-        "message": "App installed"
-    }))
-}
-
-// ── uninstall_space_app ─────────────────────────────────────────────
-
-async fn uninstall_space_app_impl(
-    user: &User,
-    space_id: SpacePartition,
-    app_type_str: &str,
-) -> crate::common::Result<serde_json::Value> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-    let _space = require_space_creator(cli, user, space_id.clone()).await?;
-
-    let space_pk_partition: Partition = space_id.into();
-    let sk = EntityType::SpaceApp(app_type_str.to_string());
-    let table = crate::common::models::space::SpaceCommon::table_name();
-
-    cli.delete_item()
-        .table_name(table)
-        .key(
-            "pk",
-            aws_sdk_dynamodb::types::AttributeValue::S(space_pk_partition.to_string()),
-        )
-        .key(
-            "sk",
-            aws_sdk_dynamodb::types::AttributeValue::S(sk.to_string()),
-        )
-        .send()
-        .await
-        .map_err(|e| crate::common::Error::Unknown(format!("Failed to uninstall app: {e}")))?;
-
-    Ok(serde_json::json!({
-        "app_type": app_type_str,
-        "message": "App uninstalled"
-    }))
-}
-
-// ── list_teams ──────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct McpTeamItem {
-    team_id: String,
-    nickname: String,
-    username: String,
-    profile_url: String,
-    description: String,
-    permissions: Vec<String>,
-}
-
-fn permission_name(p: crate::features::posts::types::TeamGroupPermission) -> &'static str {
-    use crate::features::posts::types::TeamGroupPermission;
-    match p {
-        TeamGroupPermission::PostRead => "PostRead",
-        TeamGroupPermission::PostWrite => "PostWrite",
-        TeamGroupPermission::PostEdit => "PostEdit",
-        TeamGroupPermission::PostDelete => "PostDelete",
-        TeamGroupPermission::SpaceRead => "SpaceRead",
-        TeamGroupPermission::SpaceWrite => "SpaceWrite",
-        TeamGroupPermission::SpaceEdit => "SpaceEdit",
-        TeamGroupPermission::SpaceDelete => "SpaceDelete",
-        TeamGroupPermission::TeamAdmin => "TeamAdmin",
-        TeamGroupPermission::TeamEdit => "TeamEdit",
-        TeamGroupPermission::GroupEdit => "GroupEdit",
-        TeamGroupPermission::ManagePromotions => "ManagePromotions",
-        TeamGroupPermission::ManageNews => "ManageNews",
-    }
-}
-
-async fn list_teams_impl(user: &User) -> crate::common::Result<Vec<McpTeamItem>> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-
-    let sk_prefix = "UserTeam".to_string();
-    let opt = UserTeamQueryOption::builder().sk(sk_prefix);
-    let (user_teams, _): (Vec<UserTeam>, _) = UserTeam::query(cli, &user.pk, opt).await?;
-
-    let mut items = Vec::new();
-    for ut in user_teams {
-        let team_pk = match ut.sk.clone() {
-            EntityType::UserTeam(team_pk) => team_pk,
-            _ => continue,
-        };
-
-        let team_pk_partition: Partition = team_pk.parse().unwrap_or_default();
-        let perms = Team::get_permissions_by_team_pk(cli, &team_pk_partition, &user.pk)
-            .await
-            .unwrap_or_else(|_| crate::features::posts::types::TeamGroupPermissions::empty());
-        let description = Team::get(cli, &team_pk_partition, Some(EntityType::Team))
-            .await
-            .ok()
-            .flatten()
-            .map(|team| team.description)
-            .unwrap_or_default();
-
-        items.push(McpTeamItem {
-            team_id: team_pk,
-            nickname: ut.display_name,
-            username: ut.username,
-            profile_url: ut.profile_url,
-            description,
-            permissions: perms
-                .0
-                .into_iter()
-                .map(|p| permission_name(p).to_string())
-                .collect(),
-        });
-    }
-
-    Ok(items)
-}
-
 // ── Route Setup ─────────────────────────────────────────────────────
 
 type McpService = StreamableHttpService<RatelMcpServer, LocalSessionManager>;
@@ -1437,7 +568,6 @@ const MCP_CACHE_TTL_SECS: i64 = 3600;
 struct CachedMcpService {
     service: McpService,
     created_at: i64,
-    user_pk: crate::common::types::Partition,
 }
 
 /// Global cache of MCP services keyed by hashed client_secret.
@@ -1447,26 +577,10 @@ struct CachedMcpService {
 static MCP_SERVICES: std::sync::LazyLock<RwLock<HashMap<String, CachedMcpService>>> =
     std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
 
-/// Resolve a user from the client secret stored in DynamoDB.
-/// The incoming `client_secret` is the raw token; we hash it before lookup.
-async fn resolve_user(client_secret: &str) -> Option<User> {
-    let conf = ServerConfig::default();
-    let cli = conf.dynamodb();
-
-    let hashed = McpClientSecret::hash_secret(client_secret);
-    let opt = McpClientSecret::opt().limit(1);
-    let (secrets, _) = McpClientSecret::find_by_secret(cli, &hashed, opt)
-        .await
-        .ok()?;
-
-    let secret = secrets.first()?;
-    User::get(cli, &secret.pk, Some(EntityType::User))
-        .await
-        .ok()?
-}
-
 /// Get or create a cached MCP service for the given raw client_secret.
-async fn get_or_create_service(client_secret: &str) -> Option<McpService> {
+/// Auth validation happens later during oneshot via the User extractor's
+/// McpSecret support (see `extract_user_from_mcp_secret` in user.rs).
+async fn get_or_create_service(client_secret: &str) -> McpService {
     let hashed_key = McpClientSecret::hash_secret(client_secret);
     let now = chrono::Utc::now().timestamp();
 
@@ -1475,17 +589,14 @@ async fn get_or_create_service(client_secret: &str) -> Option<McpService> {
         let cache = MCP_SERVICES.read().await;
         if let Some(entry) = cache.get(&hashed_key) {
             if now - entry.created_at < MCP_CACHE_TTL_SECS {
-                return Some(entry.service.clone());
+                return entry.service.clone();
             }
         }
     }
 
-    // Slow path: resolve user and create service
-    let user = resolve_user(client_secret).await?;
-
-    let user_pk = user.pk.clone();
+    let secret = client_secret.to_string();
     let service = StreamableHttpService::new(
-        move || RatelMcpServer::new(user.clone()),
+        move || RatelMcpServer::new(secret.clone()),
         Arc::new(LocalSessionManager::default()),
         Default::default(),
     );
@@ -1513,21 +624,24 @@ async fn get_or_create_service(client_secret: &str) -> Option<McpService> {
         CachedMcpService {
             service: service.clone(),
             created_at: now,
-            user_pk,
         },
     );
-    Some(service)
+    service
 }
 
-/// Invalidate all cached MCP services for a given user partition key.
-/// Called when a user regenerates their secret.
+/// Invalidate cached MCP service when a user regenerates their secret.
 pub async fn invalidate_user_services(user_pk: &crate::common::types::Partition) {
-    let mut cache = MCP_SERVICES.write().await;
-    cache.retain(|_, entry| &entry.user_pk != user_pk);
+    let conf = ServerConfig::default();
+    let cli = conf.dynamodb();
+    if let Ok(Some(secret)) =
+        McpClientSecret::get(cli, user_pk, Some(EntityType::McpClientSecret)).await
+    {
+        let mut cache = MCP_SERVICES.write().await;
+        cache.remove(&secret.secret);
+    }
 }
 
 /// Build the axum router for the MCP endpoint.
-/// The MCP service is mounted at `/mcp/{client_secret}`.
 pub fn mcp_router() -> Router {
     Router::new().route("/mcp/{client_secret}", axum::routing::any(mcp_handler))
 }
@@ -1536,12 +650,7 @@ async fn mcp_handler(
     axum::extract::Path(client_secret): axum::extract::Path<String>,
     request: axum::http::Request<axum::body::Body>,
 ) -> axum::response::Response {
-    let Some(service) = get_or_create_service(&client_secret).await else {
-        return axum::response::Response::builder()
-            .status(401)
-            .body(axum::body::Body::from("Invalid client secret"))
-            .unwrap();
-    };
+    let service = get_or_create_service(&client_secret).await;
 
     let resp = service.handle(request).await;
     let (parts, body) = resp.into_parts();

--- a/app/ratel/src/common/models/auth/user.rs
+++ b/app/ratel/src/common/models/auth/user.rs
@@ -132,6 +132,33 @@ impl User {
 pub const SESSION_KEY_USER_ID: &str = "user_id";
 
 #[cfg(feature = "server")]
+async fn extract_user_from_mcp_secret(parts: &Parts) -> Option<User> {
+    let auth_header = parts.headers.get("authorization")?.to_str().ok()?;
+    if !auth_header.starts_with("McpSecret") {
+        return None;
+    }
+
+    let raw_secret = auth_header.strip_prefix("McpSecret ")?;
+    if raw_secret.is_empty() {
+        return None;
+    }
+
+    let conf = ServerConfig::default();
+    let cli = conf.dynamodb();
+
+    let hashed = crate::common::models::McpClientSecret::hash_secret(raw_secret);
+    let opt = crate::common::models::McpClientSecret::opt().limit(1);
+    let (secrets, _) = crate::common::models::McpClientSecret::find_by_secret(cli, &hashed, opt)
+        .await
+        .ok()?;
+
+    let secret = secrets.first()?;
+    User::get(cli, &secret.pk, Some(EntityType::User))
+        .await
+        .ok()?
+}
+
+#[cfg(feature = "server")]
 async fn extract_user_from_parts<S>(parts: &mut Parts, state: &S) -> Result<User>
 where
     S: Send + Sync,
@@ -139,6 +166,12 @@ where
 {
     if let Some(user) = parts.extensions.get::<User>() {
         return Ok(user.clone());
+    }
+
+    // Try MCP secret auth first: Authorization: McpSecret {secret}
+    if let Some(user) = extract_user_from_mcp_secret(parts).await {
+        parts.extensions.insert(user.clone());
+        return Ok(user);
     }
 
     let conf = ServerConfig::default();

--- a/app/ratel/src/common/run.rs
+++ b/app/ratel/src/common/run.rs
@@ -32,6 +32,8 @@ fn serve(app: fn() -> Element) {
         .merge(membership_router);
     let app = dioxus_router.layer(session_layer);
 
+    crate::common::mcp::set_app_router(app.clone());
+
     #[cfg(not(feature = "lambda"))]
     {
         #[cfg(feature = "local-dev")]

--- a/app/ratel/src/features/ai_moderator/controllers/update_ai_moderator_config.rs
+++ b/app/ratel/src/features/ai_moderator/controllers/update_ai_moderator_config.rs
@@ -3,6 +3,7 @@ use crate::features::ai_moderator::*;
 use super::get_ai_moderator_config::AiModeratorConfigResponse;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub struct UpdateAiModeratorConfigRequest {
     pub enabled: bool,
     pub reply_interval: i64,
@@ -10,10 +11,14 @@ pub struct UpdateAiModeratorConfigRequest {
     pub guidelines: String,
 }
 
+#[mcp_tool(name = "update_ai_moderator", description = "Configure AI moderator for a discussion. Sets enabled state, reply interval, and guidelines. Requires creator role and premium membership.")]
 #[post("/api/spaces/{space_id}/discussions/{discussion_id}/ai-moderator", role: SpaceUserRole, user: crate::features::auth::User)]
 pub async fn update_ai_moderator_config(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
     discussion_id: SpaceDiscussionEntityType,
+    #[mcp(description = "AI moderator config: {\"enabled\": bool, \"reply_interval\": int, \"guidelines\": \"text\"}")]
     req: UpdateAiModeratorConfigRequest,
 ) -> Result<AiModeratorConfigResponse> {
     role.is_creator()?;

--- a/app/ratel/src/features/social/controllers/team.rs
+++ b/app/ratel/src/features/social/controllers/team.rs
@@ -71,17 +71,11 @@ pub async fn create_team_handler(body: CreateTeamRequest) -> crate::features::so
     })
 }
 
-#[post("/api/user-shell/teams/list", session: Extension<tower_sessions::Session>)]
+#[mcp_tool(name = "list_teams", description = "List all teams the user belongs to with their role and permissions. Use team_id from the result as the team_id parameter in create_post to post under a team.")]
+#[post("/api/user-shell/teams/list", user: crate::features::auth::User)]
 pub async fn get_user_teams_handler() -> crate::features::social::Result<Vec<crate::common::contexts::TeamItem>> {
-    let Extension(session) = session;
-    let user_pk: String = session
-        .get::<String>("user_id")
-        .await
-        .map_err(|e| crate::features::social::Error::Unauthorized(e.to_string()))?
-        .ok_or(crate::features::social::Error::Unauthorized("no session".to_string()))?;
-
     let cli = crate::features::social::config::get().dynamodb();
-    let user_pk: crate::common::types::Partition = user_pk.parse().unwrap_or_default();
+    let user_pk = user.pk.clone();
 
     let sk_prefix = "UserTeam".to_string();
     let opt = crate::features::auth::UserTeamQueryOption::builder().sk(sk_prefix);

--- a/app/ratel/src/features/spaces/mod.rs
+++ b/app/ratel/src/features/spaces/mod.rs
@@ -6,7 +6,7 @@ mod hooks;
 mod layout;
 mod models;
 pub mod pages;
-mod space_common;
+pub(crate) mod space_common;
 
 pub use layout::SpaceLayout;
 pub use space_common::{InvitationStatus, SpaceInvitationMember};

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/add_comment.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/add_comment.rs
@@ -5,14 +5,19 @@ use crate::features::spaces::pages::actions::models::SpaceAction;
 use crate::features::spaces::space_common::models::space_reward::SpaceReward;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub struct AddCommentRequest {
     pub content: String,
 }
 
+#[mcp_tool(name = "add_comment", description = "Add a comment to a discussion. Requires participant role and discussion in progress.")]
 #[post("/api/spaces/{space_id}/discussions/{discussion_sk}/comments", role: SpaceUserRole, author: SpaceAuthor, space: SpaceCommon, user: crate::features::auth::User )]
 pub async fn add_comment(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
     discussion_sk: SpacePostEntityType,
+    #[mcp(description = "Comment content as JSON: {\"content\": \"text\"}")]
     req: AddCommentRequest,
 ) -> Result<DiscussionCommentResponse> {
     SpacePost::can_view(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/list_comments.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/list_comments.rs
@@ -4,10 +4,14 @@ use crate::features::auth::OptionalUser;
 use crate::features::spaces::pages::actions::actions::discussion::*;
 use std::collections::HashSet;
 
+#[mcp_tool(name = "list_comments", description = "List comments on a discussion, sorted by likes. Supports pagination.")]
 #[get("/api/spaces/{space_id}/discussions/{discussion_sk}/comments?bookmark", role: SpaceUserRole, user: OptionalUser)]
 pub async fn list_comments(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
     discussion_sk: SpacePostEntityType,
+    #[mcp(description = "Pagination bookmark. Omit for first page.")]
     bookmark: Option<String>,
 ) -> Result<ListResponse<DiscussionCommentResponse>> {
     SpacePost::can_view(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/create_discussion.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/create_discussion.rs
@@ -1,7 +1,11 @@
 use crate::features::spaces::pages::actions::actions::discussion::*;
 
+#[mcp_tool(name = "create_discussion", description = "Create a new discussion in a space.")]
 #[post("/api/spaces/{space_id}/discussions", role: SpaceUserRole, author: crate::common::models::space::SpaceAuthor)]
-pub async fn create_discussion(space_id: SpacePartition) -> Result<SpacePost> {
+pub async fn create_discussion(
+    #[mcp(description = "Space partition key (e.g. 'SPACE#<uuid>')")]
+    space_id: SpacePartition,
+) -> Result<SpacePost> {
     SpacePost::can_edit(&role)?;
     let common_config = crate::common::CommonConfig::default();
     let cli = common_config.dynamodb();

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/delete_discussion.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/delete_discussion.rs
@@ -1,9 +1,12 @@
 use crate::features::spaces::pages::actions::actions::discussion::*;
 use crate::features::spaces::space_common::models::aggregate::DashboardAggregate;
 
+#[mcp_tool(name = "delete_discussion", description = "Delete a discussion from a space. Requires creator role.")]
 #[delete("/api/spaces/{space_id}/discussions/{discussion_sk}", role: SpaceUserRole)]
 pub async fn delete_discussion(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
     discussion_sk: SpacePostEntityType,
 ) -> Result<()> {
     SpacePost::can_edit(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/get_discussion.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/get_discussion.rs
@@ -1,8 +1,11 @@
 use crate::features::spaces::pages::actions::actions::discussion::*;
 
+#[mcp_tool(name = "get_discussion", description = "Get discussion details by ID.")]
 #[get("/api/spaces/{space_id}/discussions/{discussion_sk}", role: SpaceUserRole)]
 pub async fn get_discussion(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
     discussion_sk: SpacePostEntityType,
 ) -> Result<SpacePost> {
     SpacePost::can_view(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/update_discussion.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/discussions/update_discussion.rs
@@ -2,6 +2,7 @@ use crate::features::spaces::pages::actions::actions::discussion::*;
 use crate::features::spaces::pages::actions::models::SpaceAction;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub struct UpdateDiscussionRequest {
     #[serde(default)]
     pub title: Option<String>,
@@ -15,10 +16,14 @@ pub struct UpdateDiscussionRequest {
     pub ended_at: Option<i64>,
 }
 
+#[mcp_tool(name = "update_discussion", description = "Update a discussion (title, html_contents, category_name, started_at, ended_at). Requires creator role.")]
 #[patch("/api/spaces/{space_id}/discussions/{discussion_sk}", role: SpaceUserRole)]
 pub async fn update_discussion(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Discussion sort key (e.g. 'SpacePost#<uuid>')")]
     discussion_sk: SpacePostEntityType,
+    #[mcp(description = "Discussion update data as JSON. Fields: title, html_contents, category_name, started_at, ended_at (all optional)")]
     req: UpdateDiscussionRequest,
 ) -> Result<SpacePost> {
     SpacePost::can_edit(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/views/main/creator/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/views/main/creator/i18n.rs
@@ -12,7 +12,7 @@ translate! {
         ko: "개요",
     },
     tab_setting: {
-        en: "Setting",
+        en: "Settings",
         ko: "설정",
     },
     title_label: {

--- a/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/create_follow.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/create_follow.rs
@@ -2,13 +2,17 @@ use crate::common::models::space::SpaceCommon;
 use crate::features::spaces::pages::actions::actions::follow::models::*;
 use crate::features::spaces::pages::actions::actions::follow::*;
 
+#[mcp_tool(name = "create_follow", description = "Create a follow action in a space. Requires creator role.")]
 #[post(
     "/api/spaces/{space_pk}/follows",
     role: SpaceUserRole,
     user: crate::features::auth::User,
     space: SpaceCommon
 )]
-pub async fn create_follow(space_pk: SpacePartition) -> Result<SpaceFollowAction> {
+pub async fn create_follow(
+    #[mcp(description = "Space partition key")]
+    space_pk: SpacePartition,
+) -> Result<SpaceFollowAction> {
     SpaceFollowAction::can_edit(&role)?;
     let common_config = crate::common::CommonConfig::default();
     let cli = common_config.dynamodb();

--- a/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/follow_user.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/follow_user.rs
@@ -6,6 +6,7 @@ use crate::features::spaces::pages::actions::actions::follow::*;
 #[cfg(feature = "server")]
 use crate::features::spaces::space_common::models::space_reward::SpaceReward;
 
+#[mcp_tool(name = "follow_user", description = "Follow a user as part of a space follow action. Requires participant role.")]
 #[post(
     "/api/spaces/{space_id}/follows/{follow_id}/user",
     role: SpaceUserRole,
@@ -13,8 +14,11 @@ use crate::features::spaces::space_common::models::space_reward::SpaceReward;
     space: SpaceCommon
 )]
 pub async fn follow_user(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Follow action sort key (e.g. 'SpaceActionFollow#<uuid>')")]
     follow_id: SpaceActionFollowEntityType,
+    #[mcp(description = "Target user partition key to follow (e.g. 'USER#<uuid>')")]
     target_pk: Partition,
 ) -> Result<()> {
     let common_config = crate::common::CommonConfig::default();

--- a/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/get_follow.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/get_follow.rs
@@ -1,9 +1,12 @@
 use crate::features::spaces::pages::actions::actions::follow::*;
 use crate::features::spaces::pages::actions::models::SpaceAction;
 
+#[mcp_tool(name = "get_follow", description = "Get follow action details including the target user to follow.")]
 #[get("/api/spaces/{space_pk}/follows/{follow_id}", role: SpaceUserRole)]
 pub async fn get_follow(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Follow action sort key (e.g. 'SpaceActionFollow#<uuid>')")]
     follow_id: SpaceActionFollowEntityType,
 ) -> Result<SpaceAction> {
     let common_config = crate::common::CommonConfig::default();

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/create_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/create_poll.rs
@@ -2,8 +2,12 @@ use crate::features::spaces::pages::actions::actions::poll::*;
 use crate::features::spaces::pages::actions::models::SpaceAction;
 use crate::features::spaces::space_common::models::aggregate::DashboardAggregate;
 
+#[mcp_tool(name = "create_poll", description = "Create a new poll action in a space. Requires creator role.")]
 #[post("/api/spaces/{space_pk}/polls", role: SpaceUserRole)]
-pub async fn create_poll(space_pk: SpacePartition) -> Result<PollResponse> {
+pub async fn create_poll(
+    #[mcp(description = "Space partition key")]
+    space_pk: SpacePartition,
+) -> Result<PollResponse> {
     SpacePoll::can_edit(&role)?;
     let common_config = crate::common::CommonConfig::default();
     let cli = common_config.dynamodb();

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/delete_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/delete_poll.rs
@@ -1,8 +1,14 @@
 use crate::features::spaces::pages::actions::actions::poll::*;
 use crate::features::spaces::space_common::models::aggregate::DashboardAggregate;
 
+#[mcp_tool(name = "delete_poll", description = "Delete a poll from a space. Requires creator role.")]
 #[delete("/api/spaces/{space_pk}/polls/{poll_sk}", role: SpaceUserRole)]
-pub async fn delete_poll(space_pk: SpacePartition, poll_sk: SpacePollEntityType) -> Result<String> {
+pub async fn delete_poll(
+    #[mcp(description = "Space partition key")]
+    space_pk: SpacePartition,
+    #[mcp(description = "Poll sort key (e.g. 'SpacePoll#<uuid>')")]
+    poll_sk: SpacePollEntityType,
+) -> Result<String> {
     SpacePoll::can_edit(&role)?;
     let common_config = crate::common::CommonConfig::default();
     let cli = common_config.dynamodb();

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/get_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/get_poll.rs
@@ -2,9 +2,12 @@ use crate::features::auth::OptionalUser;
 
 use crate::features::spaces::pages::actions::actions::poll::*;
 
+#[mcp_tool(name = "get_poll", description = "Get poll details including questions and the current user's response.")]
 #[get("/api/spaces/{space_pk}/polls/{poll_sk}", role: SpaceUserRole, user: OptionalUser)]
 pub async fn get_poll(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Poll sort key (e.g. 'SpacePoll#<uuid>')")]
     poll_sk: SpacePollEntityType,
 ) -> Result<PollResponse> {
     SpacePoll::can_view(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/respond_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/respond_poll.rs
@@ -5,6 +5,7 @@ use crate::features::spaces::pages::actions::models::SpaceAction;
 use crate::features::spaces::space_common::models::space_reward::SpaceReward;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub struct RespondPollRequest {
     pub answers: Vec<Answer>,
 }
@@ -122,10 +123,14 @@ async fn get_respondent_from_panels(
     ))
 }
 
+#[mcp_tool(name = "respond_poll", description = "Submit answers to a poll. Requires participant role and space in Ongoing status.")]
 #[post("/api/spaces/{space_pk}/polls/{poll_sk}/respond", role: SpaceUserRole, author: SpaceAuthor, space: SpaceCommon, user: crate::features::auth::User)]
 pub async fn respond_poll(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Poll sort key (e.g. 'SpacePoll#<uuid>')")]
     poll_sk: SpacePollEntityType,
+    #[mcp(description = "Poll answers. Each answer: {\"answer_type\": \"single_choice\", \"answer\": <index>} or {\"answer_type\": \"multiple_choice\", \"answer\": [<indices>]}")]
     req: RespondPollRequest,
 ) -> Result<RespondPollResponse> {
     let common_config = crate::common::CommonConfig::default();

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/update_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/update_poll.rs
@@ -2,6 +2,7 @@ use crate::features::spaces::pages::actions::actions::poll::*;
 use crate::features::spaces::pages::actions::models::SpaceAction;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum UpdatePollRequest {
     Title { title: String },
@@ -11,10 +12,14 @@ pub enum UpdatePollRequest {
     CanisterUploadEnabled { canister_upload_enabled: bool },
 }
 
+#[mcp_tool(name = "update_poll", description = "Update a poll (title, time range, questions, response_editable). Requires creator role.")]
 #[post("/api/spaces/{space_pk}/polls/{poll_sk}", role: SpaceUserRole)]
 pub async fn update_poll(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Poll sort key (e.g. 'SpacePoll#<uuid>')")]
     poll_sk: SpacePollEntityType,
+    #[mcp(description = "Poll update data as JSON. Supported variants: {\"title\": \"...\"}, {\"started_at\": <ms>, \"ended_at\": <ms>}, {\"questions\": [...]}, {\"response_editable\": true}")]
     req: UpdatePollRequest,
 ) -> Result<String> {
     SpacePoll::can_edit(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/create_quiz.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/create_quiz.rs
@@ -1,7 +1,11 @@
 use crate::features::spaces::pages::actions::actions::quiz::*;
 
+#[mcp_tool(name = "create_quiz", description = "Create a new quiz action in a space. Requires creator role.")]
 #[post("/api/spaces/{space_pk}/quizzes", role: SpaceUserRole)]
-pub async fn create_quiz(space_pk: SpacePartition) -> Result<QuizResponse> {
+pub async fn create_quiz(
+    #[mcp(description = "Space partition key")]
+    space_pk: SpacePartition,
+) -> Result<QuizResponse> {
     SpaceQuiz::can_edit(&role)?;
     let common_config = crate::common::CommonConfig::default();
     let cli = common_config.dynamodb();

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/get_quiz.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/get_quiz.rs
@@ -2,9 +2,12 @@ use crate::features::auth::OptionalUser;
 
 use crate::features::spaces::pages::actions::actions::quiz::*;
 
+#[mcp_tool(name = "get_quiz", description = "Get quiz details including questions, attempt count, and the current user's score.")]
 #[get("/api/spaces/{space_pk}/quizzes/{quiz_id}", role: SpaceUserRole, user: OptionalUser)]
 pub async fn get_quiz(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Quiz sort key (e.g. 'SpaceQuiz#<uuid>')")]
     quiz_id: SpaceQuizEntityType,
 ) -> Result<QuizResponse> {
     SpaceQuiz::can_view(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/respond_quiz.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/respond_quiz.rs
@@ -4,10 +4,12 @@ use crate::features::spaces::pages::actions::actions::quiz::*;
 use crate::features::spaces::space_common::models::space_reward::SpaceReward;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub struct RespondQuizRequest {
     pub answers: Vec<Answer>,
 }
 
+#[mcp_tool(name = "respond_quiz", description = "Submit answers to a quiz. Requires participant role. Returns score.")]
 #[post(
     "/api/spaces/{space_pk}/quizzes/{quiz_id}/respond",
     role: SpaceUserRole,
@@ -16,8 +18,11 @@ pub struct RespondQuizRequest {
     space: SpaceCommon
 )]
 pub async fn respond_quiz(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Quiz sort key (e.g. 'SpaceQuiz#<uuid>')")]
     quiz_id: SpaceQuizEntityType,
+    #[mcp(description = "Quiz answers. Each answer: {\"answer_type\": \"single_choice\", \"answer\": <index>} or {\"answer_type\": \"multiple_choice\", \"answer\": [<indices>]}")]
     req: RespondQuizRequest,
 ) -> Result<()> {
     let common_config = crate::common::CommonConfig::default();

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/update_quiz.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/update_quiz.rs
@@ -1,6 +1,7 @@
 use crate::features::spaces::pages::actions::actions::quiz::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub struct UpdateQuizRequest {
     #[serde(default)]
     pub title: Option<String>,
@@ -22,10 +23,14 @@ pub struct UpdateQuizRequest {
     pub files: Option<Vec<File>>,
 }
 
+#[mcp_tool(name = "update_quiz", description = "Update a quiz (title, description, time, questions, answers, pass_score, retry_count, files). Requires creator role.")]
 #[post("/api/spaces/{space_pk}/quizzes/{quiz_id}", role: SpaceUserRole)]
 pub async fn update_quiz(
+    #[mcp(description = "Space partition key")]
     space_pk: SpacePartition,
+    #[mcp(description = "Quiz sort key (e.g. 'SpaceQuiz#<uuid>')")]
     quiz_id: SpaceQuizEntityType,
+    #[mcp(description = "Quiz update data as JSON. Fields: title, description, started_at, ended_at, retry_count, pass_score, questions, answers, files (all optional)")]
     req: UpdateQuizRequest,
 ) -> Result<String> {
     SpaceQuiz::can_edit(&role)?;

--- a/app/ratel/src/features/spaces/pages/actions/controllers/list_actions.rs
+++ b/app/ratel/src/features/spaces/pages/actions/controllers/list_actions.rs
@@ -16,8 +16,12 @@ use crate::features::spaces::pages::actions::actions::quiz::{SpaceQuiz, SpaceQui
 #[cfg(feature = "server")]
 use std::collections::HashSet;
 
+#[mcp_tool(name = "list_actions", description = "List all actions in a space (polls, quizzes, discussions, follow). Shows action type, title, and status.")]
 #[get("/api/spaces/{space_pk}/actions", role: SpaceUserRole, user: OptionalUser, space: SpaceCommon)]
-pub async fn list_actions(space_pk: SpacePartition) -> Result<Vec<SpaceActionSummary>> {
+pub async fn list_actions(
+    #[mcp(description = "Space partition key")]
+    space_pk: SpacePartition,
+) -> Result<Vec<SpaceActionSummary>> {
     let cli = crate::features::spaces::pages::actions::config::get()
         .common
         .dynamodb();

--- a/app/ratel/src/features/spaces/pages/apps/apps/general/controllers/delete_space.rs
+++ b/app/ratel/src/features/spaces/pages/apps/apps/general/controllers/delete_space.rs
@@ -7,8 +7,12 @@ pub struct DeleteSpaceResponse {
     pub message: String,
 }
 
+#[mcp_tool(name = "delete_space", description = "Delete a space and unlink its post. Requires creator role.")]
 #[delete("/api/spaces/{space_id}/settings", role: SpaceUserRole)]
-pub async fn delete_space(space_id: SpacePartition) -> crate::common::Result<DeleteSpaceResponse> {
+pub async fn delete_space(
+    #[mcp(description = "Space partition key")]
+    space_id: SpacePartition,
+) -> crate::common::Result<DeleteSpaceResponse> {
     use crate::common::models::space::SpaceCommon;
     use crate::common::types::{EntityType, Partition};
     use crate::features::posts::models::Post;

--- a/app/ratel/src/features/spaces/pages/apps/apps/general/mod.rs
+++ b/app/ratel/src/features/spaces/pages/apps/apps/general/mod.rs
@@ -1,4 +1,4 @@
-mod controllers;
+pub(crate) mod controllers;
 mod i18n;
 mod views;
 

--- a/app/ratel/src/features/spaces/pages/apps/controllers/install_space_app.rs
+++ b/app/ratel/src/features/spaces/pages/apps/controllers/install_space_app.rs
@@ -4,9 +4,12 @@ use crate::common::SpaceUserRole;
 use crate::common::types::Partition;
 use crate::common::types::SpacePartition;
 
+#[mcp_tool(name = "install_space_app", description = "Install an app in a space. Requires creator role. Types: General, File, Analyzes, Panels.")]
 #[post("/api/spaces/{space_id}/apps", role: SpaceUserRole)]
 pub async fn install_space_app(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "App type: 'General', 'File', 'Analyzes', or 'Panels'")]
     app_type: SpaceAppType,
 ) -> Result<SpaceApp> {
     SpaceApp::can_edit(role)?;

--- a/app/ratel/src/features/spaces/pages/apps/controllers/uninstall_space_app.rs
+++ b/app/ratel/src/features/spaces/pages/apps/controllers/uninstall_space_app.rs
@@ -4,9 +4,12 @@ use crate::common::SpaceUserRole;
 use crate::common::types::Partition;
 use crate::common::types::SpacePartition;
 
+#[mcp_tool(name = "uninstall_space_app", description = "Uninstall an app from a space. Requires creator role.")]
 #[delete("/api/spaces/{space_id}/apps", role: SpaceUserRole)]
 pub async fn uninstall_space_app(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "App type: 'General', 'File', 'Analyzes', or 'Panels'")]
     app_type: SpaceAppType,
 ) -> Result<SpaceApp> {
     SpaceApp::can_delete(role)?;

--- a/app/ratel/src/features/spaces/pages/apps/mod.rs
+++ b/app/ratel/src/features/spaces/pages/apps/mod.rs
@@ -1,6 +1,6 @@
 pub mod apps;
 mod context;
-mod controllers;
+pub(crate) mod controllers;
 mod hooks;
 mod layout;
 mod menu;

--- a/app/ratel/src/features/spaces/pages/apps/types/space_app_type.rs
+++ b/app/ratel/src/features/spaces/pages/apps/types/space_app_type.rs
@@ -3,6 +3,7 @@ use super::*;
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, Default, DynamoEnum, Eq, PartialEq, Translate,
 )]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 pub enum SpaceAppType {
     #[default]
     #[translate(en = "General", ko = "스페이스 설정")]

--- a/app/ratel/src/features/spaces/space_common/controllers/get_space.rs
+++ b/app/ratel/src/features/spaces/space_common/controllers/get_space.rs
@@ -5,8 +5,12 @@ use crate::features::posts::models::Post;
 use crate::features::posts::types::{BoosterType, SpaceType};
 use crate::spaces::{InvitationStatus, SpaceInvitationMember};
 
+#[mcp_tool(name = "get_space", description = "Get space details by ID, including status, visibility, participation info.")]
 #[get("/api/spaces/{space_id}", user: OptionalUser)]
-pub async fn get_space(space_id: SpacePartition) -> Result<SpaceResponse> {
+pub async fn get_space(
+    #[mcp(description = "Space partition key (e.g. 'SPACE#<uuid>' or '<uuid>')")]
+    space_id: SpacePartition,
+) -> Result<SpaceResponse> {
     let config = crate::features::spaces::space_common::config::get();
     let dynamo = config.common.dynamodb();
 

--- a/app/ratel/src/features/spaces/space_common/controllers/update_space.rs
+++ b/app/ratel/src/features/spaces/space_common/controllers/update_space.rs
@@ -11,6 +11,7 @@ use crate::features::spaces::space_common::models::SpaceInvitationMember;
 use crate::features::spaces::space_common::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum UpdateSpaceRequest {
     Publish {
@@ -89,9 +90,12 @@ impl From<SpaceCommon> for UpdateSpaceResponse {
     }
 }
 
+#[mcp_tool(name = "update_space", description = "Update a space (publish, change visibility, content, title, start, finish, quota, etc.). Requires creator role.")]
 #[patch("/api/spaces/{space_id}", role: SpaceUserRole, space: SpaceCommon)]
 pub async fn update_space(
+    #[mcp(description = "Space partition key")]
     space_id: SpacePartition,
+    #[mcp(description = "Update data as JSON. Supported variants: {\"visibility\": \"Public\"}, {\"anonymous_participation\": true}, {\"join_anytime\": true}, {\"start\": true}, {\"finished\": true}, {\"quotas\": 100}, {\"title\": \"...\"}, {\"content\": \"...\"}, {\"publish\": true, \"visibility\": \"Public\"}, {\"logo\": \"url\"}")]
     req: UpdateSpaceRequest,
 ) -> Result<UpdateSpaceResponse> {
     if role != SpaceUserRole::Creator {

--- a/packages/by-macros/src/mcp_tool.rs
+++ b/packages/by-macros/src/mcp_tool.rs
@@ -1,3 +1,4 @@
+use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
@@ -58,10 +59,12 @@ impl Parse for McpToolArgs {
     }
 }
 
-/// Parsed info from the next `#[post("...", user: User)]` or `#[get("...", user: User)]` attribute.
+/// Parsed info from the route attribute.
 struct RouteAttrInfo {
-    /// Extracted "user" bindings from the route attribute (e.g., `user: User`)
-    extractors: Vec<(Ident, syn::Type)>,
+    method: String,
+    path: String,
+    path_params: Vec<String>,
+    query_params: Vec<String>,
 }
 
 fn parse_route_attr(attr: &syn::Attribute) -> Option<RouteAttrInfo> {
@@ -71,46 +74,155 @@ fn parse_route_attr(attr: &syn::Attribute) -> Option<RouteAttrInfo> {
         return None;
     }
 
-    // Parse the attribute tokens: ("path", key: Type, ...)
-    let mut extractors = Vec::new();
+    let method = name.to_uppercase();
+
     if let syn::Meta::List(meta_list) = &attr.meta {
         let tokens = meta_list.tokens.clone();
-        // We need to parse: "path", ident: Type, ident: Type, ...
-        // Use a simple approach: parse comma-separated items after the path string
-        let parser = |input: ParseStream| -> syn::Result<Vec<(Ident, syn::Type)>> {
-            let mut result = Vec::new();
-            // Skip the path string
-            let _path: LitStr = input.parse()?;
-
-            while input.peek(Token![,]) {
-                let _: Token![,] = input.parse()?;
-                if input.is_empty() {
-                    break;
-                }
-                // Try to parse `ident: Type`
-                if input.peek(Ident) && input.peek2(Token![:]) {
-                    let ident: Ident = input.parse()?;
-                    let _: Token![:] = input.parse()?;
-                    let ty: syn::Type = input.parse()?;
-                    result.push((ident, ty));
-                }
+        let parser = |input: ParseStream| -> syn::Result<String> {
+            let path: LitStr = input.parse()?;
+            while !input.is_empty() {
+                let _ = input.parse::<proc_macro2::TokenTree>();
             }
-            Ok(result)
+            Ok(path.value())
         };
 
         match syn::parse::Parser::parse2(parser, tokens) {
-            Ok(pairs) => {
-                extractors = pairs;
+            Ok(route_path) => {
+                let (path_params, query_params) = extract_route_params(&route_path);
+                Some(RouteAttrInfo {
+                    method,
+                    path: route_path,
+                    path_params,
+                    query_params,
+                })
             }
             Err(err) => {
-                // Surface a clear diagnostic when a recognized route attribute
-                // cannot be parsed, instead of silently ignoring the error.
                 panic!("failed to parse route attribute `{}`: {}", name, err);
+            }
+        }
+    } else {
+        None
+    }
+}
+
+fn extract_route_params(route: &str) -> (Vec<String>, Vec<String>) {
+    let mut path_params = Vec::new();
+    let mut query_params = Vec::new();
+
+    let (path_part, query_part) = if let Some(idx) = route.find('?') {
+        (&route[..idx], Some(&route[idx + 1..]))
+    } else {
+        (route, None)
+    };
+
+    for segment in path_part.split('/') {
+        if segment.starts_with('{') && segment.ends_with('}') {
+            path_params.push(segment[1..segment.len() - 1].to_string());
+        } else if segment.starts_with(':') {
+            path_params.push(segment[1..].to_string());
+        }
+    }
+
+    if let Some(qp) = query_part {
+        for param in qp.split('&') {
+            let param = param.trim();
+            if !param.is_empty() {
+                query_params.push(param.to_string());
             }
         }
     }
 
-    Some(RouteAttrInfo { extractors })
+    (path_params, query_params)
+}
+
+fn build_format_path(route: &str) -> String {
+    let path_part = if let Some(idx) = route.find('?') {
+        &route[..idx]
+    } else {
+        route
+    };
+
+    let mut result = String::new();
+    for segment in path_part.split('/') {
+        if !result.is_empty() || path_part.starts_with('/') {
+            if !result.is_empty() || segment.is_empty() {
+                result.push('/');
+            }
+        }
+        if segment.starts_with('{') && segment.ends_with('}') {
+            result.push_str("{}");
+        } else if segment.starts_with(':') {
+            result.push_str("{}");
+        } else {
+            result.push_str(segment);
+        }
+    }
+
+    result
+}
+
+fn is_option_type(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            return segment.ident == "Option";
+        }
+    }
+    false
+}
+
+/// Extract `#[mcp(description = "...")]` from a param's attributes.
+/// Returns the description string if found.
+fn extract_mcp_description(attrs: &[syn::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("mcp") {
+            continue;
+        }
+        if let syn::Meta::List(meta_list) = &attr.meta {
+            let parser = |input: ParseStream| -> syn::Result<String> {
+                let pairs =
+                    Punctuated::<syn::MetaNameValue, Token![,]>::parse_terminated(input)?;
+                for pair in &pairs {
+                    if pair.path.is_ident("description") {
+                        if let syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(s),
+                            ..
+                        }) = &pair.value
+                        {
+                            return Ok(s.value());
+                        }
+                    }
+                }
+                Err(input.error("expected description = \"...\""))
+            };
+            if let Ok(desc) = syn::parse::Parser::parse2(parser, meta_list.tokens.clone()) {
+                return Some(desc);
+            }
+        }
+    }
+    None
+}
+
+/// Strip `#[mcp(...)]` attributes from a PatType, returning a new PatType.
+fn strip_mcp_attrs(p: &PatType) -> PatType {
+    let mut cleaned = p.clone();
+    cleaned.attrs.retain(|a| !a.path().is_ident("mcp"));
+    cleaned
+}
+
+fn param_ident(p: &PatType) -> &Ident {
+    match &*p.pat {
+        Pat::Ident(pat_ident) => &pat_ident.ident,
+        other => panic!(
+            "#[mcp_tool]: unsupported parameter pattern `{}`.",
+            quote! { #other }
+        ),
+    }
+}
+
+enum ParamClassification<'a> {
+    Path(&'a PatType),
+    Query(&'a PatType),
+    Body(&'a PatType),
 }
 
 pub fn mcp_tool_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -127,17 +239,15 @@ pub fn mcp_tool_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let tool_name = &args.name;
     let tool_description = &args.description;
 
-    // Find the route attribute (#[post], #[get], etc.) to extract user/session params
     let route_info = function
         .attrs
         .iter()
-        .find_map(parse_route_attr);
+        .find_map(parse_route_attr)
+        .expect("#[mcp_tool] requires a route attribute (#[post], #[get], #[put], #[patch], #[delete])");
 
-    let extractor_params: Vec<(Ident, syn::Type)> = route_info
-        .map(|info| info.extractors)
-        .unwrap_or_default();
+    let http_method = &route_info.method;
 
-    // Collect the function's own params (from the signature)
+    // Collect function params
     let fn_params: Vec<&PatType> = function
         .sig
         .inputs
@@ -148,89 +258,236 @@ pub fn mcp_tool_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // Build the _mcp_impl function signature:
-    //   pub async fn create_post_handler_mcp_impl(user: User, param1: T1, ...) -> Result<...>
+    // Classify params
+    let fn_param_info: Vec<ParamClassification> = fn_params
+        .iter()
+        .map(|p| {
+            let name = param_ident(p).to_string();
+            if route_info.path_params.contains(&name) {
+                ParamClassification::Path(p)
+            } else if route_info.query_params.contains(&name) {
+                ParamClassification::Query(p)
+            } else {
+                ParamClassification::Body(p)
+            }
+        })
+        .collect();
+
     let fn_name = &function.sig.ident;
     let impl_fn_name = format_ident!("{}_mcp_impl", fn_name);
+    let handler_fn_name = format_ident!("{}_mcp_handler", fn_name);
     let vis = &function.vis;
     let return_type = &function.sig.output;
-    let original_body = &function.block;
-    let fn_attrs: Vec<_> = function
-        .attrs
-        .iter()
-        .filter(|a| {
-            let path = a.path();
-            // Keep doc attrs, skip route/mcp_tool attrs
-            path.is_ident("doc") || path.is_ident("cfg")
-        })
-        .collect();
 
-    // Build extractor param tokens for the _impl function
-    let extractor_param_tokens: Vec<_> = extractor_params
-        .iter()
-        .map(|(name, ty)| quote! { #name: #ty })
-        .collect();
+    // Generate request struct name: create_discussion → CreateDiscussionMcpRequest
+    let struct_name = format_ident!(
+        "{}McpRequest",
+        fn_name.to_string().to_case(Case::Pascal)
+    );
 
-    // Build fn param tokens for the _impl function
-    let fn_param_tokens: Vec<_> = fn_params.iter().map(|p| quote! { #p }).collect();
+    // ── Build _mcp_impl params ──────────────────────────────────────
 
-    // All params for the _impl function
-    let all_impl_params = {
-        let mut params = Vec::new();
-        params.extend(extractor_param_tokens.iter().cloned());
-        params.extend(fn_param_tokens.iter().cloned());
-        params
-    };
+    let mut impl_params: Vec<TokenStream> = vec![quote! { mcp_secret: String }];
+    let mut path_param_names: Vec<Ident> = Vec::new();
+    let mut query_param_entries: Vec<(Ident, bool)> = Vec::new();
+    let mut body_param_entries: Vec<Ident> = Vec::new();
 
-    // Build the call args for the original function body rewrite
-    let extractor_names: Vec<_> = extractor_params.iter().map(|(name, _)| name).collect();
-    let fn_param_names: Vec<_> = fn_params
-        .iter()
-        .map(|p| match &*p.pat {
-            Pat::Ident(pat_ident) => &pat_ident.ident,
-            other => panic!(
-                "#[mcp_tool]: unsupported parameter pattern `{}`. \
-                 Only simple identifier patterns are supported (e.g., `name: Type`). \
-                 Destructuring patterns and wildcards are not supported.",
-                quote! { #other }
-            ),
-        })
-        .collect();
+    // All params for the request struct (with descriptions and cleaned types)
+    let mut struct_fields: Vec<TokenStream> = Vec::new();
+    // Field names for destructuring the request struct in _mcp_handler
+    let mut all_field_names: Vec<Ident> = Vec::new();
 
-    let all_call_args = {
-        let mut args: Vec<_> = extractor_names.iter().map(|n| quote! { #n }).collect();
-        args.extend(fn_param_names.iter().map(|n| quote! { #n }));
-        args
-    };
-
-    // Generate the _mcp_impl function with the original body
-    let impl_fn = quote! {
-        #(#fn_attrs)*
-        #[cfg(feature = "server")]
-        #vis async fn #impl_fn_name(#(#all_impl_params),*) #return_type
-            #original_body
-    };
-
-    // Rewrite the original function body to call _mcp_impl
-    let new_body: syn::Block = syn::parse2(quote! {
-        {
-            #impl_fn_name(#(#all_call_args),*).await
+    for path_param_name in &route_info.path_params {
+        for info in &fn_param_info {
+            if let ParamClassification::Path(p) = info {
+                let ident = param_ident(p);
+                if ident.to_string() == *path_param_name {
+                    let cleaned = strip_mcp_attrs(p);
+                    let ty = &cleaned.ty;
+                    let desc = extract_mcp_description(&p.attrs);
+                    let desc_attr = desc.map(|d| quote! { #[schemars(description = #d)] });
+                    struct_fields.push(quote! { #desc_attr pub #ident: #ty });
+                    impl_params.push(quote! { #cleaned });
+                    path_param_names.push(ident.clone());
+                    all_field_names.push(ident.clone());
+                }
+            }
         }
-    })
-    .expect("failed to parse rewritten body");
+    }
 
-    function.block = Box::new(new_body);
+    for info in &fn_param_info {
+        if let ParamClassification::Query(p) = info {
+            let ident = param_ident(p);
+            let cleaned = strip_mcp_attrs(p);
+            let ty = &cleaned.ty;
+            let is_option = is_option_type(&p.ty);
+            let desc = extract_mcp_description(&p.attrs);
+            let desc_attr = desc.map(|d| quote! { #[schemars(description = #d)] });
+            struct_fields.push(quote! { #desc_attr pub #ident: #ty });
+            impl_params.push(quote! { #cleaned });
+            query_param_entries.push((ident.clone(), is_option));
+            all_field_names.push(ident.clone());
+        }
+    }
 
-    // Generate a constant that stores the tool metadata for MCP registration
+    for info in &fn_param_info {
+        if let ParamClassification::Body(p) = info {
+            let ident = param_ident(p);
+            let cleaned = strip_mcp_attrs(p);
+            let ty = &cleaned.ty;
+            let desc = extract_mcp_description(&p.attrs);
+            let desc_attr = desc.map(|d| quote! { #[schemars(description = #d)] });
+            struct_fields.push(quote! { #desc_attr pub #ident: #ty });
+            impl_params.push(quote! { #cleaned });
+            body_param_entries.push(ident.clone());
+            all_field_names.push(ident.clone());
+        }
+    }
+
+    // ── Generate request struct ─────────────────────────────────────
+
+    let request_struct = if struct_fields.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            #[cfg(feature = "server")]
+            #[derive(Debug, serde::Serialize, serde::Deserialize, rmcp::schemars::JsonSchema)]
+            #vis struct #struct_name {
+                #(#struct_fields),*
+            }
+        }
+    };
+
+    // ── Generate _mcp_impl (oneshot) ────────────────────────────────
+
+    let format_path = build_format_path(&route_info.path);
+
+    let path_construction = if path_param_names.is_empty() {
+        quote! { let mut __path = #format_path.to_string(); }
+    } else {
+        quote! { let mut __path = format!(#format_path, #(#path_param_names),*); }
+    };
+
+    let query_param_code = if query_param_entries.is_empty() {
+        quote! {}
+    } else {
+        let query_pushes: Vec<TokenStream> = query_param_entries
+            .iter()
+            .map(|(ident, is_option)| {
+                let name_str = ident.to_string();
+                if *is_option {
+                    quote! {
+                        if let Some(ref __v) = #ident {
+                            __qp.push(format!("{}={}", #name_str, urlencoding::encode(&format!("{}", __v))));
+                        }
+                    }
+                } else {
+                    quote! {
+                        __qp.push(format!("{}={}", #name_str, urlencoding::encode(&format!("{}", #ident))));
+                    }
+                }
+            })
+            .collect();
+
+        quote! {
+            let mut __qp: Vec<String> = Vec::new();
+            #(#query_pushes)*
+            if !__qp.is_empty() {
+                __path = format!("{}?{}", __path, __qp.join("&"));
+            }
+        }
+    };
+
+    let body_code = if body_param_entries.is_empty() {
+        quote! { let __body_bytes: Option<Vec<u8>> = None; }
+    } else if body_param_entries.len() == 1 {
+        let ident = &body_param_entries[0];
+        let name_str = ident.to_string();
+        quote! {
+            let __body = serde_json::json!({ #name_str: #ident });
+            let __body_bytes: Option<Vec<u8>> = serde_json::to_vec(&__body).ok();
+        }
+    } else {
+        let json_entries: Vec<TokenStream> = body_param_entries
+            .iter()
+            .map(|ident| {
+                let name_str = ident.to_string();
+                quote! { #name_str: #ident }
+            })
+            .collect();
+        quote! {
+            let __body = serde_json::json!({ #(#json_entries),* });
+            let __body_bytes: Option<Vec<u8>> = serde_json::to_vec(&__body).ok();
+        }
+    };
+
+    let impl_fn = quote! {
+        #[cfg(feature = "server")]
+        #vis async fn #impl_fn_name(#(#impl_params),*) #return_type {
+            #path_construction
+            #query_param_code
+            #body_code
+            crate::common::mcp::mcp_oneshot(#http_method, &__path, &mcp_secret, __body_bytes).await
+        }
+    };
+
+    // ── Generate _mcp_handler ───────────────────────────────────────
+
+    let handler_fn = if struct_fields.is_empty() {
+        // No request struct — handler takes only mcp_secret
+        quote! {
+            #[cfg(feature = "server")]
+            #vis async fn #handler_fn_name(
+                mcp_secret: &str,
+            ) -> crate::common::mcp::McpResult {
+                use crate::common::mcp::IntoMcpResult;
+                #impl_fn_name(mcp_secret.to_string()).await.into_mcp()
+            }
+        }
+    } else {
+        // Destructure request struct into individual params
+        let field_refs: Vec<TokenStream> = all_field_names
+            .iter()
+            .map(|n| quote! { #n })
+            .collect();
+
+        quote! {
+            #[cfg(feature = "server")]
+            #vis async fn #handler_fn_name(
+                mcp_secret: &str,
+                req: #struct_name,
+            ) -> crate::common::mcp::McpResult {
+                use crate::common::mcp::IntoMcpResult;
+                let #struct_name { #(#field_refs),* } = req;
+                #impl_fn_name(mcp_secret.to_string(), #(#field_refs),*).await.into_mcp()
+            }
+        }
+    };
+
+    // ── Generate metadata constant ──────────────────────────────────
+
     let meta_const_name = format_ident!(
         "MCP_TOOL_META_{}",
         fn_name.to_string().to_uppercase()
     );
-
     let impl_fn_name_str = impl_fn_name.to_string();
 
+    // ── Strip #[mcp(...)] from function params before emitting ──────
+
+    for input in &mut function.sig.inputs {
+        if let FnArg::Typed(pat_type) = input {
+            pat_type.attrs.retain(|a| !a.path().is_ident("mcp"));
+        }
+    }
+
+    // ── Emit everything ─────────────────────────────────────────────
+
     let output = quote! {
+        #request_struct
+
         #impl_fn
+
+        #handler_fn
 
         /// MCP tool metadata generated by `#[mcp_tool]`.
         #[cfg(feature = "server")]


### PR DESCRIPTION
- Introduced `mcp_oneshot` utility for sending HTTP requests through the Axum router.
- Added `#[mcp_tool]` macro for generating MCP tool handlers and metadata.
- Updated existing controllers to include MCP tool metadata and handler functions.
- Enhanced route parsing to support path and query parameters in MCP tools.
- Integrated `tower` dependency for MCP oneshot functionality.