### PR TITLE
fix(mention): prevent UTF-8 boundary panic on long non-ASCII content

### DIFF
--- a/app/ratel/src/common/utils/aws/bedrock_embeddings.rs
+++ b/app/ratel/src/common/utils/aws/bedrock_embeddings.rs
@@ -20,7 +20,11 @@ impl BedrockEmbeddingsClient {
 
     pub async fn embed(&self, text: &str) -> Result<Vec<f32>> {
         let input_text = if text.len() > MAX_INPUT_CHARS {
-            &text[..MAX_INPUT_CHARS]
+            let mut end = MAX_INPUT_CHARS;
+            while end > 0 && !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            &text[..end]
         } else {
             text
         };

--- a/app/ratel/src/common/utils/mention.rs
+++ b/app/ratel/src/common/utils/mention.rs
@@ -121,10 +121,14 @@ pub async fn create_mention_notifications(
     cta_url: &str,
 ) {
     let mentioned_pks = extract_mentioned_pks(content);
+    if mentioned_pks.is_empty() {
+        return;
+    }
     let author_pk_str = author_pk.to_string();
     let preview = strip_mention_markup(content);
-    let preview = if preview.len() > 100 {
-        format!("{}...", &preview[..100])
+    let preview = if preview.chars().count() > 100 {
+        let truncated: String = preview.chars().take(100).collect();
+        format!("{}...", truncated)
     } else {
         preview
     };

--- a/app/ratel/src/features/posts/views/post_detail/mod.rs
+++ b/app/ratel/src/features/posts/views/post_detail/mod.rs
@@ -26,8 +26,8 @@ pub fn PostDetail(post_id: FeedPartition) -> Element {
         .map(|p| {
             let re = regex::Regex::new(r"<[^>]*>").unwrap();
             let text = re.replace_all(&p.html_contents, "").to_string();
-            if text.len() > 200 {
-                text[..200].to_string()
+            if text.chars().count() > 200 {
+                text.chars().take(200).collect::<String>()
             } else {
                 text
             }

--- a/playwright/tests/utils.js
+++ b/playwright/tests/utils.js
@@ -164,6 +164,29 @@ export async function waitForHydrated(page, testId, timeout = 15000) {
   );
 }
 
+/**
+ * Click a locator and wait for a target element to become visible, retrying
+ * the click if the target doesn't appear. Dioxus `onclick` handlers on
+ * dynamically rendered elements (`use_loader`-backed cards, freshly mounted
+ * modals) can be bound after the DOM node is already visible, so a click
+ * fired immediately after `toBeVisible` is silently dropped. Uses the same
+ * retry cadence as `openHomeTeamsDropdown`. The pre-click visibility check
+ * keeps the retry idempotent (important for modal-triggering buttons — a
+ * second click on a full-screen backdrop would close the modal again).
+ */
+export async function clickAndWaitForVisible(
+  clickable,
+  target,
+  { timeout = 15000 } = {},
+) {
+  await expect(async () => {
+    if (!(await target.isVisible({ timeout: 100 }).catch(() => false))) {
+      await clickable.click();
+    }
+    await expect(target).toBeVisible({ timeout: 1500 });
+  }).toPass({ timeout, intervals: [300, 600, 1200, 2000] });
+}
+
 export async function getEditor(page) {
   const editor = page.locator("[contenteditable]");
   await expect(editor).toBeVisible();
@@ -345,7 +368,14 @@ export async function createAction(page, spaceUrl, typeKey, urlRegex) {
     const fab = document.querySelector('[class*="fixed right-4 bottom-4"]');
     if (fab) fab.style.display = "none";
   });
-  await click(page, { testId: "admin-add-action-card" });
+  // The admin add-action card is rendered by ActionDashboard after its
+  // action loader resolves; Dioxus may not have bound the onclick handler
+  // by the time the element becomes visible, so a bare click can be dropped.
+  // Use the retry helper to click until the TypePicker modal surfaces.
+  const addCard = page.getByTestId("admin-add-action-card");
+  await expect(addCard).toBeVisible();
+  const typeOption = page.getByTestId(`type-option-${typeKey}`);
+  await clickAndWaitForVisible(addCard, typeOption);
   await click(page, { testId: `type-option-${typeKey}` });
   await page.waitForURL(urlRegex, { waitUntil: "load", timeout: 60000 });
 }

--- a/playwright/tests/web/team-space-with-signup-users.spec.js
+++ b/playwright/tests/web/team-space-with-signup-users.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
   click,
+  clickAndWaitForVisible,
   clickNoNav,
   createAction,
   createTeamFromHome,
@@ -540,11 +541,10 @@ test.describe.serial("Space with actions created by a team", () => {
       // Find and click the quiz card in the carousel to open the overlay
       const quizCard = page.locator('[data-type="quiz"]').first();
       await expect(quizCard).toBeVisible({ timeout: 10000 });
-      await quizCard.click();
 
       // Quiz arena overlay appears
       const overlay = page.getByTestId("quiz-arena-overlay");
-      await expect(overlay).toBeVisible({ timeout: 10000 });
+      await clickAndWaitForVisible(quizCard, overlay);
 
       // Overview page — click Begin to start
       await expect(page.getByTestId("quiz-arena-overview")).toBeVisible({
@@ -603,11 +603,10 @@ test.describe.serial("Space with actions created by a team", () => {
       // Find and click the quiz card in the carousel to open the overlay
       const quizCard = page.locator('[data-type="quiz"]').first();
       await expect(quizCard).toBeVisible({ timeout: 10000 });
-      await quizCard.click();
 
       // Quiz arena overlay appears
       const overlay = page.getByTestId("quiz-arena-overlay");
-      await expect(overlay).toBeVisible({ timeout: 10000 });
+      await clickAndWaitForVisible(quizCard, overlay);
 
       // Overview page — click Begin to start
       await expect(page.getByTestId("quiz-arena-overview")).toBeVisible({
@@ -918,10 +917,9 @@ test.describe.serial("Space with actions created by a team", () => {
       // in place (no navigation).
       const pollCard = page.locator('[data-type="poll"]').first();
       await expect(pollCard).toBeVisible({ timeout: 10000 });
-      await pollCard.click();
 
       const overlay = page.getByTestId("poll-arena-overlay");
-      await expect(overlay).toBeVisible({ timeout: 15000 });
+      await clickAndWaitForVisible(pollCard, overlay);
 
       await clickNoNav(page, { testId: "poll-arena-begin" });
 
@@ -955,10 +953,9 @@ test.describe.serial("Space with actions created by a team", () => {
       // in place (no navigation).
       const pollCard = page.locator('[data-type="poll"]').first();
       await expect(pollCard).toBeVisible({ timeout: 10000 });
-      await pollCard.click();
 
       const overlay = page.getByTestId("poll-arena-overlay");
-      await expect(overlay).toBeVisible({ timeout: 15000 });
+      await clickAndWaitForVisible(pollCard, overlay);
 
       await clickNoNav(page, { testId: "poll-arena-begin" });
 


### PR DESCRIPTION
## Summary

- Fix server panic at `mention.rs:127` when users post long Korean (or any non-ASCII) comments, which caused HTTP 500 on comment submission in production
- Add the same char-safe slicing to two other user-input code paths that had the same bug pattern

## Root Cause

`create_mention_notifications` computed a comment preview using byte-indexed slicing:
```rust
let preview = if preview.len() > 100 {
    format!(\"{}...\", &preview[..100])   // panics if byte 100 is mid-UTF-8-char
} else { preview };
```

When a user wrote a comment over 100 bytes that happened to have a multi-byte character (e.g. Korean '적' at bytes 99–101), `&preview[..100]` panicked at a UTF-8 boundary. The function ran unconditionally before checking whether any mentions existed, so **even comments with no @ mention would panic**.

## Fix

1. `app/ratel/src/common/utils/mention.rs`
   - Early return if `mentioned_pks.is_empty()` — skips preview computation entirely for comments without mentions (the common case)
   - Switch preview truncation from byte-based to char-based: `chars().take(100).collect::<String>()`

2. `app/ratel/src/features/posts/views/post_detail/mod.rs`
   - Same pattern: SSR description was doing `text[..200]` on user-authored post content. Switched to `chars().take(200)`

3. `app/ratel/src/common/utils/aws/bedrock_embeddings.rs`
   - Keeps byte-based slicing (byte limit is the actual constraint for the Bedrock API), but rewinds to the nearest UTF-8 char boundary via `is_char_boundary` before slicing

## Impact

- `create_mention_notifications` is called by 4 comment/reply endpoints (posts + spaces) — all benefit from the fix
- Preview byte size can grow up to ~3x for Korean (100 bytes → 300 bytes max). DynamoDB item size and email size both far below any limit
- Behavior for ASCII is unchanged
- No API surface change; no schema/template change

## Test plan

- [x] Reproduced panic locally with original code (reverted fix, posted long Korean comment → server panic in \`dx serve\` terminal)
- [x] Verified fix locally (comment without mention + long Korean → 200 OK)
- [x] Verified fix locally (comment with mention + long Korean → 200 OK)
- [x] \`cargo check --features server\` passes
- [x] \`cargo check --features web\` passes
- [x] \`dx fmt\` applied