### PR TITLE
fix(vpc-endpoint): restrict SES endpoint to supported AZs in ap-northeast-2

### DIFF
--- a/cdk/lib/vpc-endpoint-stack.ts
+++ b/cdk/lib/vpc-endpoint-stack.ts
@@ -84,10 +84,19 @@ export class VpcEndpointStack extends Stack {
       "Shared services to SES",
     );
 
+    // email-smtp endpoint does not support all AZs in ap-northeast-2 (excludes
+    // ap-northeast-2d). Restrict to the three supported AZs explicitly.
     new ec2.InterfaceVpcEndpoint(this, "SesEndpoint", {
       vpc: this.vpc,
       service: ec2.InterfaceVpcEndpointAwsService.EMAIL_SMTP,
-      subnets: { subnetType: ec2.SubnetType.PUBLIC },
+      subnets: {
+        subnetType: ec2.SubnetType.PUBLIC,
+        availabilityZones: [
+          "ap-northeast-2a",
+          "ap-northeast-2b",
+          "ap-northeast-2c",
+        ],
+      },
       privateDnsEnabled: true,
       securityGroups: [sesEndpointSg],
     });


### PR DESCRIPTION
## Summary
- `email-smtp` VPC interface endpoint in ap-northeast-2 does not support `ap-northeast-2d`
- Deployment failed with `UPDATE_ROLLBACK_COMPLETE` because the default VPC has a subnet in that AZ
- Restrict `subnets.availabilityZones` to `ap-northeast-2a/b/c` to avoid the unsupported AZ

## Test plan
- [ ] Deploy `ratel-vpc-endpoints-ap-northeast-2` stack and verify it reaches `UPDATE_COMPLETE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)