### PR TITLE
refactor(activity): simplify XP calculation and update leaderboard terminology

### DIFF
--- a/.claude/rules/conventions/build-commands.md
+++ b/.claude/rules/conventions/build-commands.md
@@ -4,15 +4,30 @@ globs: ["Makefile", "docker-compose*.yml", "app/ratel/Cargo.toml"]
 
 # Build & Verification Commands
 
-## Dioxus App (app/ratel/)
+## Checking compliation errors (app/ratel/)
 
 ```bash
+```
+
+## Dioxus App (app/ratel/)
+
+### Lint check
+```bash
+# MUST run after nay code change in app/ratel
+# This verifies compliation error for server
+cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features server
+
+# MUST run after nay code change in app/ratel
+# This verifies compliation error for web
+cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features web
+
 # MUST run after any code change in app/ratel/
 cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' dx check --features web
 
 # Dev server (port 8000)
 cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev dx serve --port 8000 --web
 ```
+
 
 **`DYNAMO_TABLE_PREFIX` is required at compile time** for DynamoEntity. Use `ratel-dev` for dev, `ratel-local` for Docker local.
 
@@ -28,6 +43,9 @@ cd playwright && npx playwright test <file>
 
 ```bash
 make run          # all services
-make infra        # infrastructure only (LocalStack, DynamoDB)
+AWS_REGION=ap-northeast-2 AWS_DEFAULT_REGION=ap-northeast-2 make infra        # infrastructure only (LocalStack, DynamoDB)
 make stop         # stop all
+
+docker start ratel-localstack-init-1 # Reset database
 ```
+

--- a/app/ratel/js/src/membership/index.js
+++ b/app/ratel/js/src/membership/index.js
@@ -11,9 +11,16 @@ function requestIdentityVerification(storeId, channelKey, prefix) {
     storeId,
     identityVerificationId,
     channelKey,
+    // bypass: {
+    //   inicisUnified: {
+    //     flgFixedUser: "N",
+    //     directAgency: "PASS",
+    //     logoUrl: "https://metadata.ratel.foundation/logos/logo-symbol.png",
+    //   },
+    // },
   };
   return window.PortOne.requestIdentityVerification(payload).then(
-    () => identityVerificationId
+    () => identityVerificationId,
   );
 }
 

--- a/app/ratel/src/common/models/auth/user_follow.rs
+++ b/app/ratel/src/common/models/auth/user_follow.rs
@@ -12,6 +12,14 @@ pub struct UserFollow {
 
     pub user_pk: Partition,
     pub target_user_pk: Partition,
+    #[serde(default)]
+    pub space_id: Option<String>,
+    #[serde(default)]
+    pub action_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub profile_url: Option<String>,
 }
 
 #[cfg(feature = "server")]
@@ -19,6 +27,17 @@ impl UserFollow {
     pub fn new_follow_records(
         follower_pk: Partition,
         target_pk: Partition,
+    ) -> (Self, Self) {
+        Self::new_follow_records_with_space(follower_pk, target_pk, None, None, None, None)
+    }
+
+    pub fn new_follow_records_with_space(
+        follower_pk: Partition,
+        target_pk: Partition,
+        space_id: Option<String>,
+        action_id: Option<String>,
+        display_name: Option<String>,
+        profile_url: Option<String>,
     ) -> (Self, Self) {
         let now = get_now_timestamp_millis();
         let follower_id = follower_pk.to_string();
@@ -30,6 +49,10 @@ impl UserFollow {
             created_at: now,
             user_pk: follower_pk.clone(),
             target_user_pk: target_pk.clone(),
+            space_id: space_id.clone(),
+            action_id: action_id.clone(),
+            display_name: display_name.clone(),
+            profile_url: profile_url.clone(),
         };
 
         let following_record = UserFollow {
@@ -38,6 +61,10 @@ impl UserFollow {
             created_at: now,
             user_pk: follower_pk,
             target_user_pk: target_pk,
+            space_id,
+            action_id,
+            display_name,
+            profile_url,
         };
 
         (follower_record, following_record)

--- a/app/ratel/src/common/stream_handler.rs
+++ b/app/ratel/src/common/stream_handler.rs
@@ -56,11 +56,25 @@ pub async fn handle_stream_record(
 
             if sk.starts_with("SPACE_POST_COMMENT#") {
                 // AiModeratorReplyIndex: index comment into Qdrant
-                let comment = deserialize(image)?;
+                let comment: crate::features::spaces::pages::actions::actions::discussion::SpacePostComment = deserialize(image)?;
                 if let Err(e) =
-                    crate::features::rag::qdrant::indexers::reply_indexer::index_reply(comment).await
+                    crate::features::rag::qdrant::indexers::reply_indexer::index_reply(comment.clone()).await
                 {
                     tracing::error!(error = %e, "stream: AiModeratorReplyIndex failed");
+                }
+                // DiscussionXpRecord: record XP for discussion comment
+                if let Err(e) =
+                    crate::features::activity::services::handle_discussion_xp(comment).await
+                {
+                    tracing::error!(error = %e, "stream: DiscussionXpRecord failed");
+                }
+            } else if sk.starts_with("SPACE_POST_COMMENT_REPLY#") {
+                // DiscussionXpRecord: record XP for discussion reply
+                let comment = deserialize(image)?;
+                if let Err(e) =
+                    crate::features::activity::services::handle_discussion_xp(comment).await
+                {
+                    tracing::error!(error = %e, "stream: DiscussionXpRecord (reply) failed");
                 }
             } else if sk == "POST" || sk.starts_with("POST") {
                 // PostVectorIndex for newly inserted published posts
@@ -97,6 +111,30 @@ pub async fn handle_stream_record(
                     .await
                 {
                     tracing::error!(error = %e, "stream: SpaceStatusChangeEvent failed");
+                }
+            } else if sk.starts_with("SPACE_POLL_USER_ANSWER#") {
+                // PollXpRecord: record XP for poll answer
+                let answer = deserialize(image)?;
+                if let Err(e) =
+                    crate::features::activity::services::handle_poll_xp(answer).await
+                {
+                    tracing::error!(error = %e, "stream: PollXpRecord failed");
+                }
+            } else if sk.starts_with("SPACE_QUIZ_ATTEMPT#") {
+                // QuizXpRecord: record XP for quiz attempt
+                let attempt = deserialize(image)?;
+                if let Err(e) =
+                    crate::features::activity::services::handle_quiz_xp(attempt).await
+                {
+                    tracing::error!(error = %e, "stream: QuizXpRecord failed");
+                }
+            } else if sk.starts_with("FOLLOWER#") {
+                // FollowXpRecord: record XP for follow action
+                let follow = deserialize(image)?;
+                if let Err(e) =
+                    crate::features::activity::services::handle_follow_xp(follow).await
+                {
+                    tracing::error!(error = %e, "stream: FollowXpRecord failed");
                 }
             }
         }

--- a/app/ratel/src/common/types/event_bridge_envelope.rs
+++ b/app/ratel/src/common/types/event_bridge_envelope.rs
@@ -30,6 +30,10 @@ pub enum DetailType {
     AiModeratorReplyIndex,
     ActivityScoreAggregate,
     SpaceStatusChangeEvent,
+    PollXpRecord,
+    QuizXpRecord,
+    DiscussionXpRecord,
+    FollowXpRecord,
     #[serde(other)]
     Unknown,
 }
@@ -116,6 +120,22 @@ impl EventBridgeEnvelope {
                     DetailType::parse_detail(&self.detail)?;
                 crate::features::spaces::space_common::services::handle_space_status_change(event)
                     .await
+            }
+            DetailType::PollXpRecord => {
+                let answer = DetailType::parse_detail(&self.detail)?;
+                crate::features::activity::services::handle_poll_xp(answer).await
+            }
+            DetailType::QuizXpRecord => {
+                let attempt = DetailType::parse_detail(&self.detail)?;
+                crate::features::activity::services::handle_quiz_xp(attempt).await
+            }
+            DetailType::DiscussionXpRecord => {
+                let comment = DetailType::parse_detail(&self.detail)?;
+                crate::features::activity::services::handle_discussion_xp(comment).await
+            }
+            DetailType::FollowXpRecord => {
+                let follow = DetailType::parse_detail(&self.detail)?;
+                crate::features::activity::services::handle_follow_xp(follow).await
             }
             DetailType::Unknown => {
                 tracing::warn!(

--- a/app/ratel/src/features/activity/components/mod.rs
+++ b/app/ratel/src/features/activity/components/mod.rs
@@ -1,5 +1,3 @@
-mod activity_score_setting;
 mod ranking_widget;
 
-pub use activity_score_setting::*;
 pub use ranking_widget::*;

--- a/app/ratel/src/features/activity/controllers/mod.rs
+++ b/app/ratel/src/features/activity/controllers/mod.rs
@@ -6,4 +6,4 @@ mod record_activity;
 pub use get_ranking::*;
 pub use get_my_score::*;
 #[cfg(feature = "server")]
-pub(crate) use record_activity::*;
+pub use record_activity::*;

--- a/app/ratel/src/features/activity/controllers/record_activity.rs
+++ b/app/ratel/src/features/activity/controllers/record_activity.rs
@@ -27,7 +27,7 @@ fn calculate_xp(data: &SpaceActivityData) -> i64 {
 }
 
 #[cfg(feature = "server")]
-pub(crate) async fn record_activity(
+pub async fn record_activity(
     cli: &aws_sdk_dynamodb::Client,
     space_id: SpacePartition,
     author: AuthorPartition,

--- a/app/ratel/src/features/activity/controllers/record_activity.rs
+++ b/app/ratel/src/features/activity/controllers/record_activity.rs
@@ -1,44 +1,27 @@
 use crate::features::activity::models::SpaceActivity;
 use crate::features::activity::*;
 
+/// Fixed XP values per activity type
 #[cfg(feature = "server")]
-fn calculate_base_score(data: &SpaceActivityData, activity_score: i64) -> i64 {
-    match data {
-        SpaceActivityData::Poll { .. } => activity_score,
-        SpaceActivityData::Follow { .. } => activity_score,
-        SpaceActivityData::Quiz { passed, .. } => {
-            if *passed {
-                activity_score
-            } else {
-                0
-            }
-        }
-        SpaceActivityData::Discussion {
-            is_first_contribution,
-            ..
-        } => {
-            if *is_first_contribution {
-                activity_score
-            } else {
-                0
-            }
-        }
-        SpaceActivityData::Unknown => 0,
-    }
-}
+pub const XP_FOLLOW: i64 = 1_000;
+#[cfg(feature = "server")]
+pub const XP_QUIZ_PASSED: i64 = 20_000;
+#[cfg(feature = "server")]
+pub const XP_QUIZ_FAILED: i64 = 1_000;
+#[cfg(feature = "server")]
+pub const XP_DISCUSSION_REPLY: i64 = 5_000;
+#[cfg(feature = "server")]
+pub const XP_POLL: i64 = 50_000;
 
 #[cfg(feature = "server")]
-fn calculate_additional_score(data: &SpaceActivityData, additional_score_per_item: i64) -> i64 {
+fn calculate_xp(data: &SpaceActivityData) -> i64 {
     match data {
-        SpaceActivityData::Poll {
-            answered_optional_count,
-            ..
-        } => additional_score_per_item * (*answered_optional_count as i64),
-        SpaceActivityData::Quiz { correct_count, .. } => {
-            additional_score_per_item * (*correct_count as i64)
+        SpaceActivityData::Poll { .. } => XP_POLL,
+        SpaceActivityData::Follow { .. } => XP_FOLLOW,
+        SpaceActivityData::Quiz { passed, .. } => {
+            if *passed { XP_QUIZ_PASSED } else { XP_QUIZ_FAILED }
         }
-        SpaceActivityData::Discussion { .. } => additional_score_per_item,
-        SpaceActivityData::Follow { .. } => 0,
+        SpaceActivityData::Discussion { .. } => XP_DISCUSSION_REPLY,
         SpaceActivityData::Unknown => 0,
     }
 }
@@ -50,14 +33,11 @@ pub(crate) async fn record_activity(
     author: AuthorPartition,
     action_id: String,
     action_type: crate::features::spaces::pages::actions::types::SpaceActionType,
-    activity_score: i64,
-    additional_score_per_item: i64,
     data: SpaceActivityData,
     user_name: String,
     user_avatar: String,
 ) -> crate::common::Result<()> {
-    let base = calculate_base_score(&data, activity_score);
-    let additional = calculate_additional_score(&data, additional_score_per_item);
+    let xp = calculate_xp(&data);
 
     let activity = SpaceActivity::new(
         space_id,
@@ -65,8 +45,8 @@ pub(crate) async fn record_activity(
         action_id,
         action_type,
         data,
-        base,
-        additional,
+        xp,
+        0,
         user_name,
         user_avatar,
     );

--- a/app/ratel/src/features/activity/services/handle_xp_event.rs
+++ b/app/ratel/src/features/activity/services/handle_xp_event.rs
@@ -1,0 +1,183 @@
+#[cfg(feature = "server")]
+pub async fn handle_poll_xp(
+    answer: crate::features::spaces::pages::actions::actions::poll::SpacePollUserAnswer,
+) -> crate::common::Result<()> {
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    let space_id_str = answer.space_id.clone().unwrap_or_default();
+    if space_id_str.is_empty() {
+        tracing::warn!("PollXpRecord: missing space_id, skipping");
+        return Ok(());
+    }
+
+    let user_pk = match &answer.user_pk {
+        Some(pk) => pk.clone(),
+        None => {
+            tracing::warn!("PollXpRecord: missing user_pk, skipping");
+            return Ok(());
+        }
+    };
+
+    let space_partition = crate::common::types::SpacePartition(space_id_str);
+    let author = crate::features::activity::types::AuthorPartition::from(user_pk);
+
+    // Extract poll_id from sk: SPACE_POLL_USER_ANSWER#space_pk#poll_sk
+    let poll_id = answer.sk.to_string();
+
+    let user_name = answer.display_name.unwrap_or_default();
+    let user_avatar = answer.profile_url.unwrap_or_default();
+
+    crate::features::activity::controllers::record_activity(
+        cli,
+        space_partition,
+        author,
+        poll_id.clone(),
+        crate::features::spaces::pages::actions::types::SpaceActionType::Poll,
+        crate::features::activity::types::SpaceActivityData::Poll {
+            poll_id,
+            answered_optional_count: 0,
+        },
+        user_name,
+        user_avatar,
+    )
+    .await
+}
+
+#[cfg(feature = "server")]
+pub async fn handle_quiz_xp(
+    attempt: crate::features::spaces::pages::actions::actions::quiz::SpaceQuizAttempt,
+) -> crate::common::Result<()> {
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    let space_id_str = attempt.space_id.clone().unwrap_or_default();
+    if space_id_str.is_empty() {
+        tracing::warn!("QuizXpRecord: missing space_id, skipping");
+        return Ok(());
+    }
+
+    let user_pk = match &attempt.user_pk {
+        Some(pk) => pk.clone(),
+        None => {
+            tracing::warn!("QuizXpRecord: missing user_pk, skipping");
+            return Ok(());
+        }
+    };
+
+    let space_partition = crate::common::types::SpacePartition(space_id_str);
+    let author = crate::features::activity::types::AuthorPartition::from(user_pk);
+
+    let quiz_id = attempt.sk.to_string();
+    let pass_threshold = attempt.pass_threshold.unwrap_or(0);
+    let passed = attempt.score >= pass_threshold;
+
+    let user_name = attempt.display_name.unwrap_or_default();
+    let user_avatar = attempt.profile_url.unwrap_or_default();
+
+    crate::features::activity::controllers::record_activity(
+        cli,
+        space_partition,
+        author,
+        quiz_id.clone(),
+        crate::features::spaces::pages::actions::types::SpaceActionType::Quiz,
+        crate::features::activity::types::SpaceActivityData::Quiz {
+            quiz_id,
+            passed,
+            correct_count: attempt.score as u32,
+            pass_threshold: pass_threshold as u32,
+        },
+        user_name,
+        user_avatar,
+    )
+    .await
+}
+
+#[cfg(feature = "server")]
+pub async fn handle_discussion_xp(
+    comment: crate::features::spaces::pages::actions::actions::discussion::SpacePostComment,
+) -> crate::common::Result<()> {
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    let space_pk = match &comment.space_pk {
+        Some(pk) => pk.clone(),
+        None => {
+            tracing::warn!("DiscussionXpRecord: missing space_pk, skipping");
+            return Ok(());
+        }
+    };
+
+    let space_id_str = match &space_pk {
+        crate::common::types::Partition::Space(id) => id.clone(),
+        _ => space_pk.to_string(),
+    };
+    let space_partition = crate::common::types::SpacePartition(space_id_str);
+
+    let author =
+        crate::features::activity::types::AuthorPartition::from(comment.author_pk.clone());
+
+    // pk is the SpacePost partition (discussion reference), use as action_id
+    let discussion_id = comment.pk.to_string();
+
+    let is_first_contribution = comment.parent_comment_sk.is_none();
+
+    crate::features::activity::controllers::record_activity(
+        cli,
+        space_partition,
+        author,
+        discussion_id.clone(),
+        crate::features::spaces::pages::actions::types::SpaceActionType::TopicDiscussion,
+        crate::features::activity::types::SpaceActivityData::Discussion {
+            discussion_id,
+            is_first_contribution,
+        },
+        comment.author_display_name,
+        comment.author_profile_url,
+    )
+    .await
+}
+
+#[cfg(feature = "server")]
+pub async fn handle_follow_xp(
+    follow: crate::common::models::auth::UserFollow,
+) -> crate::common::Result<()> {
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    let space_id_str = match &follow.space_id {
+        Some(id) if !id.is_empty() => id.clone(),
+        _ => {
+            tracing::warn!("FollowXpRecord: missing space_id, skipping");
+            return Ok(());
+        }
+    };
+
+    let action_id = match &follow.action_id {
+        Some(id) if !id.is_empty() => id.clone(),
+        _ => {
+            tracing::warn!("FollowXpRecord: missing action_id, skipping");
+            return Ok(());
+        }
+    };
+
+    let space_partition = crate::common::types::SpacePartition(space_id_str);
+    let author = crate::features::activity::types::AuthorPartition::from(follow.user_pk);
+
+    let user_name = follow.display_name.unwrap_or_default();
+    let user_avatar = follow.profile_url.unwrap_or_default();
+
+    crate::features::activity::controllers::record_activity(
+        cli,
+        space_partition,
+        author,
+        action_id.clone(),
+        crate::features::spaces::pages::actions::types::SpaceActionType::Follow,
+        crate::features::activity::types::SpaceActivityData::Follow {
+            follow_id: action_id,
+        },
+        user_name,
+        user_avatar,
+    )
+    .await
+}

--- a/app/ratel/src/features/activity/services/mod.rs
+++ b/app/ratel/src/features/activity/services/mod.rs
@@ -1,3 +1,5 @@
 mod aggregate_score;
+mod handle_xp_event;
 
 pub use aggregate_score::*;
+pub use handle_xp_event::*;

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/add_comment.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/add_comment.rs
@@ -104,8 +104,6 @@ pub async fn add_comment(
             author_partition,
             discussion_sk.to_string(),
             crate::features::spaces::pages::actions::types::SpaceActionType::TopicDiscussion,
-            space_action.activity_score,
-            space_action.additional_score,
             crate::features::activity::types::SpaceActivityData::Discussion {
                 discussion_id: discussion_sk.to_string(),
                 is_first_contribution: true,

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/add_comment.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/add_comment.rs
@@ -95,25 +95,7 @@ pub async fn add_comment(
         }
     }
 
-    {
-        let author_partition = crate::features::activity::types::AuthorPartition::from(member.pk.clone());
-
-        if let Err(e) = crate::features::activity::controllers::record_activity(
-            cli,
-            space_id.clone(),
-            author_partition,
-            discussion_sk.to_string(),
-            crate::features::spaces::pages::actions::types::SpaceActionType::TopicDiscussion,
-            crate::features::activity::types::SpaceActivityData::Discussion {
-                discussion_id: discussion_sk.to_string(),
-                is_first_contribution: true,
-            },
-            member.display_name.clone(),
-            member.profile_url.clone(),
-        ).await {
-            tracing::error!(error = %e, "Failed to record discussion activity");
-        }
-    }
+    // XP recording is now handled via EventBridge on SPACE_POST_COMMENT# INSERT
 
     // Send mention notifications
     {

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/reply_comment.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/reply_comment.rs
@@ -111,8 +111,6 @@ pub async fn reply_comment(
             author_partition,
             discussion_sk.to_string(),
             crate::features::spaces::pages::actions::types::SpaceActionType::TopicDiscussion,
-            space_action.activity_score,
-            space_action.additional_score,
             crate::features::activity::types::SpaceActivityData::Discussion {
                 discussion_id: discussion_sk.to_string(),
                 is_first_contribution: false,

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/reply_comment.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/reply_comment.rs
@@ -102,25 +102,7 @@ pub async fn reply_comment(
         }
     }
 
-    {
-        let author_partition = crate::features::activity::types::AuthorPartition::from(member.pk.clone());
-
-        if let Err(e) = crate::features::activity::controllers::record_activity(
-            cli,
-            space_id.clone(),
-            author_partition,
-            discussion_sk.to_string(),
-            crate::features::spaces::pages::actions::types::SpaceActionType::TopicDiscussion,
-            crate::features::activity::types::SpaceActivityData::Discussion {
-                discussion_id: discussion_sk.to_string(),
-                is_first_contribution: false,
-            },
-            member.display_name.clone(),
-            member.profile_url.clone(),
-        ).await {
-            tracing::error!(error = %e, "Failed to record reply activity");
-        }
-    }
+    // XP recording is now handled via EventBridge on SPACE_POST_COMMENT_REPLY# INSERT
 
     // Send mention notifications
     {

--- a/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/follow_user.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/follow_user.rs
@@ -118,28 +118,19 @@ pub async fn follow_user(
     }
 
     {
-        let follow_space_action = crate::features::spaces::pages::actions::models::SpaceAction::get(
+        if let Err(e) = crate::features::activity::controllers::record_activity(
             cli,
-            &CompositePartition(space_id.clone(), follow_id.to_string()),
-            Some(EntityType::SpaceAction),
-        ).await.ok().flatten();
-        if let Some(ref sa) = follow_space_action {
-            if let Err(e) = crate::features::activity::controllers::record_activity(
-                cli,
-                space_id.clone(),
-                crate::features::activity::types::AuthorPartition::from(user.pk.clone()),
-                follow_id.to_string(),
-                crate::features::spaces::pages::actions::types::SpaceActionType::Follow,
-                sa.activity_score,
-                sa.additional_score,
-                crate::features::activity::types::SpaceActivityData::Follow {
-                    follow_id: follow_id.to_string(),
-                },
-                member.display_name.clone(),
-                member.profile_url.clone(),
-            ).await {
-                tracing::error!(error = %e, "Failed to record follow activity");
-            }
+            space_id.clone(),
+            crate::features::activity::types::AuthorPartition::from(user.pk.clone()),
+            follow_id.to_string(),
+            crate::features::spaces::pages::actions::types::SpaceActionType::Follow,
+            crate::features::activity::types::SpaceActivityData::Follow {
+                follow_id: follow_id.to_string(),
+            },
+            member.display_name.clone(),
+            member.profile_url.clone(),
+        ).await {
+            tracing::error!(error = %e, "Failed to record follow activity");
         }
     }
 

--- a/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/follow_user.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/follow/controllers/follow_user.rs
@@ -50,7 +50,14 @@ pub async fn follow_user(
     }
 
     let (follower_record, following_record) =
-        UserFollow::new_follow_records(user.pk.clone(), target_pk.clone());
+        UserFollow::new_follow_records_with_space(
+            user.pk.clone(),
+            target_pk.clone(),
+            Some(space_id.to_string()),
+            Some(follow_id.to_string()),
+            Some(member.display_name.clone()),
+            Some(member.profile_url.clone()),
+        );
 
     let follow_tx = follower_record.create_transact_write_item();
     let following_tx = following_record.create_transact_write_item();
@@ -117,22 +124,7 @@ pub async fn follow_user(
         }
     }
 
-    {
-        if let Err(e) = crate::features::activity::controllers::record_activity(
-            cli,
-            space_id.clone(),
-            crate::features::activity::types::AuthorPartition::from(user.pk.clone()),
-            follow_id.to_string(),
-            crate::features::spaces::pages::actions::types::SpaceActionType::Follow,
-            crate::features::activity::types::SpaceActivityData::Follow {
-                follow_id: follow_id.to_string(),
-            },
-            member.display_name.clone(),
-            member.profile_url.clone(),
-        ).await {
-            tracing::error!(error = %e, "Failed to record follow activity");
-        }
-    }
+    // XP recording is now handled via EventBridge on FOLLOWER# INSERT
 
     Ok(())
 }

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/respond_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/respond_poll.rs
@@ -306,8 +306,6 @@ pub async fn respond_poll(
                 crate::features::activity::types::AuthorPartition::from(activity_user_pk),
                 poll_action_id.clone(),
                 SpaceActionType::Poll,
-                space_action.activity_score,
-                space_action.additional_score,
                 crate::features::activity::types::SpaceActivityData::Poll {
                     poll_id: poll_sk.to_string(),
                     answered_optional_count: optional_count,

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/respond_poll.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/controllers/respond_poll.rs
@@ -230,7 +230,6 @@ pub async fn respond_poll(
             .await?;
     } else {
         let respondent = get_respondent_from_panels(cli, &space_pk, &member.pk).await?;
-        let activity_answers = req.answers.clone();
         let answer_record = SpacePollUserAnswer::new(
             space_pk.clone(),
             poll_sk_entity.clone(),
@@ -250,10 +249,6 @@ pub async fn respond_poll(
                 &space_pk, 1,
             );
         crate::transact_write_items!(cli, vec![agg_item]).ok();
-
-        let activity_user_pk = user.pk.clone();
-        let activity_user_name = member.display_name.clone();
-        let activity_user_avatar = member.profile_url.clone();
 
         match SpaceReward::get_by_action(
             cli,
@@ -286,36 +281,7 @@ pub async fn respond_poll(
             }
         }
 
-        {
-            let optional_count = poll.questions.iter().enumerate().filter(|(i, q)| {
-                let is_required = match q {
-                    Question::SingleChoice(cq) => cq.is_required,
-                    Question::MultipleChoice(cq) => cq.is_required,
-                    Question::ShortAnswer(sq) => sq.is_required,
-                    Question::Subjective(sq) => sq.is_required,
-                    Question::Checkbox(cq) => cq.is_required,
-                    Question::Dropdown(dq) => dq.is_required,
-                    Question::LinearScale(lq) => lq.is_required,
-                };
-                is_required != Some(true) && activity_answers.get(*i).is_some()
-            }).count() as u32;
-
-            if let Err(e) = crate::features::activity::controllers::record_activity(
-                cli,
-                space_partition.clone(),
-                crate::features::activity::types::AuthorPartition::from(activity_user_pk),
-                poll_action_id.clone(),
-                SpaceActionType::Poll,
-                crate::features::activity::types::SpaceActivityData::Poll {
-                    poll_id: poll_sk.to_string(),
-                    answered_optional_count: optional_count,
-                },
-                activity_user_name,
-                activity_user_avatar,
-            ).await {
-                tracing::error!(error = %e, "Failed to record poll activity");
-            }
-        }
+        // XP recording is now handled via EventBridge on SPACE_POLL_USER_ANSWER# INSERT
     }
 
     Ok(RespondPollResponse {})

--- a/app/ratel/src/features/spaces/pages/actions/actions/poll/models/space_poll_user_answer.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/poll/models/space_poll_user_answer.rs
@@ -23,6 +23,8 @@ pub struct SpacePollUserAnswer {
     pub display_name: Option<String>,
     pub profile_url: Option<String>,
     pub username: Option<String>,
+    #[serde(default)]
+    pub space_id: Option<String>,
 }
 
 #[cfg(feature = "server")]
@@ -37,6 +39,10 @@ impl SpacePollUserAnswer {
         let user_pk = author.pk;
         let created_at = get_now_timestamp_millis();
         let (pk, sk) = Self::keys(&user_pk, &poll_sk, &space_pk);
+        let space_id_str = match &space_pk {
+            Partition::Space(id) => id.clone(),
+            _ => space_pk.to_string(),
+        };
         Self {
             pk: pk.clone(),
             sk,
@@ -47,6 +53,7 @@ impl SpacePollUserAnswer {
             display_name: Some(author.display_name),
             profile_url: Some(author.profile_url),
             username: Some(author.username),
+            space_id: Some(space_id_str),
         }
     }
     // FIXME: Because of EntityType(String, String) Type cannot deserialize from string

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/respond_quiz.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/respond_quiz.rs
@@ -88,11 +88,9 @@ pub async fn respond_quiz(
     }
 
     let already_passed = attempts.iter().any(|a| a.score >= quiz.pass_score);
-    if score >= quiz.pass_score && !already_passed {
-        let activity_user_pk = user.pk.clone();
-        let activity_user_name = member.display_name.clone();
-        let activity_user_avatar = member.profile_url.clone();
+    let passed = score >= quiz.pass_score;
 
+    if passed && !already_passed {
         match SpaceReward::get_by_action(
             cli,
             space_id.clone(),
@@ -103,7 +101,7 @@ pub async fn respond_quiz(
         {
             Ok(space_reward) => {
                 if let Err(e) =
-                    SpaceReward::award(cli, &space_reward, user.pk, Some(space.user_pk.clone()))
+                    SpaceReward::award(cli, &space_reward, user.pk.clone(), Some(space.user_pk.clone()))
                         .await
                 {
                     tracing::error!(
@@ -123,27 +121,26 @@ pub async fn respond_quiz(
                 );
             }
         }
+    }
 
-        {
-            if let Err(e) = crate::features::activity::controllers::record_activity(
-                cli,
-                space_id.clone(),
-                crate::features::activity::types::AuthorPartition::from(activity_user_pk),
-                quiz_action_id.clone(),
-                crate::features::spaces::pages::actions::types::SpaceActionType::Quiz,
-                space_action.activity_score,
-                space_action.additional_score,
-                crate::features::activity::types::SpaceActivityData::Quiz {
-                    quiz_id: quiz_id.to_string(),
-                    passed: true,
-                    correct_count: score as u32,
-                    pass_threshold: quiz.pass_score as u32,
-                },
-                activity_user_name,
-                activity_user_avatar,
-            ).await {
-                tracing::error!(error = %e, "Failed to record quiz activity");
-            }
+    // Record XP for both passed and failed attempts
+    {
+        if let Err(e) = crate::features::activity::controllers::record_activity(
+            cli,
+            space_id.clone(),
+            crate::features::activity::types::AuthorPartition::from(user.pk),
+            quiz_action_id.clone(),
+            crate::features::spaces::pages::actions::types::SpaceActionType::Quiz,
+            crate::features::activity::types::SpaceActivityData::Quiz {
+                quiz_id: quiz_id.to_string(),
+                passed,
+                correct_count: score as u32,
+                pass_threshold: quiz.pass_score as u32,
+            },
+            member.display_name.clone(),
+            member.profile_url.clone(),
+        ).await {
+            tracing::error!(error = %e, "Failed to record quiz activity");
         }
     }
     Ok(())

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/respond_quiz.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/controllers/respond_quiz.rs
@@ -77,7 +77,7 @@ pub async fn respond_quiz(
         return Err(SpaceActionQuizError::NoRemainingAttempts.into());
     }
     let score = calculate_score(&quiz.questions, &correct.answers, &req.answers)?;
-    let attempt = SpaceQuizAttempt::new(quiz_id.clone(), member.clone(), req.answers, score);
+    let attempt = SpaceQuizAttempt::new(space_id.clone(), quiz_id.clone(), member.clone(), req.answers, score, quiz.pass_score);
     attempt.create(cli).await?;
 
     if attempts.is_empty() {
@@ -123,26 +123,7 @@ pub async fn respond_quiz(
         }
     }
 
-    // Record XP for both passed and failed attempts
-    {
-        if let Err(e) = crate::features::activity::controllers::record_activity(
-            cli,
-            space_id.clone(),
-            crate::features::activity::types::AuthorPartition::from(user.pk),
-            quiz_action_id.clone(),
-            crate::features::spaces::pages::actions::types::SpaceActionType::Quiz,
-            crate::features::activity::types::SpaceActivityData::Quiz {
-                quiz_id: quiz_id.to_string(),
-                passed,
-                correct_count: score as u32,
-                pass_threshold: quiz.pass_score as u32,
-            },
-            member.display_name.clone(),
-            member.profile_url.clone(),
-        ).await {
-            tracing::error!(error = %e, "Failed to record quiz activity");
-        }
-    }
+    // XP recording is now handled via EventBridge on SPACE_QUIZ_ATTEMPT# INSERT
     Ok(())
 }
 

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/models/space_quiz_attempt.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/models/space_quiz_attempt.rs
@@ -24,15 +24,21 @@ pub struct SpaceQuizAttempt {
     pub profile_url: Option<String>,
     #[serde(default)]
     pub username: Option<String>,
+    #[serde(default)]
+    pub space_id: Option<String>,
+    #[serde(default)]
+    pub pass_threshold: Option<i64>,
 }
 
 #[cfg(feature = "server")]
 impl SpaceQuizAttempt {
     pub fn new(
+        space_id: SpacePartition,
         quiz_id: SpaceQuizEntityType,
         author: crate::common::models::space::SpaceUser,
         answers: Vec<Answer>,
         score: i64,
+        pass_threshold: i64,
     ) -> Self {
         let created_at = get_now_timestamp_millis();
         let attempt_id = uuid::Uuid::now_v7().to_string();
@@ -51,6 +57,8 @@ impl SpaceQuizAttempt {
             display_name: Some(author.display_name),
             profile_url: Some(author.profile_url),
             username: Some(author.username),
+            space_id: Some(space_id.to_string()),
+            pass_threshold: Some(pass_threshold),
         }
     }
 

--- a/app/ratel/src/features/spaces/pages/actions/components/action_common_settings/mod.rs
+++ b/app/ratel/src/features/spaces/pages/actions/components/action_common_settings/mod.rs
@@ -119,16 +119,12 @@ pub fn ActionCommonSettings(
                     initial_ended_at: Some(setting.ended_at),
                     on_change: move |range: DateTimeRange| async move {
                         if let (Some(start_date), Some(end_date)) = (range.start_date, range.end_date) {
-                            let started_at = range.timezone.local_to_utc_millis(
-                                start_date,
-                                range.start_hour,
-                                range.start_minute,
-                            );
-                            let ended_at = range.timezone.local_to_utc_millis(
-                                end_date,
-                                range.end_hour,
-                                range.end_minute,
-                            );
+                            let started_at = range
+                                .timezone
+                                .local_to_utc_millis(start_date, range.start_hour, range.start_minute);
+                            let ended_at = range
+                                .timezone
+                                .local_to_utc_millis(end_date, range.end_hour, range.end_minute);
                             let req = UpdateSpaceActionRequest::Time {
                                 started_at,
                                 ended_at,
@@ -193,8 +189,7 @@ pub fn ActionCommonSettings(
                     }
                 },
             }
-
-            crate::features::activity::components::ActivityScoreSetting { space_id, action_id, action_setting }
+        
         }
     }
 }

--- a/app/ratel/src/features/spaces/pages/actions/controllers/update_space_action.rs
+++ b/app/ratel/src/features/spaces/pages/actions/controllers/update_space_action.rs
@@ -16,7 +16,6 @@ pub enum UpdateSpaceActionRequest {
     Credits { credits: u64 },
     Time { started_at: i64, ended_at: i64 },
     Prerequisite { prerequisite: bool },
-    ActivityScore { activity_score: i64, additional_score: i64 },
 }
 
 #[post(
@@ -87,23 +86,6 @@ pub async fn update_space_action(
                 .await
                 .map_err(|e| {
                     crate::error!("Failed to update space action: {e:?}");
-                    SpaceActionError::ActionUpdateFailed
-                })?;
-        }
-        UpdateSpaceActionRequest::ActivityScore {
-            activity_score,
-            additional_score,
-        } => {
-            space_action.activity_score = activity_score;
-            space_action.additional_score = additional_score;
-            SpaceAction::updater(&pk, &EntityType::SpaceAction)
-                .with_activity_score(activity_score)
-                .with_additional_score(additional_score)
-                .with_updated_at(now)
-                .execute(cli)
-                .await
-                .map_err(|e| {
-                    crate::error!("Failed to update activity score: {e:?}");
                     SpaceActionError::ActionUpdateFailed
                 })?;
         }

--- a/app/ratel/src/features/spaces/pages/index/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/index/i18n.rs
@@ -260,9 +260,9 @@ translate! {
         ko: "내 순위",
     },
 
-    total_score: {
-        en: "Total Score",
-        ko: "총 점수",
+    total_xp: {
+        en: "Total XP",
+        ko: "총 경험치",
     },
 
     poll_label: {
@@ -296,8 +296,13 @@ translate! {
     },
 
     no_ranking_yet: {
-        en: "No ranking data yet. Complete actions to earn your place!",
-        ko: "아직 랭킹 데이터가 없습니다. 활동을 완료하여 순위를 올리세요!",
+        en: "No ranking data yet. Complete actions to earn XP!",
+        ko: "아직 랭킹 데이터가 없습니다. 활동을 완료하여 경험치를 얻으세요!",
+    },
+
+    xp_label: {
+        en: "XP",
+        ko: "경험치",
     },
 
     prereq_heading: {

--- a/app/ratel/src/features/spaces/pages/index/leaderboard_panel/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/leaderboard_panel/component.rs
@@ -98,7 +98,7 @@ fn LeaderboardContent(space_id: ReadSignal<SpacePartition>) -> Element {
                 }
                 div {
                     div { class: "leaderboard-my-rank__score", "{my_score.total_score}" }
-                    div { class: "leaderboard-my-rank__score-label", "{tr.total_score}" }
+                    div { class: "leaderboard-my-rank__score-label", "{tr.total_xp}" }
                 }
             }
 
@@ -197,7 +197,7 @@ fn PodiumEntry(
                 div { class: "leaderboard-podium__medal", "{place}" }
             }
             span { class: "leaderboard-podium__name", "{entry.name}" }
-            span { class: "leaderboard-podium__score", "{entry.total_score}" }
+            span { class: "leaderboard-podium__score", "{entry.total_score} XP" }
         }
     }
 }
@@ -232,7 +232,7 @@ fn LeaderboardEntry(
             if is_me {
                 span { class: "leaderboard-entry__me-badge", "{you_label}" }
             }
-            span { class: "leaderboard-entry__score", "{entry.total_score}" }
+            span { class: "leaderboard-entry__score", "{entry.total_score} XP" }
         }
     }
 }

--- a/cdk/lib/dynamo-stream-event.ts
+++ b/cdk/lib/dynamo-stream-event.ts
@@ -545,5 +545,233 @@ export class DynamoStreamEventStack extends Stack {
       },
       targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
     });
+
+    // ── Pipe 9: Poll Answer Insert → PollXpRecord ────────────────────
+    // Triggers when a new SpacePollUserAnswer is inserted (user responds to poll)
+    new pipes.CfnPipe(this, "PollXpPipe", {
+      name: `ratel-${stage}-poll-xp-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["INSERT"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: [{ prefix: "SPACE_POLL_USER_ANSWER#" }] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "PollXpRecord",
+        },
+        inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+      },
+    });
+
+    // ── Rule: Route PollXpRecord events to app-shell Lambda ──────────
+    new events.Rule(this, "PollXpRecordRule", {
+      eventBus,
+      description:
+        "Route poll answer events to app-shell for XP recording",
+      eventPattern: {
+        source: ["ratel.dynamodb.stream"],
+        detailType: ["PollXpRecord"],
+      },
+      targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+    });
+
+    // ── Pipe 10: Quiz Attempt Insert → QuizXpRecord ──────────────────
+    // Triggers when a new SpaceQuizAttempt is inserted (user attempts quiz)
+    new pipes.CfnPipe(this, "QuizXpPipe", {
+      name: `ratel-${stage}-quiz-xp-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["INSERT"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: [{ prefix: "SPACE_QUIZ_ATTEMPT#" }] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "QuizXpRecord",
+        },
+        inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+      },
+    });
+
+    // ── Rule: Route QuizXpRecord events to app-shell Lambda ──────────
+    new events.Rule(this, "QuizXpRecordRule", {
+      eventBus,
+      description:
+        "Route quiz attempt events to app-shell for XP recording",
+      eventPattern: {
+        source: ["ratel.dynamodb.stream"],
+        detailType: ["QuizXpRecord"],
+      },
+      targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+    });
+
+    // ── Pipe 11: Discussion Comment Insert → DiscussionXpRecord ──────
+    // Triggers when a new SpacePostComment is inserted (comment on discussion)
+    new pipes.CfnPipe(this, "DiscussionCommentXpPipe", {
+      name: `ratel-${stage}-discussion-comment-xp-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["INSERT"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: [{ prefix: "SPACE_POST_COMMENT#" }] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "DiscussionXpRecord",
+        },
+        inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+      },
+    });
+
+    // ── Pipe 11b: Discussion Reply Insert → DiscussionXpRecord ───────
+    // Triggers when a new SpacePostCommentReply is inserted (reply to comment)
+    new pipes.CfnPipe(this, "DiscussionReplyXpPipe", {
+      name: `ratel-${stage}-discussion-reply-xp-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["INSERT"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: [{ prefix: "SPACE_POST_COMMENT_REPLY#" }] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "DiscussionXpRecord",
+        },
+        inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+      },
+    });
+
+    // ── Rule: Route DiscussionXpRecord events to app-shell Lambda ────
+    new events.Rule(this, "DiscussionXpRecordRule", {
+      eventBus,
+      description:
+        "Route discussion comment/reply events to app-shell for XP recording",
+      eventPattern: {
+        source: ["ratel.dynamodb.stream"],
+        detailType: ["DiscussionXpRecord"],
+      },
+      targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+    });
+
+    // ── Pipe 12: Follow Insert → FollowXpRecord ─────────────────────
+    // Triggers when a new Follower record is inserted (user follows someone)
+    new pipes.CfnPipe(this, "FollowXpPipe", {
+      name: `ratel-${stage}-follow-xp-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["INSERT"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: [{ prefix: "FOLLOWER#" }] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "FollowXpRecord",
+        },
+        inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+      },
+    });
+
+    // ── Rule: Route FollowXpRecord events to app-shell Lambda ────────
+    new events.Rule(this, "FollowXpRecordRule", {
+      eventBus,
+      description:
+        "Route follow events to app-shell for XP recording",
+      eventPattern: {
+        source: ["ratel.dynamodb.stream"],
+        detailType: ["FollowXpRecord"],
+      },
+      targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+    });
   }
 }


### PR DESCRIPTION
- Replaced `activity_score` and `additional_score` with a unified `XP` calculation in `record_activity`
- Removed redundant `ActivityScore` update logic from `update_space_action`
- Updated leaderboard UI to display "XP" instead of "Total Score"
- Adjusted i18n keys and translations to reflect the terminology change
- Removed unused `activity_score_setting` module