### PR TITLE
fix(workflow): correct artifact path in prod workflow

### DIFF
--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -350,6 +350,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-shell-lambda-${{ github.sha }}
-          path: ${{ github.workspace }}/app-shell.tar.gz
+          path: ${{ github.workspace }}/app-shell-lambda.tar.gz
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
- Updated the artifact path in `upload-artifact` step to ensure the correct file is uploaded.
- Changed from `app-shell.tar.gz` to `app-shell-lambda.tar.gz`.