### PR TITLE
feat(spaces): add start time setting for spaces with countdown timer

### DIFF
--- a/app/ratel/src/features/spaces/pages/apps/apps/general/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/apps/apps/general/i18n.rs
@@ -211,4 +211,16 @@ translate! {
         en: "Space logo updated successfully.",
         ko: "스페이스 로고가 변경되었습니다.",
     },
+    start_time_setting: {
+        en: "Start Time",
+        ko: "시작 시간",
+    },
+    start_time_description: {
+        en: "Set when this space will start. A countdown will be shown to participants.",
+        ko: "스페이스 시작 시간을 설정합니다. 참여자에게 카운트다운이 표시됩니다.",
+    },
+    start_time_updated_successfully: {
+        en: "Start time updated successfully.",
+        ko: "시작 시간이 변경되었습니다.",
+    },
 }

--- a/app/ratel/src/features/spaces/pages/apps/apps/general/views/home/mod.rs
+++ b/app/ratel/src/features/spaces/pages/apps/apps/general/views/home/mod.rs
@@ -5,6 +5,7 @@ mod invite_participant;
 mod join_anytime_setting;
 mod space_logo_setting;
 mod space_visibility_setting;
+mod start_time_setting;
 use invite_participant::*;
 mod administrators;
 use administrators::*;
@@ -12,6 +13,7 @@ use anonymous_setting::*;
 use join_anytime_setting::*;
 use space_logo_setting::*;
 use space_visibility_setting::*;
+use start_time_setting::*;
 
 const DEFAULT_PROFILE_IMAGE: &str = "https://metadata.ratel.foundation/ratel/default-profile.png";
 
@@ -54,6 +56,8 @@ pub fn SpaceGeneralAppPage(space_id: ReadSignal<SpacePartition>) -> Element {
                 {tr.space_setting}
             }
             SpaceLogoSetting {}
+
+            StartTimeSetting {}
 
             SpaceVisibilitySetting {}
 

--- a/app/ratel/src/features/spaces/pages/apps/apps/general/views/home/start_time_setting.rs
+++ b/app/ratel/src/features/spaces/pages/apps/apps/general/views/home/start_time_setting.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+#[component]
+pub fn StartTimeSetting() -> Element {
+    let mut space = use_space();
+    let tr: GeneralTranslate = use_translate();
+    let mut toast = use_toast();
+
+    rsx! {
+        Card {
+            div { class: "flex justify-between items-center self-stretch py-4 px-5 border-b border-separator",
+                p { class: "font-semibold text-center font-raleway text-[17px]/[20px] tracking-[-0.18px] text-web-font-primary",
+                    {tr.start_time_setting}
+                }
+            }
+
+            div { class: "flex flex-col items-start self-stretch gap-2.5 p-5 bg-card max-mobile:p-4",
+                p { class: "font-normal leading-6 font-raleway text-[15px] tracking-[0.5px] text-card-meta",
+                    {tr.start_time_description}
+                }
+
+                DateAndTimePicker {
+                    initial_started_at: space().started_at,
+                    on_change: move |range: DateTimeRange| async move {
+                        if let Some(start_date) = range.start_date {
+                            let started_at = range
+                                .timezone
+                                .local_to_utc_millis(start_date, range.start_hour, range.start_minute);
+                            let space_id = space().id;
+                            let result = update_space(
+                                    space_id,
+                                    UpdateSpaceRequest::StartTime {
+                                        started_at: Some(started_at),
+                                    },
+                                )
+                                .await;
+                            match result {
+                                Ok(_) => {
+                                    space.with_mut(|s| s.started_at = Some(started_at));
+                                    toast.info(tr.start_time_updated_successfully);
+                                }
+                                Err(err) => {
+                                    toast.error(err);
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+}

--- a/app/ratel/src/features/spaces/pages/index/arena_viewer/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/arena_viewer/component.rs
@@ -34,16 +34,18 @@ pub fn ArenaViewer(
         Some(SpaceStatus::Finished) => tr.status_finished.to_string(),
         _ => tr.status_open.to_string(),
     };
-    let participant_count = space.quota - space.remains;
-    let participants = format_number(participant_count);
-    let remaining = format_number(space.remains);
+    let participants = format_number(space.participants);
+    let remaining = if space.quota == 0 {
+        "-".to_string()
+    } else {
+        format_number(space.remains)
+    };
     let rewards = space
         .rewards
         .map(|r| format_number(r))
         .unwrap_or_else(|| "0".to_string());
 
-    let show_participate =
-        !space.participated && space.can_participate;
+    let show_participate = !space.participated && space.can_participate;
 
     let mut ctx = use_space_context();
     let panel_requirements = ctx.panel_requirements();

--- a/app/ratel/src/features/spaces/pages/index/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/index/i18n.rs
@@ -332,4 +332,28 @@ translate! {
         en: "Waiting for Space to Start",
         ko: "스페이스 시작 대기 중",
     },
+    waiting_participants: {
+        en: "Participants",
+        ko: "참여자",
+    },
+    waiting_starts_in: {
+        en: "Starts In",
+        ko: "시작까지",
+    },
+    waiting_days: {
+        en: "D",
+        ko: "일",
+    },
+    waiting_hours: {
+        en: "H",
+        ko: "시",
+    },
+    waiting_minutes: {
+        en: "M",
+        ko: "분",
+    },
+    waiting_seconds: {
+        en: "S",
+        ko: "초",
+    },
 }

--- a/app/ratel/src/features/spaces/pages/index/signin_card/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/signin_card/component.rs
@@ -23,9 +23,11 @@ pub fn SigninCard(
                     span { class: "stat__value", "{participants}" }
                     span { class: "stat__label", "{tr.participants}" }
                 }
-                div { class: "stat",
-                    span { class: "stat__value", "{remaining}" }
-                    span { class: "stat__label", "{tr.remaining}" }
+                if ctx.space().quota > 0 {
+                    div { class: "stat",
+                        span { class: "stat__value", "{remaining}" }
+                        span { class: "stat__label", "{tr.remaining}" }
+                    }
                 }
                 div { class: "stat",
                     span { class: "stat__value", "{rewards}" }

--- a/app/ratel/src/features/spaces/pages/index/waiting_card/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/waiting_card/component.rs
@@ -1,10 +1,38 @@
 use crate::features::spaces::pages::actions::types::SpaceActionSummary;
 use crate::features::spaces::pages::index::*;
+use crate::features::spaces::space_common::hooks::use_space;
 
 #[component]
 pub fn WaitingCard(prereqs: Vec<SpaceActionSummary>) -> Element {
     let tr: SpaceViewerTranslate = use_translate();
     let lang = use_language();
+    let space = use_space()();
+    let participants = format_number(space.participants);
+
+    let started_at = space.started_at;
+    let mut remaining_secs = use_signal(|| 0i64);
+
+    use_effect(move || {
+        #[cfg(feature = "web")]
+        if let Some(start_ms) = started_at {
+            spawn(async move {
+                loop {
+                    let now_ms = js_sys::Date::now() as i64;
+                    let diff = (start_ms - now_ms) / 1000;
+                    remaining_secs.set(diff.max(0));
+                    if diff <= 0 {
+                        break;
+                    }
+                    gloo_timers::future::sleep(std::time::Duration::from_secs(1)).await;
+                }
+            });
+        }
+    });
+
+    let days = remaining_secs() / 86400;
+    let hours = (remaining_secs() % 86400) / 3600;
+    let minutes = (remaining_secs() % 3600) / 60;
+    let seconds = remaining_secs() % 60;
 
     rsx! {
         document::Link { rel: "stylesheet", href: asset!("./style.css") }
@@ -27,7 +55,39 @@ pub fn WaitingCard(prereqs: Vec<SpaceActionSummary>) -> Element {
             }
 
             span { class: "waiting-card__heading", "{tr.waiting_heading}" }
-            p { class: "waiting-card__desc", "{tr.waiting_desc}" }
+
+            // Countdown timer
+            if started_at.is_some() && remaining_secs() > 0 {
+                div { class: "waiting-card__countdown",
+                    span { class: "waiting-card__countdown-label", "{tr.waiting_starts_in}" }
+                    div { class: "waiting-card__countdown-timer",
+                        if days > 0 {
+                            div { class: "waiting-card__countdown-unit",
+                                span { class: "waiting-card__countdown-value", "{days}" }
+                                span { class: "waiting-card__countdown-suffix", "{tr.waiting_days}" }
+                            }
+                        }
+                        div { class: "waiting-card__countdown-unit",
+                            span { class: "waiting-card__countdown-value", "{hours:02}" }
+                            span { class: "waiting-card__countdown-suffix", "{tr.waiting_hours}" }
+                        }
+                        div { class: "waiting-card__countdown-unit",
+                            span { class: "waiting-card__countdown-value", "{minutes:02}" }
+                            span { class: "waiting-card__countdown-suffix", "{tr.waiting_minutes}" }
+                        }
+                        div { class: "waiting-card__countdown-unit",
+                            span { class: "waiting-card__countdown-value", "{seconds:02}" }
+                            span { class: "waiting-card__countdown-suffix", "{tr.waiting_seconds}" }
+                        }
+                    }
+                }
+            }
+
+            // Participant count
+            div { class: "waiting-card__participants",
+                span { class: "waiting-card__participants-count", "{participants}" }
+                span { class: "waiting-card__participants-label", "{tr.waiting_participants}" }
+            }
 
             // Completed checklist summary
             if !prereqs.is_empty() {

--- a/app/ratel/src/features/spaces/pages/index/waiting_card/style.css
+++ b/app/ratel/src/features/spaces/pages/index/waiting_card/style.css
@@ -52,6 +52,81 @@
   max-width: 300px;
 }
 
+/* ── Countdown ──────────────────────────────────── */
+
+.waiting-card__countdown {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 14px;
+  /* background: var(--dark, rgba(252,179,0,0.06)) var(--light, rgba(252,179,0,0.08)); */
+  /* border: 1px solid rgba(252,179,0,0.15); */
+}
+
+.waiting-card__countdown-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #fcb300;
+}
+
+.waiting-card__countdown-timer {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.waiting-card__countdown-unit {
+  display: flex;
+  align-items: baseline;
+  gap: 1px;
+}
+
+.waiting-card__countdown-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--waiting-text-primary);
+  min-width: 2ch;
+  text-align: center;
+}
+
+.waiting-card__countdown-suffix {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--waiting-text);
+  text-transform: uppercase;
+}
+
+.waiting-card__participants {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 20px;
+  border-radius: 12px;
+  background: var(--dark, rgba(255,255,255,0.04)) var(--light, rgba(0,0,0,0.03));
+  border: 1px solid var(--waiting-border);
+}
+
+.waiting-card__participants-count {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fcb300;
+}
+
+.waiting-card__participants-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--waiting-text);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .waiting-card__list {
   width: 100%;
   display: flex;

--- a/app/ratel/src/features/spaces/space_common/controllers/get_space.rs
+++ b/app/ratel/src/features/spaces/space_common/controllers/get_space.rs
@@ -1,11 +1,14 @@
-use crate::common::*;
 use crate::common::models::space::{SpaceCommon, SpaceParticipant};
 use crate::common::models::{OptionalUser, User};
+use crate::common::*;
 use crate::features::posts::models::Post;
 use crate::features::posts::types::{BoosterType, SpaceType};
 use crate::spaces::{InvitationStatus, SpaceInvitationMember};
 
-#[mcp_tool(name = "get_space", description = "Get space details by ID, including status, visibility, participation info.")]
+#[mcp_tool(
+    name = "get_space",
+    description = "Get space details by ID, including status, visibility, participation info."
+)]
 #[get("/api/spaces/{space_id}", user: OptionalUser)]
 pub async fn get_space(
     #[mcp(description = "Space partition key (e.g. 'SPACE#<uuid>' or '<uuid>')")]
@@ -72,7 +75,8 @@ pub async fn get_space(
     let has_prerequisite = {
         use crate::features::spaces::pages::actions::models::SpaceAction;
         let opt = SpaceAction::opt_all();
-        let (actions, _) = SpaceAction::find_by_space(dynamo, space_pk_partition.clone(), opt).await
+        let (actions, _) = SpaceAction::find_by_space(dynamo, space_pk_partition.clone(), opt)
+            .await
             .unwrap_or_default();
         actions.iter().any(|a| a.prerequisite)
     };
@@ -112,6 +116,7 @@ pub async fn get_space(
         anonymous_participation: space.anonymous_participation,
         join_anytime: space.join_anytime,
         can_participate,
+        participants: space.participants,
         participated,
         participant_display_name,
         participant_profile_url,
@@ -121,6 +126,7 @@ pub async fn get_space(
         is_report: false,
         logo: space.logo,
         has_prerequisite,
+        started_at: space.started_at,
     })
 }
 
@@ -157,6 +163,7 @@ pub struct SpaceResponse {
     #[serde(default)]
     pub join_anytime: bool,
     pub can_participate: bool,
+    pub participants: i64,
     pub participated: bool,
     pub participant_display_name: Option<String>,
     pub participant_profile_url: Option<String>,
@@ -168,6 +175,7 @@ pub struct SpaceResponse {
     pub logo: String,
     #[serde(default)]
     pub has_prerequisite: bool,
+    pub started_at: Option<i64>,
 }
 
 #[cfg(feature = "server")]

--- a/app/ratel/src/features/spaces/space_common/controllers/update_space.rs
+++ b/app/ratel/src/features/spaces/space_common/controllers/update_space.rs
@@ -48,6 +48,9 @@ pub enum UpdateSpaceRequest {
     Logo {
         logo: String,
     },
+    StartTime {
+        started_at: Option<i64>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -67,6 +70,7 @@ pub struct UpdateSpaceResponse {
     pub remains: i64,
     #[serde(default)]
     pub logo: String,
+    pub started_at: Option<i64>,
 }
 
 #[cfg(feature = "server")]
@@ -86,6 +90,7 @@ impl From<SpaceCommon> for UpdateSpaceResponse {
             quota: s.quota,
             remains: s.remains,
             logo: s.logo,
+            started_at: s.started_at,
         }
     }
 }
@@ -220,6 +225,13 @@ pub async fn update_space(
             su = su.with_logo(logo.clone());
 
             updated_space.logo = logo;
+        }
+        UpdateSpaceRequest::StartTime { started_at } => {
+            if let Some(ts) = started_at {
+                su = su.with_started_at(ts);
+            }
+
+            updated_space.started_at = started_at;
         }
         UpdateSpaceRequest::Quota { quotas } => {
             let remains = updated_space.remains + (quotas - updated_space.quota);


### PR DESCRIPTION
- Introduced `StartTimeSetting` component to configure space start time
- Updated `WaitingCard` to display a countdown timer until the space starts
- Enhanced `get_space` and `update_space` controllers to handle `started_at` field
- Added i18n keys for start time and countdown-related strings
- Adjusted styles for countdown timer and participant display in `WaitingCard`