### PR TITLE
feat(social): add team member role change in management page

### DIFF
--- a/app/ratel/src/features/social/pages/member/controllers/mod.rs
+++ b/app/ratel/src/features/social/pages/member/controllers/mod.rs
@@ -2,9 +2,11 @@ mod add_member;
 mod get_team_member_permission;
 mod list_members;
 mod remove_member;
+mod update_member_role;
 
 pub use add_member::*;
 pub use crate::features::social::controllers::find_user::*;
 pub use get_team_member_permission::*;
 pub use list_members::*;
 pub use remove_member::*;
+pub use update_member_role::*;

--- a/app/ratel/src/features/social/pages/member/controllers/update_member_role.rs
+++ b/app/ratel/src/features/social/pages/member/controllers/update_member_role.rs
@@ -60,15 +60,29 @@ pub async fn update_member_role_handler(
 
     if !already_in_target_role {
         // Build transact items: delete all existing UserTeamGroup rows, insert the new one.
-        let mut transact_items: Vec<aws_sdk_dynamodb::types::TransactWriteItem> = existing_groups
-            .iter()
-            .map(|utg| {
-                crate::features::auth::UserTeamGroup::delete_transact_write_item(
-                    utg.pk.clone(),
-                    utg.sk.clone(),
-                )
-            })
-            .collect();
+        // Must fit in a single DynamoDB TransactWriteItems call (max 100 items) so the
+        // delete + insert is atomic — chunking across transactions would let a failure
+        // leave the user partially de-grouped.
+        const MAX_TRANSACT_ITEMS: usize = 100;
+        let total_items = existing_groups.len() + 1;
+        if total_items > MAX_TRANSACT_ITEMS {
+            crate::error!(
+                "update_member_role: user {} has {} groups in team {}, exceeds single-transaction limit",
+                target_user.pk,
+                existing_groups.len(),
+                team_pk,
+            );
+            return Err(MemberError::RoleChangeFailed.into());
+        }
+
+        let mut transact_items: Vec<aws_sdk_dynamodb::types::TransactWriteItem> =
+            Vec::with_capacity(total_items);
+        for utg in &existing_groups {
+            transact_items.push(crate::features::auth::UserTeamGroup::delete_transact_write_item(
+                utg.pk.clone(),
+                utg.sk.clone(),
+            ));
+        }
 
         let new_user_team_group = crate::features::auth::UserTeamGroup::new(
             target_user.pk.clone(),
@@ -78,7 +92,10 @@ pub async fn update_member_role_handler(
         );
         transact_items.push(new_user_team_group.upsert_transact_write_item());
 
-        crate::transact_write_all_items!(cli, transact_items);
+        crate::transact_write_items!(cli, transact_items).map_err(|e| {
+            crate::error!("update_member_role: transact_write failed: {e}");
+            MemberError::RoleChangeFailed
+        })?;
     }
 
     Ok(TeamMemberResponse {

--- a/app/ratel/src/features/social/pages/member/controllers/update_member_role.rs
+++ b/app/ratel/src/features/social/pages/member/controllers/update_member_role.rs
@@ -1,0 +1,92 @@
+use super::super::dto::{TeamMemberResponse, TeamRole, UpdateMemberRoleRequest};
+use super::super::*;
+
+use crate::features::posts::models::{Team, TeamOwner};
+use crate::features::posts::types::{TeamGroupPermission, TeamGroupPermissions};
+
+#[patch("/api/teams/:team_pk/members/role", user: crate::features::auth::User, team: Team, permissions: TeamGroupPermissions)]
+pub async fn update_member_role_handler(
+    team_pk: TeamPartition,
+    body: UpdateMemberRoleRequest,
+) -> Result<TeamMemberResponse> {
+    let conf = super::super::config::get();
+    let cli = conf.common.dynamodb();
+    let team_pk: Partition = team_pk.into();
+
+    // Permission check — same as add/remove.
+    let can_edit = permissions.contains(TeamGroupPermission::TeamAdmin)
+        || permissions.contains(TeamGroupPermission::TeamEdit)
+        || permissions.contains(TeamGroupPermission::GroupEdit);
+    if !can_edit {
+        return Err(Error::NoPermission);
+    }
+
+    // Cannot change own role.
+    if body.user_pk == user.pk.to_string() {
+        return Err(MemberError::CannotChangeOwnRole.into());
+    }
+
+    // Cannot change owner's role.
+    if let Some(team_owner) = TeamOwner::get(cli, &team_pk, Some(&EntityType::TeamOwner)).await? {
+        if team_owner.user_pk.to_string() == body.user_pk {
+            return Err(MemberError::CannotChangeOwnerRole.into());
+        }
+    }
+
+    // Verify target user exists.
+    let target_user = crate::features::auth::User::get(cli, &body.user_pk, Some(EntityType::User))
+        .await?
+        .ok_or(MemberError::UserNotFound)?;
+
+    // Find all existing UserTeamGroup entries for this user in this team.
+    let opt = crate::features::auth::UserTeamGroupQueryOption::builder().sk(target_user.pk.to_string());
+    let (existing_groups, _) =
+        crate::features::auth::UserTeamGroup::find_by_team_pk(cli, team_pk.clone(), opt).await?;
+
+    if existing_groups.is_empty() {
+        return Err(MemberError::UserNotFound.into());
+    }
+
+    let new_team_group_sk = EntityType::TeamGroup(body.role.to_string());
+    let new_user_team_group_sk = EntityType::UserTeamGroup(new_team_group_sk.to_string());
+    let new_permissions: i64 = match body.role {
+        TeamRole::Admin => TeamGroupPermissions::all().into(),
+        TeamRole::Member => TeamGroupPermissions::member().into(),
+    };
+
+    // Fast path: already in the requested role with the only matching group.
+    let already_in_target_role = existing_groups.len() == 1
+        && existing_groups[0].sk.to_string() == new_user_team_group_sk.to_string();
+
+    if !already_in_target_role {
+        // Build transact items: delete all existing UserTeamGroup rows, insert the new one.
+        let mut transact_items: Vec<aws_sdk_dynamodb::types::TransactWriteItem> = existing_groups
+            .iter()
+            .map(|utg| {
+                crate::features::auth::UserTeamGroup::delete_transact_write_item(
+                    utg.pk.clone(),
+                    utg.sk.clone(),
+                )
+            })
+            .collect();
+
+        let new_user_team_group = crate::features::auth::UserTeamGroup::new(
+            target_user.pk.clone(),
+            new_team_group_sk,
+            new_permissions,
+            team.pk.clone(),
+        );
+        transact_items.push(new_user_team_group.upsert_transact_write_item());
+
+        crate::transact_write_all_items!(cli, transact_items);
+    }
+
+    Ok(TeamMemberResponse {
+        user_id: target_user.pk.to_string(),
+        username: target_user.username.clone(),
+        display_name: target_user.display_name.clone(),
+        profile_url: target_user.profile_url.clone(),
+        role: body.role,
+        is_owner: false,
+    })
+}

--- a/app/ratel/src/features/social/pages/member/dto/mod.rs
+++ b/app/ratel/src/features/social/pages/member/dto/mod.rs
@@ -10,6 +10,7 @@ mod remove_member_response;
 mod team_member_permission;
 mod team_member_response;
 mod team_role;
+mod update_member_role_request;
 
 pub use add_team_member_request::*;
 pub use add_team_member_response::*;
@@ -19,3 +20,4 @@ pub use remove_member_response::*;
 pub use team_member_permission::*;
 pub use team_member_response::*;
 pub use team_role::*;
+pub use update_member_role_request::*;

--- a/app/ratel/src/features/social/pages/member/dto/update_member_role_request.rs
+++ b/app/ratel/src/features/social/pages/member/dto/update_member_role_request.rs
@@ -1,0 +1,9 @@
+use super::super::*;
+use super::TeamRole;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub struct UpdateMemberRoleRequest {
+    pub user_pk: String,
+    pub role: TeamRole,
+}

--- a/app/ratel/src/features/social/pages/member/types.rs
+++ b/app/ratel/src/features/social/pages/member/types.rs
@@ -9,6 +9,14 @@ pub enum MemberError {
     #[error("Too many invitations")]
     #[translate(en = "You can invite up to 100 members at once.", ko = "한번에 최대 100명까지 초대할 수 있습니다.")]
     TooManyInvitations,
+
+    #[error("Cannot change your own role")]
+    #[translate(en = "You cannot change your own role.", ko = "본인의 역할은 변경할 수 없습니다.")]
+    CannotChangeOwnRole,
+
+    #[error("Cannot change owner role")]
+    #[translate(en = "The team owner's role cannot be changed.", ko = "팀 소유자의 역할은 변경할 수 없습니다.")]
+    CannotChangeOwnerRole,
 }
 
 #[cfg(feature = "server")]
@@ -18,6 +26,8 @@ impl MemberError {
         match self {
             MemberError::UserNotFound => StatusCode::NOT_FOUND,
             MemberError::TooManyInvitations => StatusCode::BAD_REQUEST,
+            MemberError::CannotChangeOwnRole => StatusCode::FORBIDDEN,
+            MemberError::CannotChangeOwnerRole => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/app/ratel/src/features/social/pages/member/types.rs
+++ b/app/ratel/src/features/social/pages/member/types.rs
@@ -17,6 +17,10 @@ pub enum MemberError {
     #[error("Cannot change owner role")]
     #[translate(en = "The team owner's role cannot be changed.", ko = "팀 소유자의 역할은 변경할 수 없습니다.")]
     CannotChangeOwnerRole,
+
+    #[error("Role change failed")]
+    #[translate(en = "Failed to change member role.", ko = "멤버 역할 변경에 실패했습니다.")]
+    RoleChangeFailed,
 }
 
 #[cfg(feature = "server")]
@@ -28,6 +32,7 @@ impl MemberError {
             MemberError::TooManyInvitations => StatusCode::BAD_REQUEST,
             MemberError::CannotChangeOwnRole => StatusCode::FORBIDDEN,
             MemberError::CannotChangeOwnerRole => StatusCode::FORBIDDEN,
+            MemberError::RoleChangeFailed => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/app/ratel/src/features/social/pages/setting/i18n.rs
+++ b/app/ratel/src/features/social/pages/setting/i18n.rs
@@ -238,6 +238,21 @@ translate! {
         ko: "멤버 제거에 실패했습니다. 다시 시도해주세요.",
     },
 
+    make_admin: {
+        en: "Make admin",
+        ko: "관리자로 변경",
+    },
+
+    make_member: {
+        en: "Make member",
+        ko: "멤버로 변경",
+    },
+
+    failed_change_role: {
+        en: "Failed to change member role. Please try again.",
+        ko: "멤버 역할 변경에 실패했습니다. 다시 시도해주세요.",
+    },
+
     subscription: {
         en: "Subscription",
         ko: "구독",

--- a/app/ratel/src/features/social/pages/setting/views/management_page.rs
+++ b/app/ratel/src/features/social/pages/setting/views/management_page.rs
@@ -11,6 +11,12 @@ use crate::features::posts::types::{TeamGroupPermission, TeamGroupPermissions};
 use dioxus::prelude::*;
 use dioxus_primitives::scroll_area::ScrollDirection;
 
+#[derive(Clone)]
+pub struct ChangeRolePayload {
+    pub user_id: String,
+    pub new_role: TeamRole,
+}
+
 const PAGE_SIZE: i32 = 10;
 
 #[component]
@@ -50,6 +56,11 @@ pub fn ManagementPage(username: String) -> Element {
 
     let mut error_msg = use_signal(|| Option::<String>::None);
     let failed_remove_member = tr.failed_remove_member.to_string();
+    let failed_change_role = tr.failed_change_role.to_string();
+
+    let user_ctx = crate::features::auth::hooks::use_user_context();
+    let current_user_pk: Option<String> =
+        user_ctx().user.as_ref().map(|u| u.pk.to_string());
 
     // Members infinite scroll query
     let team_pk_signal = use_signal(|| team_pk.clone());
@@ -110,9 +121,7 @@ pub fn ManagementPage(username: String) -> Element {
                         size: ButtonSize::Small,
                         class: "flex items-center gap-2".to_string(),
                         onclick: on_add_members_click,
-                        lucide_dioxus::UserPlus {
-                            class: "w-4 h-4 [&>path]:stroke-btn-primary-text [&>line]:stroke-btn-primary-text",
-                        }
+                        lucide_dioxus::UserPlus { class: "w-4 h-4 [&>path]:stroke-btn-primary-text [&>line]:stroke-btn-primary-text" }
                         {tr.add_members}
                     }
                 }
@@ -138,17 +147,23 @@ pub fn ManagementPage(username: String) -> Element {
                 ScrollArea {
                     direction: ScrollDirection::Vertical,
                     class: "flex flex-col max-h-[540px]",
-                    for (idx, member) in members.iter().enumerate() {
+                    for (idx , member) in members.iter().enumerate() {
                         {
                             let is_last = idx == members.len() - 1;
                             let member = member.clone();
                             let failed_remove = failed_remove_member.clone();
+                            let failed_role = failed_change_role.clone();
+                            let is_self = current_user_pk
+                                .as_deref()
+                                .map(|pk| pk == member.user_id.as_str())
+                                .unwrap_or(false);
                             rsx! {
                                 MemberRow {
                                     key: "{member.user_id}",
                                     member: member.clone(),
                                     is_last,
                                     can_manage,
+                                    is_self,
                                     on_remove: move |_| {
                                         let member = member.clone();
                                         let team_pk = team_pk_signal();
@@ -157,12 +172,34 @@ pub fn ManagementPage(username: String) -> Element {
                                         let mut members_query = members_query;
                                         spawn(async move {
                                             let result = crate::features::social::pages::member::controllers::remove_team_member_handler(
-                                                team_pk.clone(),
-                                                crate::features::social::pages::member::dto::RemoveMemberRequest {
-                                                    user_pks: vec![member.user_id.clone()],
-                                                },
-                                            )
-                                            .await;
+                                                    team_pk.clone(),
+                                                    crate::features::social::pages::member::dto::RemoveMemberRequest {
+                                                        user_pks: vec![member.user_id.clone()],
+                                                    },
+                                                )
+                                                .await;
+                                            if result.is_err() {
+                                                error_msg.set(Some(failed_msg));
+                                            } else {
+                                                error_msg.set(None);
+                                                members_query.refresh();
+                                            }
+                                        });
+                                    },
+                                    on_change_role: move |payload: ChangeRolePayload| {
+                                        let team_pk = team_pk_signal();
+                                        let mut error_msg = error_msg.clone();
+                                        let failed_msg = failed_role.clone();
+                                        let mut members_query = members_query;
+                                        spawn(async move {
+                                            let result = crate::features::social::pages::member::controllers::update_member_role_handler(
+                                                    team_pk.clone(),
+                                                    crate::features::social::pages::member::dto::UpdateMemberRoleRequest {
+                                                        user_pk: payload.user_id,
+                                                        role: payload.new_role,
+                                                    },
+                                                )
+                                                .await;
                                             if result.is_err() {
                                                 error_msg.set(Some(failed_msg));
                                             } else {
@@ -192,7 +229,14 @@ pub fn ManagementPage(username: String) -> Element {
 }
 
 #[component]
-fn MemberRow(member: TeamMemberResponse, is_last: bool, can_manage: bool, on_remove: EventHandler<()>) -> Element {
+fn MemberRow(
+    member: TeamMemberResponse,
+    is_last: bool,
+    can_manage: bool,
+    is_self: bool,
+    on_remove: EventHandler<()>,
+    on_change_role: EventHandler<ChangeRolePayload>,
+) -> Element {
     let tr: TeamSettingsTranslate = use_translate();
     let border_class = if is_last {
         ""
@@ -200,6 +244,7 @@ fn MemberRow(member: TeamMemberResponse, is_last: bool, can_manage: bool, on_rem
         "border-b border-border"
     };
     let mut show_menu = use_signal(|| false);
+    let can_change_role = can_manage && !member.is_owner && !is_self;
 
     let display = if member.display_name.is_empty() {
         member.username.clone()
@@ -227,7 +272,9 @@ fn MemberRow(member: TeamMemberResponse, is_last: bool, can_manage: bool, on_rem
 
                 // Name + username
                 div { class: "flex flex-col min-w-0 flex-1",
-                    span { class: "text-sm font-semibold text-text-primary truncate", "{display}" }
+                    span { class: "text-sm font-semibold text-text-primary truncate",
+                        "{display}"
+                    }
                     span { class: "text-xs text-foreground-muted truncate", "@{member.username}" }
                 }
 
@@ -258,9 +305,7 @@ fn MemberRow(member: TeamMemberResponse, is_last: bool, can_manage: bool, on_rem
                                 e.stop_propagation();
                                 show_menu.toggle();
                             },
-                            lucide_dioxus::Ellipsis {
-                                class: "w-4 h-4 [&>circle]:fill-text-primary [&>circle]:stroke-none",
-                            }
+                            lucide_dioxus::Ellipsis { class: "w-4 h-4 [&>circle]:fill-text-primary [&>circle]:stroke-none" }
                         }
                         if show_menu() {
                             div {
@@ -270,6 +315,48 @@ fn MemberRow(member: TeamMemberResponse, is_last: bool, can_manage: bool, on_rem
                             div {
                                 class: if is_last { "absolute right-0 bottom-8 z-20 w-44 bg-popover border border-border rounded-lg shadow-lg py-1 overflow-hidden" } else { "absolute right-0 top-8 z-20 w-44 bg-popover border border-border rounded-lg shadow-lg py-1 overflow-hidden" },
                                 onclick: move |e| e.stop_propagation(),
+                                if can_change_role && member.role != TeamRole::Admin {
+                                    Button {
+                                        style: ButtonStyle::Text,
+                                        size: ButtonSize::Small,
+                                        shape: ButtonShape::Square,
+                                        class: "flex items-center gap-2 w-full text-text-primary justify-start".to_string(),
+                                        onclick: {
+                                            let user_id = member.user_id.clone();
+                                            move |_| {
+                                                show_menu.set(false);
+                                                on_change_role
+                                                    .call(ChangeRolePayload {
+                                                        user_id: user_id.clone(),
+                                                        new_role: TeamRole::Admin,
+                                                    });
+                                            }
+                                        },
+                                        lucide_dioxus::ShieldCheck { class: "w-4 h-4 [&>path]:stroke-text-primary" }
+                                        {tr.make_admin}
+                                    }
+                                }
+                                if can_change_role && member.role != TeamRole::Member {
+                                    Button {
+                                        style: ButtonStyle::Text,
+                                        size: ButtonSize::Small,
+                                        shape: ButtonShape::Square,
+                                        class: "flex items-center gap-2 w-full text-text-primary justify-start".to_string(),
+                                        onclick: {
+                                            let user_id = member.user_id.clone();
+                                            move |_| {
+                                                show_menu.set(false);
+                                                on_change_role
+                                                    .call(ChangeRolePayload {
+                                                        user_id: user_id.clone(),
+                                                        new_role: TeamRole::Member,
+                                                    });
+                                            }
+                                        },
+                                        lucide_dioxus::User { class: "w-4 h-4 [&>path]:stroke-text-primary [&>circle]:stroke-text-primary" }
+                                        {tr.make_member}
+                                    }
+                                }
                                 Button {
                                     style: ButtonStyle::Text,
                                     size: ButtonSize::Small,
@@ -279,9 +366,7 @@ fn MemberRow(member: TeamMemberResponse, is_last: bool, can_manage: bool, on_rem
                                         show_menu.set(false);
                                         on_remove.call(());
                                     },
-                                    lucide_dioxus::UserMinus {
-                                        class: "w-4 h-4 [&>path]:stroke-destructive [&>line]:stroke-destructive",
-                                    }
+                                    lucide_dioxus::UserMinus { class: "w-4 h-4 [&>path]:stroke-destructive [&>line]:stroke-destructive" }
                                     {tr.remove_from_team}
                                 }
                             }

--- a/app/ratel/src/features/social/pages/setting/views/management_page.rs
+++ b/app/ratel/src/features/social/pages/setting/views/management_page.rs
@@ -12,9 +12,9 @@ use dioxus::prelude::*;
 use dioxus_primitives::scroll_area::ScrollDirection;
 
 #[derive(Clone)]
-pub struct ChangeRolePayload {
-    pub user_id: String,
-    pub new_role: TeamRole,
+struct ChangeRolePayload {
+    user_id: String,
+    new_role: TeamRole,
 }
 
 const PAGE_SIZE: i32 = 10;
@@ -147,7 +147,7 @@ pub fn ManagementPage(username: String) -> Element {
                 ScrollArea {
                     direction: ScrollDirection::Vertical,
                     class: "flex flex-col max-h-[540px]",
-                    for (idx, member) in members.iter().enumerate() {
+                    for (idx , member) in members.iter().enumerate() {
                         {
                             let is_last = idx == members.len() - 1;
                             let member = member.clone();

--- a/app/ratel/src/features/social/pages/setting/views/management_page.rs
+++ b/app/ratel/src/features/social/pages/setting/views/management_page.rs
@@ -147,7 +147,7 @@ pub fn ManagementPage(username: String) -> Element {
                 ScrollArea {
                     direction: ScrollDirection::Vertical,
                     class: "flex flex-col max-h-[540px]",
-                    for (idx , member) in members.iter().enumerate() {
+                    for (idx, member) in members.iter().enumerate() {
                         {
                             let is_last = idx == members.len() - 1;
                             let member = member.clone();


### PR DESCRIPTION
Adds a PATCH /api/teams/:team_pk/members/role endpoint that swaps a member's UserTeamGroup atomically (delete + insert via transact_write, since role is encoded in the sk). The handler rejects self-edits and owner role changes, and reuses the existing TeamAdmin/TeamEdit/GroupEdit permission gate.

In the team management page dropdown, "Make admin" / "Make member" options are added above "Remove from team", hidden for the current user, the team owner, and the role the member already holds.


https://github.com/user-attachments/assets/915b7101-3454-41f3-98f6-b4d046c07ffb

