### PR TITLE
fix(spaces): update role assignment logic in ParticipateCard component

### DIFF
--- a/app/ratel/src/features/spaces/pages/index/participate_card/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/participate_card/component.rs
@@ -65,7 +65,14 @@ pub fn ParticipateCard(
                                 .is_ok()
                             {
                                 on_joined.call(());
-                                ctx.restart();
+                                ctx.space.restart();
+                                if ctx.panel_requirements.is_empty()
+                                    && matches!(ctx.space().status, Some(SpaceStatus::Ongoing))
+                                {
+                                    ctx.role.set(SpaceUserRole::Participant);
+                                } else {
+                                    ctx.role.set(SpaceUserRole::Candidate);
+                                }
                             }
                         }
                     },

--- a/app/ratel/src/features/spaces/pages/index/participate_card/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/participate_card/component.rs
@@ -65,14 +65,7 @@ pub fn ParticipateCard(
                                 .is_ok()
                             {
                                 on_joined.call(());
-                                ctx.space.restart();
-                                if ctx.panel_requirements.is_empty()
-                                    && matches!(ctx.space().status, Some(SpaceStatus::Ongoing))
-                                {
-                                    ctx.role.set(SpaceUserRole::Participant);
-                                } else {
-                                    ctx.role.set(SpaceUserRole::Candidate);
-                                }
+                                ctx.restart();
                             }
                         }
                     },
@@ -197,10 +190,7 @@ fn ConsentModal(
                             .is_ok()
                         {
                             on_joined.call(());
-                            ctx.space.restart();
-                            if let Ok(new_role) = get_user_role(space_id()).await {
-                                ctx.current_role.set(new_role);
-                            }
+                            ctx.restart();
                         }
                     },
                     "{tr.consent_confirm}"


### PR DESCRIPTION
- Adjusted `ctx.restart` to `ctx.space.restart` for better specificity
- Added conditional logic to set user role based on panel requirements
  and space status
- Ensures correct role assignment between `Participant` and `Candidate`