### PR TITLE
feat(seo): add space/post-specific OG and Twitter Card meta tags

### DIFF
--- a/app/ratel/src/app.rs
+++ b/app/ratel/src/app.rs
@@ -34,36 +34,12 @@ pub fn App() -> Element {
         interop::initialize(&serde_wasm_bindgen::to_value(&serde_json::json!({})).unwrap());
     });
 
-    let keywords = vec![
-        "ratel".to_string(),
-        "knowledge platform".to_string(),
-        "ai knowledge base".to_string(),
-        "human knowledge dataset".to_string(),
-        "ai training data".to_string(),
-        "community intelligence".to_string(),
-        "participatory platform".to_string(),
-        "survey rewards".to_string(),
-        "poll rewards".to_string(),
-        "web3 knowledge economy".to_string(),
-        "ai memory platform".to_string(),
-        "vector knowledge database".to_string(),
-        "collective intelligence".to_string(),
-    ];
-
     rsx! {
         document::Link { rel: "icon", href: crate::common::assets::FAVICON }
         document::Link { rel: "stylesheet", href: MAIN_CSS }
         document::Link {
             rel: "stylesheet",
             href: asset!("/assets/dx-components-theme.css"),
-        }
-        crate::common::SeoMeta {
-            title: "Ratel – AI Knowledge Platform Powered by Human Essences",
-            description: "Ratel is a participatory knowledge platform where users share expertise, opinions, and insights as structured “Essences”. AI agents learn from the knowledge base while users earn rewards through surveys, polls, and discussions.",
-            image: "https://metadata.ratel.foundation/logos/logo-symbol.png",
-            url: "https://ratel.foundation",
-            robots: Robots::IndexNofollow,
-            keywords,
         }
         document::Script { src: MAIN_JS }
         document::Script { src: "https://cdn.portone.io/v2/browser-sdk.js" }

--- a/app/ratel/src/features/posts/views/post_detail/mod.rs
+++ b/app/ratel/src/features/posts/views/post_detail/mod.rs
@@ -1,3 +1,4 @@
+use crate::common::components::SeoMeta;
 use crate::features::posts::components::post_detail::*;
 use crate::features::posts::controllers::dto::*;
 use crate::features::posts::controllers::get_post::get_post_handler;
@@ -14,7 +15,36 @@ pub fn PostDetail(post_id: FeedPartition) -> Element {
 
     let detail = resource();
 
+    let post_title = detail
+        .post
+        .as_ref()
+        .map(|p| p.title.clone())
+        .unwrap_or_default();
+    let post_description = detail
+        .post
+        .as_ref()
+        .map(|p| {
+            let re = regex::Regex::new(r"<[^>]*>").unwrap();
+            let text = re.replace_all(&p.html_contents, "").to_string();
+            if text.len() > 200 {
+                text[..200].to_string()
+            } else {
+                text
+            }
+        })
+        .unwrap_or_default();
+    let post_image = detail
+        .post
+        .as_ref()
+        .and_then(|p| p.urls.first().cloned())
+        .unwrap_or_default();
+
     rsx! {
+        SeoMeta {
+            title: post_title,
+            description: post_description,
+            image: post_image,
+        }
         div { class: "flex flex-col gap-6 py-6 px-6 mx-auto w-full max-w-desktop max-tablet:px-2.5",
             PostDetailHeader { detail: detail.clone(), post_pk: post_id.clone() }
             PostContent {

--- a/app/ratel/src/features/spaces/layout.rs
+++ b/app/ratel/src/features/spaces/layout.rs
@@ -105,7 +105,11 @@ pub fn SpaceLayout(space_id: ReadSignal<SpacePartition>) -> Element {
     };
 
     rsx! {
-        SeoMeta { title: space.title.clone(), description: space.description() }
+        SeoMeta {
+            title: space.title.clone(),
+            description: space.description(),
+            image: if space.logo.is_empty() { "https://metadata.ratel.foundation/logos/logo-symbol.png".to_string() } else { space.logo.clone() },
+        }
         div { class: "{layout_class}", "data-testid": "space-layout-container",
             if show_sidebar {
                 SpaceNav {
@@ -139,7 +143,9 @@ pub fn SpaceLayout(space_id: ReadSignal<SpacePartition>) -> Element {
             }
             div { class: "{content_class}",
                 if show_sidebar {
-                    div { class: "max-tablet:w-full max-tablet:fixed max-tablet:top-0 max-tablet:z-50 max-tablet:bg-space-bg", "data-testid": "space-top-wrapper",
+                    div {
+                        class: "max-tablet:w-full max-tablet:fixed max-tablet:top-0 max-tablet:z-50 max-tablet:bg-space-bg",
+                        "data-testid": "space-top-wrapper",
                         SpaceTop {
                             labels,
                             space_status,

--- a/app/ratel/src/views/index/mod.rs
+++ b/app/ratel/src/views/index/mod.rs
@@ -1,3 +1,4 @@
+use crate::common::components::{Robots, SeoMeta};
 use crate::features::posts::components::CreatePostButton;
 use crate::features::timeline::components::{
     DraftTimeline, FollowingTimeline, PopularTimeline, SpaceTimeline, TeamTimeline,
@@ -9,11 +10,35 @@ pub fn Index() -> Element {
     let user_ctx = crate::features::auth::hooks::use_user_context();
     let user = user_ctx().user.clone();
 
+    let keywords = vec![
+        "ratel".to_string(),
+        "knowledge platform".to_string(),
+        "ai knowledge base".to_string(),
+        "human knowledge dataset".to_string(),
+        "ai training data".to_string(),
+        "community intelligence".to_string(),
+        "participatory platform".to_string(),
+        "survey rewards".to_string(),
+        "poll rewards".to_string(),
+        "web3 knowledge economy".to_string(),
+        "ai memory platform".to_string(),
+        "vector knowledge database".to_string(),
+        "collective intelligence".to_string(),
+    ];
+
     rsx! {
-        div { class: "relative flex overflow-x-hidden gap-5 justify-between py-3 pl-2 mx-auto w-full min-h-screen max-tablet:px-2.5",
+        SeoMeta {
+            title: "Ratel – AI Knowledge Platform Powered by Human Essences",
+            description: "Ratel is a participatory knowledge platform where users share expertise, opinions, and insights as structured Essences. AI agents learn from the knowledge base while users earn rewards through surveys, polls, and discussions.",
+            image: "https://metadata.ratel.foundation/logos/logo-symbol.png",
+            url: "https://ratel.foundation",
+            robots: Robots::IndexNofollow,
+            keywords,
+        }
+        div { class: "flex overflow-x-hidden relative gap-5 justify-between py-3 pl-2 mx-auto w-full min-h-screen max-tablet:px-2.5",
             div { class: "flex flex-col gap-4 w-full",
                 if user.is_some() {
-                    CreatePostButton { class: "w-fit self-end" }
+                    CreatePostButton { class: "self-end w-fit" }
                     DraftTimeline {}
                     SpaceTimeline {}
                     FollowingTimeline {}


### PR DESCRIPTION
## Summary

- **Root cause**: Global `SeoMeta` in `app.rs` was rendered first in SSR HTML. Slack/Twitter/LinkedIn crawlers use the **first** `og:title`/`og:description`/`og:image` occurrence, so Ratel branding always won over space-specific content.
- Remove global `SeoMeta` from `app.rs`; move Ratel branding to `Index` (homepage) only
- `SpaceLayout`: add `image` prop — space logo, fallback to Ratel logo when empty
- `PostDetail`: add `SeoMeta` with post title, HTML-stripped description (first 200 chars), and first URL as image

## Changes

| File | Change |
|------|--------|
| `app/ratel/src/app.rs` | Remove global `SeoMeta` |
| `app/ratel/src/views/index/mod.rs` | Add Ratel default `SeoMeta` for homepage |
| `app/ratel/src/features/spaces/layout.rs` | Add `image` prop to existing `SeoMeta` |
| `app/ratel/src/features/posts/views/post_detail/mod.rs` | Add `SeoMeta` with post-specific data |

## Test plan

- [ ] Share a space URL on Slack → preview shows space title, description, and logo
- [ ] Share a space URL with no logo → preview shows Ratel logo
- [ ] Share a post URL on Slack → preview shows post title and description
- [ ] Share a post URL with image URL → preview shows that image
- [ ] Homepage still shows Ratel branding when shared
- [ ] `cargo check --features web` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)