### PR TITLE
fix(activity): correct ranking order and score aggregation logic

### DIFF
--- a/app/ratel/src/features/activity/controllers/get_ranking.rs
+++ b/app/ratel/src/features/activity/controllers/get_ranking.rs
@@ -23,7 +23,7 @@ pub async fn get_ranking_handler(
 
     let opts = SpaceScore::opt_with_bookmark(bookmark)
         .limit(50)
-        .scan_index_forward(true);
+        .scan_index_forward(false);
 
     let (scores, next_bookmark) = SpaceScore::find_by_space_rank(cli, &space_pk, opts).await?;
 

--- a/app/ratel/src/features/activity/models/space_score.rs
+++ b/app/ratel/src/features/activity/models/space_score.rs
@@ -11,9 +11,9 @@ pub struct SpaceScore {
     #[dynamo(prefix = "SCSP", name = "find_by_space_rank", index = "gsi2", pk)]
     pub space_pk: Partition,
     #[dynamo(prefix = "SCR", index = "gsi1", sk)]
+    #[dynamo(prefix = "SCR", index = "gsi2", order = 1, sk)]
     pub total_score: i64,
     #[serde(default)]
-    #[dynamo(prefix = "SCR", index = "gsi2", order = 1, sk)]
     pub rank_total_score: i64,
 
     #[dynamo(index = "gsi2", order = 3, sk)]

--- a/app/ratel/src/features/activity/services/aggregate_score.rs
+++ b/app/ratel/src/features/activity/services/aggregate_score.rs
@@ -50,7 +50,7 @@ pub async fn aggregate_score(
 
     SpaceScore::updater(&score_pk, &score_sk)
         .with_total_score(new_total)
-        .with_rank_total_score(-new_total)
+        .with_rank_total_score(new_total)
         .with_poll_score(poll)
         .with_quiz_score(quiz)
         .with_follow_score(follow)


### PR DESCRIPTION
- Updated `get_ranking_handler` to fetch scores in descending order
- Fixed `SpaceScore` model to align `total_score` indexing configuration
- Corrected `aggregate_score` to use positive values for `rank_total_score`