### PR TITLE
fix(spaces): mobile UI improvements for space index pages

### DIFF
--- a/app/ratel/src/features/spaces/pages/index/action_dashboard/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_dashboard/style.css
@@ -252,8 +252,23 @@
 /* ── Responsive ──────────────────────────────────── */
 @media (max-width: 500px) {
   .quest-card { width: 320px; min-height: 340px; padding: 22px 20px 20px; }
+  .quest-card__title { font-size: 17px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .carousel-track { padding-left: calc(50vw - 160px); padding-right: calc(50vw - 160px); gap: 20px; }
   .carousel-wrapper::before, .carousel-wrapper::after { width: 60px; }
-  .bottom-bar { padding: 14px 16px 20px; }
+  .bottom-bar { padding: 10px 16px 16px; gap: 10px; }
+  .quest-progress { gap: 10px; }
+  .quest-progress__label { font-size: 9px; }
+  .quest-progress__bar-wrap { display: none; }
+  .quest-progress__fraction { font-size: 11px; }
+  .quest-progress__fraction::before {
+    content: '';
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: #22c55e;
+    box-shadow: 0 0 6px rgba(34,197,94,0.4);
+    margin-right: 6px;
+    vertical-align: middle;
+  }
   .archive-panel { right: 16px; width: calc(100vw - 32px); }
 }

--- a/app/ratel/src/features/spaces/pages/index/action_pages/poll/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/poll/style.css
@@ -93,6 +93,8 @@
   display: flex;
   align-items: center;
   gap: 14px;
+  flex: 1;
+  min-width: 0;
 }
 .poll-header__back {
   width: 36px;
@@ -122,6 +124,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 .poll-header__type {
   display: inline-flex;
@@ -142,11 +145,15 @@
   font-weight: 700;
   line-height: 1.3;
   color: var(--dark, #f0f0f5) var(--light, #1a1a2e);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .poll-header__right {
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-shrink: 0;
 }
 .poll-header__status {
   display: inline-flex;

--- a/app/ratel/src/features/spaces/pages/index/action_pages/quiz/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/quiz/style.css
@@ -19,7 +19,7 @@
   display: flex; align-items: center; justify-content: space-between;
   padding: 20px 28px; flex-shrink: 0;
 }
-.quiz-topbar__left { display: flex; align-items: center; gap: 14px; }
+.quiz-topbar__left { display: flex; align-items: center; gap: 14px; flex: 1; min-width: 0; }
 .quiz-topbar__back {
   width: 40px; height: 40px; border-radius: 10px;
   background: var(--dark, rgba(12,12,26,0.65)) var(--light, rgba(255,255,255,0.72));
@@ -35,15 +35,17 @@
   font-family: 'Orbitron', sans-serif; font-size: 14px; font-weight: 700;
   letter-spacing: 0.06em; text-transform: uppercase;
   color: var(--dark, #f0f0f5) var(--light, #12121a);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
 }
 .quiz-topbar__badge {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 12px; border-radius: 8px;
   font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
   background: rgba(168,85,247,0.08); color: #a855f7; border: 1px solid rgba(168,85,247,0.18);
+  white-space: nowrap; flex-shrink: 0;
 }
-.quiz-topbar__badge svg { width: 14px; height: 14px; }
-.quiz-topbar__right { display: flex; align-items: center; gap: 14px; }
+.quiz-topbar__badge svg { width: 14px; height: 14px; flex-shrink: 0; }
+.quiz-topbar__right { display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
 
 /* ── Progress ring ───────────────────────────────── */
 .progress-ring { position: relative; width: 48px; height: 48px; flex-shrink: 0; }
@@ -70,8 +72,9 @@
   backdrop-filter: blur(16px);
   border: 1px solid var(--dark, rgba(255,255,255,0.06)) var(--light, rgba(0,0,0,0.08));
   font-size: 11px; font-weight: 600; color: var(--dark, #8888a8) var(--light, #6b6b80);
+  white-space: nowrap; flex-shrink: 0;
 }
-.attempts-chip svg { width: 14px; height: 14px; color: #a855f7; }
+.attempts-chip svg { width: 14px; height: 14px; color: #a855f7; flex-shrink: 0; }
 
 /* ═══════════════════════════════════════════════════
    SCREEN 1 — OVERVIEW

--- a/app/ratel/src/features/spaces/pages/index/arena_topbar/style.css
+++ b/app/ratel/src/features/spaces/pages/index/arena_topbar/style.css
@@ -5,7 +5,6 @@
   display: flex; align-items: center; justify-content: space-between;
   padding: 20px 28px; flex-shrink: 0;
 }
-.arena-topbar__brand { display: flex; align-items: center; gap: 14px; }
 .arena-topbar__logo {
   width: 40px; height: 40px; border-radius: 10px; object-fit: cover;
   border: 1px solid rgba(252,179,0,0.15);
@@ -14,13 +13,18 @@
 .arena-topbar__title {
   font-family: 'Orbitron', sans-serif; font-weight: 700; font-size: 16px;
   letter-spacing: 0.06em; text-transform: uppercase;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.arena-topbar__brand {
+  display: flex; align-items: center; gap: 14px;
+  min-width: 0; flex: 1;
 }
 .arena-topbar__status {
   display: inline-flex; align-items: center; gap: 5px;
   padding: 3px 10px; border-radius: 100px;
   background: rgba(110,237,216,0.08); border: 1px solid rgba(110,237,216,0.15);
   font-size: 10px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
-  color: #6eedd8; margin-left: 12px;
+  color: #6eedd8; margin-left: 12px; white-space: nowrap; flex-shrink: 0;
 }
 .arena-topbar__status::before {
   content: ''; width: 5px; height: 5px; border-radius: 50%;
@@ -76,8 +80,10 @@
 /* ── Responsive ──────────────────────────────────── */
 
 @media (max-width: 500px) {
-  .arena-topbar { padding: 16px; }
+  .arena-topbar { padding: 12px 16px; }
+  .arena-topbar__brand { gap: 10px; }
   .arena-topbar__logo { width: 32px; height: 32px; }
-  .arena-topbar__title { font-size: 13px; }
+  .arena-topbar__title { font-size: 13px; max-width: 120px; }
+  .arena-topbar__status { display: none; }
   .hud-btn { width: 36px; height: 36px; }
 }

--- a/app/ratel/src/features/spaces/pages/index/arena_viewer/style.css
+++ b/app/ratel/src/features/spaces/pages/index/arena_viewer/style.css
@@ -133,6 +133,12 @@
   text-align: center;
   margin-bottom: 8px;
   text-shadow: 0 0 40px rgba(252,179,0,0.15);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 16px;
+  box-sizing: border-box;
 }
 
 .portal-status {

--- a/app/ratel/src/features/spaces/pages/index/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/component.rs
@@ -62,10 +62,24 @@ pub fn SpaceIndexPage(space_id: ReadSignal<SpacePartition>) -> Element {
             crossorigin: "anonymous",
         }
         document::Link {
+            rel: "preload",
+            href: "https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Outfit:wght@300;400;500;600;700&display=swap",
+            r#as: "style",
+        }
+        document::Link {
             rel: "stylesheet",
             href: "https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Outfit:wght@300;400;500;600;700&display=swap",
         }
+        document::Link { rel: "preload", href: asset!("./style.css"), r#as: "style" }
         document::Link { rel: "stylesheet", href: asset!("./style.css") }
+        // Preload sub-component CSS to prevent flash of unstyled content
+        document::Link { rel: "preload", href: asset!("./arena_topbar/style.css"), r#as: "style" }
+        document::Link { rel: "preload", href: asset!("./arena_viewer/style.css"), r#as: "style" }
+        document::Link { rel: "preload", href: asset!("./prerequisite_card/style.css"), r#as: "style" }
+        document::Link { rel: "preload", href: asset!("./action_dashboard/style.css"), r#as: "style" }
+        document::Link { rel: "preload", href: asset!("./action_pages/poll/style.css"), r#as: "style" }
+        document::Link { rel: "preload", href: asset!("./action_pages/quiz/style.css"), r#as: "style" }
+        document::Link { rel: "preload", href: asset!("./action_pages/discussion/style.css"), r#as: "style" }
 
         div { class: "arena", "data-testid": "space-index-page",
             ArenaTopbar {

--- a/app/ratel/src/features/spaces/pages/index/prerequisite_card/style.css
+++ b/app/ratel/src/features/spaces/pages/index/prerequisite_card/style.css
@@ -167,4 +167,15 @@
 
 @media (max-width: 500px) {
   .prereq-card { width: calc(100vw - 32px); padding: 24px 18px 20px; }
+  .prereq-card__progress-bar-wrap { display: none; }
+  .prereq-card__progress-text::before {
+    content: '';
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: #22c55e;
+    box-shadow: 0 0 6px rgba(34,197,94,0.4);
+    margin-right: 6px;
+    vertical-align: middle;
+  }
 }

--- a/app/ratel/src/features/spaces/pages/overview/views/overview_content.rs
+++ b/app/ratel/src/features/spaces/pages/overview/views/overview_content.rs
@@ -44,7 +44,7 @@ pub fn OverviewContent(
         div { class: "flex justify-center px-4 pt-5 mx-auto w-full",
             div { class: "flex flex-col gap-5 w-full max-w-desktop",
                 div { class: "flex gap-2.5 justify-between items-start",
-                    h1 { class: "flex-1 font-bold text-[28px]/[32px] max-mobile:text-xl text-text-primary",
+                    h1 { class: "flex-1 min-w-0 font-bold text-[28px]/[32px] max-mobile:text-xl text-text-primary truncate",
                         "{space.title}"
                     }
                     div { class: "flex gap-2 items-center",
@@ -159,7 +159,7 @@ pub fn OverviewContent(
                     }
                 }
 
-                div { class: "flex flex-wrap justify-between items-center gap-y-2 py-4 border-y border-card-border",
+                div { class: "flex flex-wrap gap-y-2 justify-between items-center py-4 border-y border-card-border",
                     div { class: "flex gap-2.5 items-center min-w-0",
                         div { class: "flex flex-row items-center min-w-0 gap-[8px]",
                             {render_author_avatar(&space.author_profile_url, &space.author_display_name)}

--- a/app/ratel/src/features/spaces/space_common/components/space_top/mod.rs
+++ b/app/ratel/src/features/spaces/space_common/components/space_top/mod.rs
@@ -215,7 +215,7 @@ pub fn SpaceTitle(title: String) -> Element {
                 }
             } else {
                 div {
-                    class: "font-bold text-[15px] text-web-font-primary max-tablet:truncate max-tablet:text-sm",
+                    class: "font-bold text-[15px] text-web-font-primary truncate max-tablet:text-sm",
                     onclick: move |_| {
                         if role().can_edit() {
                             editing.set(true);


### PR DESCRIPTION
- Preload sub-component CSS in space index to prevent flash of unstyled content during page transitions and overlay opens
- Add text truncation on mobile for titles in arena topbar, space top, overview page, quest cards, and quiz/poll action headers
- Replace progress bar with green dot indicator on mobile for action dashboard and prerequisite card
- Hide arena topbar status badge on mobile to prevent overflow
- Add white-space: nowrap to status badges and action chips to prevent unwanted line breaks