### PR TITLE
feat(discussion): add edit and delete functionality for comments

### DIFF
--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/update_comment.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/controllers/comments/update_comment.rs
@@ -63,10 +63,15 @@ pub async fn update_comment(
     }
 
     let now = chrono::Utc::now().timestamp();
+    // Only touch `content` / `updated_at` / `images`. `updated_at_align` is the
+    // tiebreaker in GSI2 (`find_by_post_order_by_likes`) and GSI3
+    // (`find_replies_by_likes`); rewriting it on every edit causes the comment
+    // to jump in the list. Leaving it at its creation-time value keeps the
+    // ordering pinned to `created_at`, which matches user expectations when
+    // they edit their own comment.
     let mut updater = SpacePostComment::updater(&space_post_pk, &comment_sk_entity)
         .with_content(req.content)
-        .with_updated_at(now)
-        .with_updated_at_align(format!("{:020}", now));
+        .with_updated_at(now);
 
     if let Some(images) = req.images {
         updater = updater.with_images(images);

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
@@ -4,8 +4,9 @@ use crate::common::components::mention_autocomplete::{
 use crate::common::hooks::use_interval;
 use crate::common::utils::mention::{apply_mention_markup, parse_mention_segments, ContentSegment};
 use crate::features::spaces::pages::actions::actions::discussion::controllers::{
-    add_comment, get_discussion_detail, like_comment, list_comments, list_replies, reply_comment,
-    AddCommentRequest, LikeCommentRequest, ReplyCommentRequest,
+    add_comment, delete_comment, get_discussion_detail, like_comment, list_comments, list_replies,
+    reply_comment, update_comment, AddCommentRequest, LikeCommentRequest, ReplyCommentRequest,
+    UpdateCommentRequest,
 };
 use crate::features::spaces::pages::actions::actions::discussion::{
     DiscussionCommentResponse, DiscussionStatus, SpacePostCommentTargetEntityType,
@@ -100,12 +101,23 @@ pub fn DiscussionArenaPage(
         });
     });
 
+    // Merge priority: the base page (returned by the loader, ordered by the
+    // server's canonical GSI) is the source of truth for content. Polled items
+    // that haven't yet been picked up by a restart are appended at the end.
+    // This way a loader restart after an edit immediately reflects the new
+    // content — the polled list may still carry the stale snapshot with the
+    // same sk, but base wins and the polled duplicate is filtered out.
     let comments: Vec<DiscussionCommentResponse> = {
         let polled = polled_new();
         let base = comments_data.items.clone();
+        let base_sks: std::collections::HashSet<String> =
+            base.iter().map(|c| c.sk.to_string()).collect();
         base.into_iter()
-            .filter(|bi| !polled.iter().any(|p| p.sk == bi.sk))
-            .chain(polled.iter().cloned())
+            .chain(
+                polled
+                    .into_iter()
+                    .filter(|p| !base_sks.contains(&p.sk.to_string())),
+            )
             .collect()
     };
 
@@ -386,6 +398,7 @@ pub fn DiscussionArenaPage(
                                     can_comment,
                                     members,
                                     comments_loader,
+                                    polled_new,
                                 }
                             }
                         }
@@ -405,9 +418,11 @@ fn CommentItem(
     can_comment: bool,
     members: ReadSignal<Vec<MentionCandidate>>,
     comments_loader: Loader<ListResponse<DiscussionCommentResponse>>,
+    polled_new: Signal<Vec<DiscussionCommentResponse>>,
 ) -> Element {
     let tr: DiscussionArenaTranslate = use_translate();
     let mut comments_loader = comments_loader;
+    let mut polled_new = polled_new;
     let mut toast = use_toast();
 
     let mut show_replies = use_signal(|| false);
@@ -420,6 +435,22 @@ fn CommentItem(
     let liked = comment.liked;
     let likes = comment.likes;
     let reply_count = comment.replies;
+
+    // Ownership: only the author sees the edit/delete menu. Server-side
+    // update/delete controllers also verify `comment.author_pk == user.pk`,
+    // so the UI gate is a UX affordance, not a security boundary.
+    let user_ctx = crate::features::auth::hooks::use_user_context();
+    let is_own = user_ctx
+        .read()
+        .user
+        .as_ref()
+        .map(|u| u.pk == comment.author_pk)
+        .unwrap_or(false);
+
+    let mut menu_open = use_signal(|| false);
+    let mut editing = use_signal(|| false);
+    let mut edit_text = use_signal(|| comment.content.clone());
+    let original_content = comment.content.clone();
 
     let on_like = move |_| async move {
         let target_sk: SpacePostCommentTargetEntityType = comment_sk().into();
@@ -481,6 +512,74 @@ fn CommentItem(
         }
     };
 
+    let start_edit_content = original_content.clone();
+    let on_edit_start = move |_| {
+        edit_text.set(start_edit_content.clone());
+        editing.set(true);
+        menu_open.set(false);
+    };
+
+    let on_edit_cancel = move |_| {
+        editing.set(false);
+    };
+
+    let on_edit_save = move |_| async move {
+        let new_text = edit_text().trim().to_string();
+        if new_text.is_empty() {
+            return;
+        }
+        let target_sk: SpacePostCommentTargetEntityType = comment_sk().into();
+        let req = UpdateCommentRequest {
+            content: new_text.clone(),
+            images: None,
+        };
+        match update_comment(space_id(), discussion_id(), target_sk, req).await {
+            Ok(_) => {
+                // Reflect the edit immediately: base (refreshed via restart)
+                // wins on content, but any stale poll-cached copy of the same
+                // sk would still override rendering for a frame if present.
+                // Patch the polled entry's content so nothing shows the old
+                // text even momentarily.
+                let sk = comment_sk();
+                polled_new.with_mut(|list| {
+                    for item in list.iter_mut() {
+                        if item.sk == sk {
+                            item.content = new_text.clone();
+                        }
+                    }
+                });
+                editing.set(false);
+                comments_loader.restart();
+                toast.info(tr.edit_success);
+            }
+            Err(err) => {
+                tracing::error!("Failed to update comment: {:?}", err);
+                toast.error(err);
+            }
+        }
+    };
+
+    let on_delete = move |_| async move {
+        let target_sk: SpacePostCommentTargetEntityType = comment_sk().into();
+        menu_open.set(false);
+        match delete_comment(space_id(), discussion_id(), target_sk).await {
+            Ok(_) => {
+                // Scrub the polled cache — list_comments(since=...) only
+                // returns comments by created_at, so a deleted item is never
+                // re-observed by polling; without this, the stale copy would
+                // linger in the polled tail forever.
+                let sk = comment_sk();
+                polled_new.with_mut(|list| list.retain(|c| c.sk != sk));
+                comments_loader.restart();
+                toast.info(tr.delete_success);
+            }
+            Err(err) => {
+                tracing::error!("Failed to delete comment: {:?}", err);
+                toast.error(err);
+            }
+        }
+    };
+
     rsx! {
         div { class: "comment-entry",
             div { class: "comment-item",
@@ -493,48 +592,113 @@ fn CommentItem(
                     div { class: "comment-item__top",
                         span { class: "comment-item__name", "{comment.author_display_name}" }
                         span { class: "comment-item__time", "{time_ago}" }
-                    }
-                    div { class: "comment-item__text",
-                        for segment in parse_mention_segments(&comment.content) {
-                            match segment {
-                                ContentSegment::Text(t) => rsx! {
-                                    span { "{t}" }
-                                },
-                                ContentSegment::Mention { display_name, .. } => rsx! {
-                                    span { class: "font-medium text-primary", "@{display_name}" }
-                                },
+                        if is_own && !editing() {
+                            div { class: "comment-menu",
+                                button {
+                                    class: "comment-menu__trigger",
+                                    "data-testid": "comment-menu-trigger",
+                                    aria_label: "{tr.more_options}",
+                                    onclick: move |_| menu_open.set(!menu_open()),
+                                    svg {
+                                        view_box: "0 0 24 24",
+                                        fill: "currentColor",
+                                        xmlns: "http://www.w3.org/2000/svg",
+                                        circle { cx: "5", cy: "12", r: "1.6" }
+                                        circle { cx: "12", cy: "12", r: "1.6" }
+                                        circle { cx: "19", cy: "12", r: "1.6" }
+                                    }
+                                }
+                                if menu_open() {
+                                    div { class: "comment-menu__dropdown",
+                                        button {
+                                            class: "comment-menu__item",
+                                            "data-testid": "comment-menu-edit",
+                                            onclick: on_edit_start,
+                                            "{tr.edit_btn}"
+                                        }
+                                        button {
+                                            class: "comment-menu__item comment-menu__item--danger",
+                                            "data-testid": "comment-menu-delete",
+                                            onclick: on_delete,
+                                            "{tr.delete_btn}"
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
-                    div { class: "comment-item__actions",
-                        button {
-                            class: if liked { "comment-action comment-action--liked" } else { "comment-action" },
-                            onclick: on_like,
-                            svg {
-                                view_box: "0 0 24 24",
-                                fill: if liked { "currentColor" } else { "none" },
-                                stroke: "currentColor",
-                                stroke_width: "2",
-                                stroke_linecap: "round",
-                                stroke_linejoin: "round",
-                                path { d: "M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" }
+                    if editing() {
+                        div { class: "comment-item__edit",
+                            textarea {
+                                class: "comment-item__edit-input",
+                                "data-testid": "comment-edit-input",
+                                rows: "2",
+                                value: "{edit_text}",
+                                oninput: move |e| {
+                                    edit_text.set(e.value());
+                                },
                             }
-                            span { "{likes}" }
+                            div { class: "comment-item__edit-actions",
+                                button {
+                                    class: "comment-item__edit-cancel",
+                                    "data-testid": "comment-edit-cancel",
+                                    onclick: on_edit_cancel,
+                                    "{tr.cancel_btn}"
+                                }
+                                button {
+                                    class: "comment-item__edit-save",
+                                    "data-testid": "comment-edit-save",
+                                    disabled: edit_text().trim().is_empty(),
+                                    onclick: on_edit_save,
+                                    "{tr.save_btn}"
+                                }
+                            }
                         }
-                        if can_comment {
+                    } else {
+                        div { class: "comment-item__text",
+                            for segment in parse_mention_segments(&comment.content) {
+                                match segment {
+                                    ContentSegment::Text(t) => rsx! {
+                                        span { "{t}" }
+                                    },
+                                    ContentSegment::Mention { display_name, .. } => rsx! {
+                                        span { class: "font-medium text-primary", "@{display_name}" }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                    if !editing() {
+                        div { class: "comment-item__actions",
                             button {
-                                class: "comment-action comment-action--reply",
-                                onclick: on_toggle_replies,
+                                class: if liked { "comment-action comment-action--liked" } else { "comment-action" },
+                                onclick: on_like,
                                 svg {
                                     view_box: "0 0 24 24",
-                                    fill: "none",
+                                    fill: if liked { "currentColor" } else { "none" },
                                     stroke: "currentColor",
                                     stroke_width: "2",
                                     stroke_linecap: "round",
                                     stroke_linejoin: "round",
-                                    path { d: "M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" }
+                                    path { d: "M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" }
                                 }
-                                span { "{tr.reply_label}" }
+                                span { "{likes}" }
+                            }
+                            if can_comment {
+                                button {
+                                    class: "comment-action comment-action--reply",
+                                    onclick: on_toggle_replies,
+                                    svg {
+                                        view_box: "0 0 24 24",
+                                        fill: "none",
+                                        stroke: "currentColor",
+                                        stroke_width: "2",
+                                        stroke_linecap: "round",
+                                        stroke_linejoin: "round",
+                                        path { d: "M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" }
+                                    }
+                                    span { "{tr.reply_label}" }
+                                }
                             }
                         }
                     }

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/i18n.rs
@@ -75,4 +75,32 @@ translate! {
         en: "Reply posted successfully.",
         ko: "답글이 성공적으로 게시되었습니다.",
     },
+    more_options: {
+        en: "More options",
+        ko: "더보기",
+    },
+    edit_btn: {
+        en: "Edit",
+        ko: "편집",
+    },
+    delete_btn: {
+        en: "Delete",
+        ko: "삭제",
+    },
+    save_btn: {
+        en: "Save",
+        ko: "저장",
+    },
+    cancel_btn: {
+        en: "Cancel",
+        ko: "취소",
+    },
+    edit_success: {
+        en: "Comment updated.",
+        ko: "댓글이 수정되었습니다.",
+    },
+    delete_success: {
+        en: "Comment deleted.",
+        ko: "댓글이 삭제되었습니다.",
+    },
 }

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
@@ -286,6 +286,69 @@
 .comment-item__text { font-size: 13px; line-height: 1.6; color: var(--text); word-break: break-word; }
 
 .comment-item__actions { display: flex; align-items: center; gap: 8px; margin-top: 2px; }
+
+/* ── Author menu (edit/delete) ─────────────────── */
+.comment-menu { position: relative; margin-left: auto; }
+.comment-menu__trigger {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; padding: 0;
+  background: transparent; border: none; border-radius: 6px;
+  cursor: pointer; color: var(--text-dim);
+  transition: background 0.15s, color 0.15s;
+}
+.comment-menu__trigger:hover { background: var(--surface-raised); color: var(--text-muted); }
+.comment-menu__trigger svg { width: 14px; height: 14px; }
+.comment-menu__dropdown {
+  position: absolute; top: calc(100% + 4px); right: 0;
+  min-width: 120px; padding: 4px;
+  display: flex; flex-direction: column;
+  background: var(--dark, rgba(12,12,26,0.95)) var(--light, rgba(255,255,255,0.98));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px var(--dark, rgba(0,0,0,0.4)) var(--light, rgba(0,0,0,0.08));
+  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+  z-index: 50;
+}
+.comment-menu__item {
+  padding: 6px 10px; border-radius: 6px;
+  background: transparent; border: none; cursor: pointer;
+  text-align: left;
+  font-family: 'Outfit', sans-serif; font-size: 12px; color: var(--text);
+  transition: background 0.15s;
+}
+.comment-menu__item:hover { background: var(--surface-raised); }
+.comment-menu__item--danger { color: #f43f5e; }
+.comment-menu__item--danger:hover { background: rgba(244,63,94,0.1); }
+
+/* ── Inline edit ───────────────────────────────── */
+.comment-item__edit { display: flex; flex-direction: column; gap: 6px; margin-top: 2px; }
+.comment-item__edit-input {
+  width: 100%; resize: vertical;
+  padding: 8px 10px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border); border-radius: 8px;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif; font-size: 13px; line-height: 1.5;
+  outline: none;
+}
+.comment-item__edit-input:focus { border-color: var(--discuss-border); }
+.comment-item__edit-actions { display: flex; justify-content: flex-end; gap: 6px; }
+.comment-item__edit-cancel,
+.comment-item__edit-save {
+  padding: 4px 12px; border-radius: 6px;
+  font-family: 'Outfit', sans-serif; font-size: 11px; font-weight: 600;
+  cursor: pointer; transition: all 0.15s;
+}
+.comment-item__edit-cancel {
+  background: transparent; color: var(--text-dim);
+  border: 1px solid var(--border);
+}
+.comment-item__edit-cancel:hover { color: var(--text); }
+.comment-item__edit-save {
+  background: var(--discuss-color); color: #0a0a0a; border: none;
+}
+.comment-item__edit-save:hover:not(:disabled) { opacity: 0.9; }
+.comment-item__edit-save:disabled { opacity: 0.4; cursor: not-allowed; }
 .comment-action {
   display: inline-flex; align-items: center; gap: 4px;
   padding: 3px 6px; border-radius: 6px; border: none; background: transparent;

--- a/playwright/tests/web/team-space-full-lifecycle.spec.js
+++ b/playwright/tests/web/team-space-full-lifecycle.spec.js
@@ -716,6 +716,74 @@ test.describe.serial("Full space lifecycle with rewards", () => {
     }
   });
 
+  // ─── 13b. User2: Edit + delete own comment via context menu ──────────────
+
+  test("User2: Edit and delete own comment", async ({ browser }) => {
+    const context = await browser.newContext({
+      storageState: user2StoragePath,
+      viewport: { width: 1440, height: 950 },
+      locale: "en-US",
+    });
+    const page = await context.newPage();
+
+    try {
+      await goto(page, spaceUrl);
+      await pauseAnimations(page);
+
+      const discCard = page.locator('[data-type="discuss"]').first();
+      await expect(discCard).toBeVisible({ timeout: 10000 });
+      await page.waitForTimeout(500);
+      await discCard.click();
+
+      await expect(page.getByTestId("discussion-arena-overlay")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Post a fresh comment that will be edited, then deleted.
+      const textarea = page.locator(".comment-input__textarea");
+      await expect(textarea).toBeVisible({ timeout: 10000 });
+      const originalText = "Draft comment from User2 — editing test.";
+      await textarea.fill(originalText);
+      await page.locator(".comment-input__submit").click();
+
+      const originalItem = page.locator(".comment-item", {
+        hasText: originalText,
+      });
+      await expect(originalItem).toBeVisible({ timeout: 10000 });
+
+      // Open the context menu on the just-posted comment and click Edit.
+      // The ⋮ trigger renders only for comments whose author matches the
+      // current user, so scoping via `hasText` uniquely targets the new one.
+      await originalItem.getByTestId("comment-menu-trigger").click();
+      await page.getByTestId("comment-menu-edit").click();
+
+      // Only one comment is editable at a time, so page-wide testids resolve
+      // to the single edit form without needing to re-scope the parent.
+      const editInput = page.getByTestId("comment-edit-input");
+      await expect(editInput).toBeVisible({ timeout: 5000 });
+      const editedText = "Edited via context-menu action.";
+      await editInput.fill(editedText);
+      await page.getByTestId("comment-edit-save").click();
+
+      // After save, comments_loader restarts and the new content renders.
+      const editedItem = page.locator(".comment-item", { hasText: editedText });
+      await expect(editedItem).toBeVisible({ timeout: 10000 });
+      await expect(
+        page.locator(".comment-item", { hasText: originalText })
+      ).toBeHidden({ timeout: 10000 });
+
+      // Delete the edited comment via the context menu.
+      await editedItem.getByTestId("comment-menu-trigger").click();
+      await page.getByTestId("comment-menu-delete").click();
+
+      await expect(
+        page.locator(".comment-item", { hasText: editedText })
+      ).toBeHidden({ timeout: 10000 });
+    } finally {
+      await context.close();
+    }
+  });
+
   // ─── 14. Creator: Finish space ─────────────────────────────────────────
 
   test("Creator: Finish the space", async ({ page }) => {


### PR DESCRIPTION
- Introduced inline editing and deletion for user-owned comments
- Updated backend to prevent reordering on comment edits
- Enhanced UI with context menu for edit/delete actions
- Added i18n strings for new actions and success messages
- Updated styles for edit/delete menu and inline editing
- Added Playwright test for editing and deleting comments