### PR TITLE
fix: list_teams MCP always returns empty list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ aws-sdk-dynamodbstreams = "1"
 qdrant-client = "1"
 serde_dynamo = { version = "4.2.14", features = ["aws-sdk-dynamodb+1"] }
 thiserror = "2.0.16"
-uuid = { version = "1.10.1", features = ["v7"] }
+uuid = { version = "1.10.1", features = ["v4", "v7"] }
 chrono = "0.4.39"
 serde_with = "3.14.0"
 percent-encoding = "2.3.2"

--- a/app/ratel/src/features/social/controllers/team.rs
+++ b/app/ratel/src/features/social/controllers/team.rs
@@ -77,7 +77,7 @@ pub async fn get_user_teams_handler() -> crate::features::social::Result<Vec<cra
     let cli = crate::features::social::config::get().dynamodb();
     let user_pk = user.pk.clone();
 
-    let sk_prefix = "UserTeam".to_string();
+    let sk_prefix = crate::common::types::EntityType::UserTeam(String::new()).to_string();
     let opt = crate::features::auth::UserTeamQueryOption::builder().sk(sk_prefix);
     let (user_teams, _): (Vec<crate::features::auth::UserTeam>, _) =
         crate::features::auth::UserTeam::query(cli, &user_pk, opt).await?;

--- a/app/ratel/src/tests/mcp_tests.rs
+++ b/app/ratel/src/tests/mcp_tests.rs
@@ -227,3 +227,125 @@ async fn test_mcp_tool_create_space() {
     ).await;
     assert_eq!(status, 200, "create_space: {:?}", body);
 }
+
+/// Helper: create a team via HTTP and return the team username.
+async fn create_test_team(ctx: &TestContext) -> String {
+    let team_username = format!("t{}", &uuid::Uuid::new_v4().simple().to_string()[..7]);
+    let (status, _, _) = crate::test_post! {
+        app: ctx.app.clone(),
+        path: "/api/teams/create",
+        headers: ctx.test_user.1.clone(),
+        body: {
+            "username": team_username,
+            "nickname": "Test Team",
+            "profile_url": "",
+            "description": ""
+        }
+    };
+    assert_eq!(status, 200, "create_team failed");
+    team_username
+}
+
+/// Helper: call list_teams via MCP and return the team_id (pk) for the given username.
+async fn get_team_id_by_username(
+    app: axum::Router,
+    token: &str,
+    username: &str,
+) -> String {
+    let (status, body) =
+        mcp_tool_call(app, token, "list_teams", serde_json::json!({})).await;
+    assert_eq!(status, 200, "list_teams: {:?}", body);
+
+    let content = extract_tool_content(&body);
+    let teams = content.as_array().expect("list_teams should return array");
+    teams
+        .iter()
+        .find(|t| t.get("username").and_then(|v| v.as_str()) == Some(username))
+        .and_then(|t| t.get("pk").and_then(|v| v.as_str()))
+        .unwrap_or_else(|| panic!("team '{}' not found in list_teams", username))
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_mcp_tool_team_create_post() {
+    let (ctx, token) = setup_mcp_test().await;
+
+    // Step 1: create a team and resolve its team_id via list_teams
+    let team_username = create_test_team(&ctx).await;
+    let team_id = get_team_id_by_username(ctx.app.clone(), &token, &team_username).await;
+
+    // Step 2: create a post under the team
+    let (status, body) = mcp_tool_call(
+        ctx.app.clone(),
+        &token,
+        "create_post",
+        serde_json::json!({ "team_id": team_id }),
+    )
+    .await;
+    assert_eq!(status, 200, "team create_post: {:?}", body);
+
+    let content = extract_tool_content(&body);
+    let post_pk = content["post_pk"]
+        .as_str()
+        .expect("should have post_pk")
+        .to_string();
+
+    // Step 3: verify the post belongs to the team by fetching it
+    let (status, body) = mcp_tool_call(
+        ctx.app,
+        &token,
+        "get_post",
+        serde_json::json!({ "post_id": post_pk }),
+    )
+    .await;
+    assert_eq!(status, 200, "get_post (team post): {:?}", body);
+}
+
+#[tokio::test]
+async fn test_mcp_tool_team_post_and_space() {
+    let (ctx, token) = setup_mcp_test().await;
+
+    // Step 1: create a team and resolve its team_id via list_teams
+    let team_username = create_test_team(&ctx).await;
+    let team_id = get_team_id_by_username(ctx.app.clone(), &token, &team_username).await;
+
+    // Step 2: create a draft post under the team
+    let (status, body) = mcp_tool_call(
+        ctx.app.clone(),
+        &token,
+        "create_post",
+        serde_json::json!({ "team_id": team_id }),
+    )
+    .await;
+    assert_eq!(status, 200, "team create_post: {:?}", body);
+    let post_pk = extract_tool_content(&body)["post_pk"]
+        .as_str()
+        .expect("should have post_pk")
+        .to_string();
+
+    // Step 3: publish the team post
+    let (status, _) = mcp_tool_call(
+        ctx.app.clone(),
+        &token,
+        "update_post",
+        serde_json::json!({
+            "post_id": post_pk,
+            "title": "Team Space Post",
+            "content": "<p>Team post content</p>",
+            "publish": true,
+            "visibility": "Public"
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "update_post (publish team post) failed");
+
+    // Step 4: create a space from the team post
+    let (status, body) = mcp_tool_call(
+        ctx.app,
+        &token,
+        "create_space",
+        serde_json::json!({ "post_id": post_pk }),
+    )
+    .await;
+    assert_eq!(status, 200, "create_space from team post: {:?}", body);
+}

--- a/app/ratel/src/tests/mcp_tests.rs
+++ b/app/ratel/src/tests/mcp_tests.rs
@@ -113,10 +113,38 @@ async fn test_mcp_tool_create_post() {
 #[tokio::test]
 async fn test_mcp_tool_list_teams() {
     let (ctx, token) = setup_mcp_test().await;
+
+    // Create a team so there is at least one team to list
+    let team_username = format!("t{}", &uuid::Uuid::new_v4().simple().to_string()[..7]);
+    let (status, _, _) = crate::test_post! {
+        app: ctx.app.clone(),
+        path: "/api/teams/create",
+        headers: ctx.test_user.1.clone(),
+        body: {
+            "username": team_username,
+            "nickname": "Test Team",
+            "profile_url": "",
+            "description": ""
+        }
+    };
+    assert_eq!(status, 200, "create_team failed");
+
+    // list_teams via MCP must return the newly created team
     let (status, body) =
         mcp_tool_call(ctx.app, &token, "list_teams", serde_json::json!({})).await;
     assert_eq!(status, 200, "list_teams: {:?}", body);
-    assert!(body.get("result").is_some(), "should have result: {:?}", body);
+
+    let content = extract_tool_content(&body);
+    let teams = content.as_array().expect("list_teams should return an array");
+    assert!(
+        !teams.is_empty(),
+        "list_teams should return at least one team after creation: {:?}",
+        body
+    );
+    let found = teams
+        .iter()
+        .any(|t| t.get("username").and_then(|v| v.as_str()) == Some(&team_username));
+    assert!(found, "created team '{}' not found in list_teams result: {:?}", team_username, teams);
 }
 
 #[tokio::test]

--- a/app/ratel/src/tests/mcp_tests.rs
+++ b/app/ratel/src/tests/mcp_tests.rs
@@ -114,20 +114,24 @@ async fn test_mcp_tool_create_post() {
 async fn test_mcp_tool_list_teams() {
     let (ctx, token) = setup_mcp_test().await;
 
-    // Create a team so there is at least one team to list
+    // Create a team so there is at least one team to list.
+    // Dioxus server functions wrap the named parameter as a JSON key:
+    // create_team_handler(body: CreateTeamRequest, ...) → send {"body": {...}}
     let team_username = format!("t{}", &uuid::Uuid::new_v4().simple().to_string()[..7]);
-    let (status, _, _) = crate::test_post! {
+    let (status, _, resp) = crate::test_post! {
         app: ctx.app.clone(),
         path: "/api/teams/create",
         headers: ctx.test_user.1.clone(),
         body: {
-            "username": team_username,
-            "nickname": "Test Team",
-            "profile_url": "",
-            "description": ""
+            "body": {
+                "username": team_username,
+                "nickname": "Test Team",
+                "profile_url": "",
+                "description": ""
+            }
         }
     };
-    assert_eq!(status, 200, "create_team failed");
+    assert_eq!(status, 200, "create_team failed: {:?}", resp);
 
     // list_teams via MCP must return the newly created team
     let (status, body) =
@@ -231,18 +235,22 @@ async fn test_mcp_tool_create_space() {
 /// Helper: create a team via HTTP and return the team username.
 async fn create_test_team(ctx: &TestContext) -> String {
     let team_username = format!("t{}", &uuid::Uuid::new_v4().simple().to_string()[..7]);
-    let (status, _, _) = crate::test_post! {
+    // Dioxus server functions wrap the named parameter as a JSON key.
+    // create_team_handler(body: CreateTeamRequest, ...) → send {"body": {...}}
+    let (status, _, resp) = crate::test_post! {
         app: ctx.app.clone(),
         path: "/api/teams/create",
         headers: ctx.test_user.1.clone(),
         body: {
-            "username": team_username,
-            "nickname": "Test Team",
-            "profile_url": "",
-            "description": ""
+            "body": {
+                "username": team_username,
+                "nickname": "Test Team",
+                "profile_url": "",
+                "description": ""
+            }
         }
     };
-    assert_eq!(status, 200, "create_team failed");
+    assert_eq!(status, 200, "create_team failed: {:?}", resp);
     team_username
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `get_user_teams_handler` used the hardcoded string `"UserTeam"` as the DynamoDB `begins_with` sk prefix, but `UserTeam` entries are stored with keys in the form `USER_TEAM#<team-pk>` (generated by `EntityType::UserTeam`'s `Display` impl). No sk ever starts with `"UserTeam"`, so every query returned an empty list.
- **Fix**: Replace the hardcoded string with `EntityType::UserTeam(String::new()).to_string()`, which produces `"USER_TEAM#"` — matching the working implementation already in `contexts/team_context.rs`.
- **Test**: Strengthen `test_mcp_tool_list_teams` to create a team first, call `list_teams` via MCP, and assert the created team appears in the response (previously the test only checked that a `result` key existed, so an empty list passed silently).

## Test plan

- [ ] Run `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-local cargo test --features "full,bypass" -- test_mcp_tool_list_teams` and verify it passes
- [ ] Verify `list_teams` MCP tool now returns the user's teams via local MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)