### PR TITLE
feat(discussion/arena): score sort + resizable panel + 3-line truncate + reply like fix

### DIFF
--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/types/post_comment_entity_type.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/types/post_comment_entity_type.rs
@@ -17,7 +17,16 @@ impl FromStr for SpacePostCommentTargetEntityType {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let s = if s.starts_with("SPACE_POST_COMMENT_REPLY#") {
+            // After stripping the prefix the remainder is `parent#reply`.
+            // The inner `#` would be parsed as a URL fragment delimiter
+            // (browsers strip everything after `#` before sending), causing
+            // requests like `/comments/parent#reply/likes` to actually hit
+            // `/comments/parent` and route to `update_comment` instead of
+            // `like_comment` — yielding `missing field content` errors.
+            // Switch to the `::` separator that `From<EntityType>` uses so
+            // both sides of the conversion produce URL-safe values.
             s.replacen("SPACE_POST_COMMENT_REPLY#", "", 1)
+                .replacen('#', "::", 1)
         } else if s.starts_with("SPACE_POST_COMMENT#") {
             s.replacen("SPACE_POST_COMMENT#", "", 1)
         } else {

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
@@ -310,17 +310,17 @@ pub fn DiscussionArenaPage(
 
     let arena = use_discussion_arena(space_id, discussion_id)?;
     let mut comments_loader = arena.comments_loader;
-    let mut polled_new = arena.polled_new;
+    let polled_new = arena.polled_new;
     let active_reply_thread = arena.active_reply_thread;
     let mut sheet_expanded = arena.sheet_expanded;
     let mut mention_query_raw = arena.mention_query_raw;
     let members = arena.members;
     let top_priority = arena.top_priority;
+    let sort_tick = arena.sort_tick;
 
     let disc = arena.disc_loader.clone()();
     let post = disc.post.clone();
     let space_action = disc.space_action.clone();
-    let comments_data = comments_loader();
 
     let status = post.status();
     let is_in_progress = status == DiscussionStatus::InProgress;
@@ -333,21 +333,35 @@ pub fn DiscussionArenaPage(
     );
     let can_comment = can_respond && can_execute && is_in_progress;
 
-    // Base page wins over polled duplicates so a loader restart after
-    // edit/delete clobbers any stale snapshot lingering in the buffer.
-    let comments: Vec<DiscussionCommentResponse> = {
+    // Merge base + polled (base wins on duplicate sks so loader restarts
+    // after edit/delete clobber stale polled snapshots), then rank by
+    // `comment_score` against the local `now`. Re-runs whenever:
+    //  - `comments_loader` resolves with new data
+    //  - `polled_new` gains a new entry
+    //  - `sort_tick` ticks (every 5s, drives time-decay reorder)
+    let comments: Memo<Vec<DiscussionCommentResponse>> = use_memo(move || {
+        // Touch sort_tick so the memo re-evaluates each tick.
+        let _ = sort_tick();
         let polled = polled_new();
-        let base = comments_data.items.clone();
+        let base = comments_loader().items;
         let base_sks: std::collections::HashSet<String> =
             base.iter().map(|c| c.sk.to_string()).collect();
-        base.into_iter()
+        let mut merged: Vec<DiscussionCommentResponse> = base
+            .into_iter()
             .chain(
                 polled
                     .into_iter()
                     .filter(|p| !base_sks.contains(&p.sk.to_string())),
             )
-            .collect()
-    };
+            .collect();
+        let now = crate::common::utils::time::get_now_timestamp();
+        merged.sort_by(|a, b| {
+            comment_score(b, now)
+                .partial_cmp(&comment_score(a, now))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        merged
+    });
 
     // `overlay_ctx` is only present when mounted as the arena overlay;
     // `on_back` falls back to `nav.go_back()` for the standalone route.
@@ -628,7 +642,7 @@ pub fn DiscussionArenaPage(
 
                         div { class: "comments-scroll",
                             div { class: "comment-list",
-                                for comment in comments.iter().filter(|c| !arena.is_deleted(c)) {
+                                for comment in comments().iter().filter(|c| !arena.is_deleted(c)) {
                                     CommentItem {
                                         key: "{comment.sk}",
                                         comment: comment.clone(),

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
@@ -226,18 +226,7 @@ fn ReplyThreadView(
                                 span { class: "comment-item__name", "{parent.author_display_name}" }
                                 span { class: "comment-item__time", "{parent_time_ago}" }
                             }
-                            div { class: "comment-item__text",
-                                for segment in parse_mention_segments(&parent.content) {
-                                    match segment {
-                                        ContentSegment::Text(t) => rsx! {
-                                            span { "{t}" }
-                                        },
-                                        ContentSegment::Mention { display_name, .. } => rsx! {
-                                            span { class: "font-medium text-primary", "@{display_name}" }
-                                        },
-                                    }
-                                }
-                            }
+                            CommentText { content: parent.content.clone() }
                             CommentImageGrid { images: parent.images.clone() }
                             div { class: "comment-item__actions",
                                 button {
@@ -798,6 +787,48 @@ fn CommentComposer(
     }
 }
 
+/// Renders comment content with mention highlighting and a "Show more"
+/// toggle when the rendered text exceeds 3 visual lines. Used by the
+/// parent in `ReplyThreadView`, top-level `CommentItem`, and `ReplyItem`
+/// so the truncation behavior stays consistent everywhere.
+///
+/// Truncation is purely visual (CSS `-webkit-line-clamp: 3` when
+/// `data-expanded="false"`); JS measures `scrollHeight > clientHeight`
+/// and sets `data-truncatable="true"` to reveal the toggle button. This
+/// matches what the user actually sees regardless of viewport width or
+/// language, instead of a brittle character count.
+#[component]
+fn CommentText(content: String) -> Element {
+    let tr: DiscussionArenaTranslate = use_translate();
+    let mut expanded = use_signal(|| false);
+
+    rsx! {
+        div {
+            class: "comment-text",
+            "data-expanded": expanded(),
+            div { class: "comment-item__text",
+                for segment in parse_mention_segments(&content) {
+                    match segment {
+                        ContentSegment::Text(t) => rsx! {
+                            span { "{t}" }
+                        },
+                        ContentSegment::Mention { display_name, .. } => rsx! {
+                            span { class: "font-medium text-primary", "@{display_name}" }
+                        },
+                    }
+                }
+            }
+            // Always rendered; CSS hides it unless JS sets
+            // `data-truncatable="true"` on the wrapper after measuring.
+            button {
+                class: "comment-item__expand",
+                onclick: move |_| expanded.toggle(),
+                if expanded() { "{tr.show_less}" } else { "{tr.show_more}" }
+            }
+        }
+    }
+}
+
 #[component]
 fn CommentItem(
     comment: DiscussionCommentResponse,
@@ -1050,18 +1081,7 @@ fn CommentItem(
                             }
                         }
                     } else {
-                        div { class: "comment-item__text",
-                            for segment in parse_mention_segments(&effective_text) {
-                                match segment {
-                                    ContentSegment::Text(t) => rsx! {
-                                        span { "{t}" }
-                                    },
-                                    ContentSegment::Mention { display_name, .. } => rsx! {
-                                        span { class: "font-medium text-primary", "@{display_name}" }
-                                    },
-                                }
-                            }
-                        }
+                        CommentText { content: effective_text.clone() }
                         CommentImageGrid { images: comment.images.clone() }
                     }
                     if !editing() {
@@ -1324,18 +1344,7 @@ fn ReplyItem(
                         }
                     }
                 } else {
-                    div { class: "comment-item__text",
-                        for segment in parse_mention_segments(&effective_text) {
-                            match segment {
-                                ContentSegment::Text(t) => rsx! {
-                                    span { "{t}" }
-                                },
-                                ContentSegment::Mention { display_name, .. } => rsx! {
-                                    span { class: "font-medium text-primary", "@{display_name}" }
-                                },
-                            }
-                        }
-                    }
+                    CommentText { content: effective_text.clone() }
                     CommentImageGrid { images: reply.images.clone() }
                     div { class: "comment-item__actions",
                         button {

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
@@ -579,6 +579,19 @@ pub fn DiscussionArenaPage(
                     }
                 }
 
+                // Drag handle for resizing the comments panel horizontally.
+                // Width is JS-owned (continuous mouse value) — Dioxus never
+                // sets `style` on the panel so the inline width survives
+                // re-renders. Hidden on mobile via media query (panel becomes
+                // a bottom sheet).
+                div {
+                    class: "comments-panel__resizer",
+                    id: "comments-panel-resizer",
+                    role: "separator",
+                    aria_label: "Resize comments panel",
+                    aria_orientation: "vertical",
+                }
+
                 // Sheet handle expand state is Dioxus-owned (data-expanded)
                 // because the JS-owned class was being clobbered by panel
                 // re-renders.

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
@@ -13,6 +13,34 @@ use crate::features::spaces::space_common::controllers::{list_space_members, Spa
 use dioxus::fullstack::Loader;
 use std::str::FromStr;
 
+/// Ranking score for a single comment, computed client-side at every
+/// render so the freshness boost stays accurate without server help.
+///
+/// Components:
+/// - `log10(likes + 1) * 3` — popularity, log-scaled so 100→200 votes is
+///   a smaller jump than 1→10.
+/// - `log10(replies + 1) * 5` — discussion activity, weighted higher
+///   than likes because replies are a stronger engagement signal.
+/// - `created_at / 86400` — additive freshness baseline (newer always
+///   ranks above older, all else equal).
+/// - `4 * exp(-age_hours / 1.0)` — short-lived "fresh boost" so a
+///   brand-new comment is visible regardless of likes/replies; decays
+///   smoothly so there is no UI jump at the 1-hour mark.
+///
+/// `now_seconds` and `comment.created_at` must share the same unit
+/// (seconds since epoch).
+pub fn comment_score(comment: &DiscussionCommentResponse, now_seconds: i64) -> f64 {
+    let likes = comment.likes as f64;
+    let replies = comment.replies as f64;
+    let likes_term = (likes + 1.0).log10() * 3.0;
+    let replies_term = (replies + 1.0).log10() * 5.0;
+    let time_term = comment.created_at as f64 / 86400.0;
+    let age_seconds = (now_seconds - comment.created_at).max(0) as f64;
+    let age_hours = age_seconds / 3600.0;
+    let fresh_term = 4.0 * (-age_hours).exp();
+    likes_term + replies_term + time_term + fresh_term
+}
+
 #[derive(Clone, Copy, DioxusController)]
 pub struct UseDiscussionArena {
     pub active_reply_thread: Signal<Option<String>>,
@@ -24,6 +52,10 @@ pub struct UseDiscussionArena {
     pub members_loader: Loader<ListResponse<SpaceMemberResponse>>,
     pub polled_new: Signal<Vec<DiscussionCommentResponse>>,
     pub last_seen_at: Signal<i64>,
+    /// Bumped every poll tick so a `use_memo` over `comment_score` re-runs
+    /// even when no new data arrives, letting the time-decay term in the
+    /// score reorder comments smoothly as time passes.
+    pub sort_tick: Signal<u32>,
     pub mention_query_raw: Signal<Option<String>>,
     pub mention_query: Signal<Option<String>>,
     pub members: ReadSignal<Vec<MentionCandidate>>,
@@ -161,7 +193,12 @@ pub fn use_discussion_arena(
             .max()
             .unwrap_or_else(crate::common::utils::time::get_now_timestamp)
     });
+    let mut sort_tick: Signal<u32> = use_signal(|| 0);
     use_interval(5000, move || {
+        // Bump unconditionally so the score-sort memo re-runs every tick,
+        // even when no new comments arrived (the fresh-boost decays with
+        // time so positions need to update independently of fetch results).
+        sort_tick.with_mut(|t| *t = t.wrapping_add(1));
         let since = last_seen_at();
         spawn(async move {
             match list_comments(space_id(), discussion_id(), None, Some(since)).await {
@@ -421,6 +458,7 @@ pub fn use_discussion_arena(
         members_loader,
         polled_new,
         last_seen_at,
+        sort_tick,
         mention_query_raw,
         mention_query,
         members,
@@ -434,4 +472,178 @@ pub fn use_discussion_arena(
         add_comment: add_comment_action,
         reply_comment: reply_comment_action,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fixture comment with only the fields `comment_score` reads.
+    fn fixture(created_at: i64, likes: u64, replies: u64) -> DiscussionCommentResponse {
+        DiscussionCommentResponse {
+            created_at,
+            likes,
+            replies,
+            ..Default::default()
+        }
+    }
+
+    // ── Sanity: monotonicity ──────────────────────────────────────
+
+    #[test]
+    fn more_likes_score_higher() {
+        let now = 1_000_000;
+        let same_age = now - 3600;
+        let a = fixture(same_age, 0, 0);
+        let b = fixture(same_age, 10, 0);
+        assert!(comment_score(&b, now) > comment_score(&a, now));
+    }
+
+    #[test]
+    fn more_replies_score_higher() {
+        let now = 1_000_000;
+        let same_age = now - 3600;
+        let a = fixture(same_age, 0, 0);
+        let b = fixture(same_age, 0, 10);
+        assert!(comment_score(&b, now) > comment_score(&a, now));
+    }
+
+    #[test]
+    fn newer_score_higher_when_engagement_equal() {
+        let now = 1_000_000;
+        let new = fixture(now, 5, 5);
+        let old = fixture(now - 86400, 5, 5);
+        assert!(comment_score(&new, now) > comment_score(&old, now));
+    }
+
+    // ── Algorithm intent ──────────────────────────────────────────
+
+    #[test]
+    fn fresh_comment_outranks_older_silent_comment() {
+        // Requirement: "1시간까지는 좋아요/대댓글 없어도 높이 보여야 함"
+        let now = 1_000_000;
+        let fresh = fixture(now - 60, 0, 0); // 1 min old
+        let old_silent = fixture(now - 7200, 0, 0); // 2 h old
+        assert!(comment_score(&fresh, now) > comment_score(&old_silent, now));
+    }
+
+    #[test]
+    fn replies_weighted_higher_than_likes() {
+        // Same age, same engagement count but different KIND of engagement —
+        // replies should win because they're a stronger discussion signal.
+        let now = 1_000_000;
+        let same_age = now - 3600;
+        let liked = fixture(same_age, 100, 0);
+        let replied = fixture(same_age, 0, 100);
+        assert!(comment_score(&replied, now) > comment_score(&liked, now));
+    }
+
+    #[test]
+    fn popular_old_comment_beats_brand_new_silent() {
+        // A meaningfully engaged comment should still outrank a silent fresh
+        // one — fresh boost shouldn't completely dominate.
+        let now = 1_000_000;
+        let popular_old = fixture(now - 21600, 50, 5); // 6h old, 50 likes 5 replies
+        let new_silent = fixture(now, 0, 0);
+        assert!(comment_score(&popular_old, now) > comment_score(&new_silent, now));
+    }
+
+    // ── Curve shape ────────────────────────────────────────────────
+
+    #[test]
+    fn fresh_boost_decays_within_a_few_hours() {
+        // Boost gap between 1h and 10h olds should be at least ~1 score
+        // point so the time-driven re-sort is observable across the 5s tick.
+        let now = 1_000_000;
+        let one_h = comment_score(&fixture(now - 3600, 0, 0), now);
+        let ten_h = comment_score(&fixture(now - 36000, 0, 0), now);
+        assert!(one_h - ten_h > 1.0, "1h={one_h}, 10h={ten_h}");
+    }
+
+    #[test]
+    fn likes_score_is_sublinear() {
+        // Mega-popular comments must NOT dominate forever. A 100-like comment
+        // should score far less than 100× a 1-like comment — that's the whole
+        // point of log scaling.
+        let now = 1_000_000;
+        let same_age = now - 3600;
+        let s_1 = comment_score(&fixture(same_age, 1, 0), now);
+        let s_100 = comment_score(&fixture(same_age, 100, 0), now);
+        // Linear scaling would give roughly 100× the increment. Log scaling
+        // should keep it under, say, 10× — comfortably sublinear.
+        assert!(
+            (s_100 - s_1) < 10.0 * (s_1 - 0.0),
+            "log scale broken: s(1)={s_1}, s(100)={s_100}"
+        );
+    }
+
+    #[test]
+    fn likes_score_jumps_stabilize_at_high_counts() {
+        // Above ~10, each decade of likes adds a near-constant ~3 points
+        // (log10(10) × W_L). Verifies the curve flattens — once a comment
+        // is "popular enough", more likes barely change ranking.
+        let now = 1_000_000;
+        let same_age = now - 3600;
+        let s_100 = comment_score(&fixture(same_age, 100, 0), now);
+        let s_1000 = comment_score(&fixture(same_age, 1_000, 0), now);
+        let s_10000 = comment_score(&fixture(same_age, 10_000, 0), now);
+        let jump_a = s_1000 - s_100;
+        let jump_b = s_10000 - s_1000;
+        let diff = (jump_a - jump_b).abs();
+        // At decades this large, +1 offset is negligible, so jumps should be
+        // essentially equal.
+        assert!(
+            diff < 0.05,
+            "decade jumps not stabilized: 100→1k={jump_a}, 1k→10k={jump_b}"
+        );
+    }
+
+    // ── Edge cases / safety ──────────────────────────────────────
+
+    #[test]
+    fn negative_age_does_not_panic() {
+        // Clock skew: comment "from the future".
+        let now = 1_000_000;
+        let future = fixture(now + 3600, 5, 0);
+        let _ = comment_score(&future, now); // must not panic
+    }
+
+    #[test]
+    fn zero_engagement_zero_age_safe() {
+        // Default-constructed comment (all zeros) must produce a finite score.
+        let s = comment_score(&DiscussionCommentResponse::default(), 0);
+        assert!(s.is_finite(), "got {s}");
+    }
+
+    // ── Realistic mixed scenario ──────────────────────────────────
+
+    #[test]
+    fn realistic_ordering_matches_intent() {
+        // Mirrors the simulation table from the design discussion.
+        let now = 1_000_000;
+        let scenarios = vec![
+            ("just_now",          fixture(now,           0, 0)),
+            ("30min_silent",      fixture(now - 1800,    0, 0)),
+            ("1h_silent",         fixture(now - 3600,    0, 0)),
+            ("1h_5_likes",        fixture(now - 3600,    5, 0)),
+            ("6h_popular",        fixture(now - 21600,   50, 5)),
+            ("1d_modest",         fixture(now - 86400,   10, 1)),
+            ("7d_classic",        fixture(now - 604800,  100, 20)),
+        ];
+        let mut scored: Vec<(&str, f64)> = scenarios
+            .iter()
+            .map(|(k, c)| (*k, comment_score(c, now)))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        let order: Vec<&str> = scored.iter().map(|(k, _)| *k).collect();
+
+        // Top should be the engaged comment (popular 6h-old).
+        assert_eq!(order[0], "6h_popular", "ranking={scored:?}");
+        // Brand-new silent comment must beat the older silent ones.
+        let pos = |k: &str| order.iter().position(|x| *x == k).unwrap();
+        assert!(pos("just_now") < pos("30min_silent"));
+        assert!(pos("just_now") < pos("1h_silent"));
+        // 1h-old with 5 likes outranks 1h-old silent.
+        assert!(pos("1h_5_likes") < pos("1h_silent"));
+    }
 }

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/script.js
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/script.js
@@ -123,10 +123,51 @@ function initCommentsPanelResizer() {
   document.addEventListener("touchcancel", onPointerUp);
 }
 
+// Measure each `.comment-text > .comment-item__text` against its 3-line
+// CSS clamp; flip `data-truncatable="true"` on the wrapper so the CSS
+// rule reveals the "Show more" button. ResizeObserver fires once when
+// `observe()` is called and again whenever the element's size changes
+// (line-clamp toggle on expand, viewport resize, font load). We skip
+// updates while expanded so the "접기" button stays visible.
+var commentTextResizeObserver = null;
+
+function getCommentTextObserver() {
+  if (commentTextResizeObserver) return commentTextResizeObserver;
+  commentTextResizeObserver = new ResizeObserver(function (entries) {
+    entries.forEach(function (entry) {
+      var textEl = entry.target;
+      var wrapper = textEl.parentElement;
+      if (!wrapper || !wrapper.classList.contains("comment-text")) return;
+      if (wrapper.dataset.expanded === "true") return;
+      // +1 tolerance for subpixel rounding.
+      var truncated = textEl.scrollHeight > textEl.clientHeight + 1;
+      if (truncated) {
+        wrapper.dataset.truncatable = "true";
+      } else {
+        wrapper.removeAttribute("data-truncatable");
+      }
+    });
+  });
+  return commentTextResizeObserver;
+}
+
+function bindCommentTextObservers() {
+  var nodes = document.querySelectorAll(
+    ".comment-text .comment-item__text:not([data-truncation-bound])"
+  );
+  if (nodes.length === 0) return;
+  var observer = getCommentTextObserver();
+  nodes.forEach(function (el) {
+    el.dataset.truncationBound = "true";
+    observer.observe(el);
+  });
+}
+
 function init() {
   initComposerAutogrow();
   initMentionFlip();
   initCommentsPanelResizer();
+  bindCommentTextObservers();
 }
 
 init();

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/script.js
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/script.js
@@ -66,9 +66,67 @@ function initMentionFlip() {
 // Dioxus re-rendered the panel content (e.g., on Reply tap → thread
 // drill-down) because the `.expanded` class lived outside the VDOM.
 
+// Drag-to-resize the comments panel. The width is JS-owned because Dioxus
+// doesn't set `style` on `.comments-panel` — the inline width survives
+// re-renders. CSS provides `min-width: 420px` (the previous fixed width);
+// here we cap the upper bound at 70% of viewport so the discussion body
+// always keeps room. Listeners are attached to `document` (not the 6px
+// handle) so the cursor doesn't fall off the hit-area mid-drag.
+var COMMENTS_PANEL_MIN = 420;
+var COMMENTS_PANEL_MAX_PCT = 0.7;
+
+function initCommentsPanelResizer() {
+  var resizer = document.getElementById("comments-panel-resizer");
+  if (!resizer || resizer.dataset.resizerBound) return;
+  var panel = document.getElementById("discussion-comments-sheet");
+  if (!panel) return;
+  resizer.dataset.resizerBound = "true";
+
+  var dragging = false;
+  var startX = 0;
+  var startWidth = 0;
+
+  function onPointerMove(e) {
+    if (!dragging) return;
+    var clientX = e.clientX !== undefined ? e.clientX : e.touches[0].clientX;
+    // Panel is on the right; dragging left (smaller clientX) widens it.
+    var deltaX = startX - clientX;
+    var newWidth = startWidth + deltaX;
+    var maxWidth = window.innerWidth * COMMENTS_PANEL_MAX_PCT;
+    if (newWidth < COMMENTS_PANEL_MIN) newWidth = COMMENTS_PANEL_MIN;
+    if (newWidth > maxWidth) newWidth = maxWidth;
+    panel.style.width = newWidth + "px";
+  }
+
+  function onPointerUp() {
+    if (!dragging) return;
+    dragging = false;
+    resizer.classList.remove("dragging");
+    document.body.classList.remove("comments-panel-resizing");
+  }
+
+  function onPointerDown(e) {
+    e.preventDefault();
+    dragging = true;
+    startX = e.clientX !== undefined ? e.clientX : e.touches[0].clientX;
+    startWidth = panel.getBoundingClientRect().width;
+    resizer.classList.add("dragging");
+    document.body.classList.add("comments-panel-resizing");
+  }
+
+  resizer.addEventListener("mousedown", onPointerDown);
+  resizer.addEventListener("touchstart", onPointerDown, { passive: false });
+  document.addEventListener("mousemove", onPointerMove);
+  document.addEventListener("touchmove", onPointerMove, { passive: false });
+  document.addEventListener("mouseup", onPointerUp);
+  document.addEventListener("touchend", onPointerUp);
+  document.addEventListener("touchcancel", onPointerUp);
+}
+
 function init() {
   initComposerAutogrow();
   initMentionFlip();
+  initCommentsPanelResizer();
 }
 
 init();

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
@@ -1246,11 +1246,52 @@ body.comments-panel-resizing {
 }
 /* The parent comment sits in its own highlighted block above the thread
    (matches YouTube/Reddit's mobile replies view where the comment you
-   tapped stays visible as context). */
+   tapped stays visible as context). Scrolls naturally with the replies
+   underneath; long bodies stay readable via the `더보기` toggle inside
+   `CommentText`. */
 .reply-thread__parent {
   padding: 4px 0 12px;
   border-bottom: 1px solid var(--border);
   background: var(--surface-raised);
+}
+
+/* `CommentText` wrapper. `data-expanded` is Dioxus-controlled (toggle
+   button); `data-truncatable` is JS-controlled (set after measuring
+   that the rendered text exceeds 3 lines). The expand button is hidden
+   unless `data-truncatable="true"` so short comments don't show a
+   useless toggle. */
+.comment-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 0;
+  width: 100%;
+}
+.comment-text[data-expanded="false"] .comment-item__text {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.comment-item__expand {
+  margin-top: 2px;
+  padding: 2px 0;
+  background: transparent;
+  border: none;
+  color: var(--accent, #fcb300);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: flex-start;
+  display: none;
+}
+.comment-text[data-truncatable="true"] .comment-item__expand {
+  display: inline-block;
+}
+.comment-item__expand:hover {
+  text-decoration: underline;
 }
 .reply-thread__list {
   padding: 4px 0 0;

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
@@ -450,7 +450,11 @@
 
 /* ── Right: Comments Panel ─────────────────────── */
 .comments-panel {
+  /* Initial width = previous fixed 420px. JS may set a larger inline
+     `style.width` via the resizer drag; `min-width` keeps the panel
+     from shrinking below the design floor regardless. */
   width: 420px;
+  min-width: 420px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -459,6 +463,32 @@
   -webkit-backdrop-filter: blur(24px);
   border-left: 1px solid var(--border);
   overflow: hidden;
+}
+
+/* Drag handle between discussion-main and comments-panel. Visual chrome
+   is intentionally minimal — a hover/active accent strip is enough to
+   signal interactivity without competing with the comment content. */
+.comments-panel__resizer {
+  width: 6px;
+  flex-shrink: 0;
+  background: transparent;
+  cursor: col-resize;
+  position: relative;
+  z-index: 2;
+  transition: background 0.15s ease;
+  user-select: none;
+}
+.comments-panel__resizer:hover,
+.comments-panel__resizer.dragging {
+  background: var(--dark, rgba(252, 179, 0, 0.35))
+    var(--light, rgba(252, 179, 0, 0.45));
+}
+/* While dragging, suppress text selection and force the col-resize
+   cursor across the whole document so the cursor doesn't flicker when
+   the pointer leaves the 6px hit-area. */
+body.comments-panel-resizing {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 
 .comments-panel__header {
@@ -978,6 +1008,11 @@
     grid-template-columns: 1fr;
   }
 
+  /* Resizer is irrelevant in bottom-sheet layout. */
+  .comments-panel__resizer {
+    display: none;
+  }
+
   /* Convert comments-panel to bottom sheet */
   .comments-panel {
     position: fixed;
@@ -985,7 +1020,12 @@
     left: 0;
     right: 0;
     z-index: 100;
-    width: 100%;
+    /* `!important` overrides any inline `style.width` set by the
+       desktop drag-resizer when the user shrinks the viewport across
+       the breakpoint. `min-width` reset lets the sheet follow small
+       phone widths (e.g. 375px). */
+    width: 100% !important;
+    min-width: 0 !important;
     max-height: 85vh;
     border-left: none;
     border-top: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Four discussion-arena improvements bundled together — all in the same `discussion` feature module:

- **Score-based comment sort (client-side, 5s re-rank tick)** — replaces server-driven likes-only ordering with a blended score (popularity + activity + freshness + 1-hour fresh boost). Re-evaluated every 5s on the polling tick so time decay reorders comments without waiting for new data. 12 unit tests cover the algorithm.
- **Reply like/edit/delete fix** — `SpacePostCommentTargetEntityType::from_str` was leaving a raw `#` between parent and reply ids, which browsers truncated as a URL fragment, mis-routing `like_comment` requests to `update_comment` and yielding HTTP 500 \`missing field content\`. Switched to the `::` separator that the reverse `From<EntityType>` already uses.
- **Drag-resizable comments panel** — 6px handle between `.discussion-main` and `.comments-panel`. Previous fixed 420px is now the minimum; max is 70% of viewport. Width is JS-owned so it survives Dioxus re-renders. Mobile bottom-sheet breakpoint hides the handle and forces `width: 100%`.
- **3-line comment truncation with toggle** — long comments collapse to 3 visual lines with a "더 보기/접기" button. Truncation is CSS `-webkit-line-clamp: 3`; JS `ResizeObserver` measures `scrollHeight > clientHeight` and toggles `data-truncatable` so the button appears only when needed. Adapts to viewport width / language / font load — char-count thresholds don't.

## Commits

- 8ce44f2e8 fix(discussion/comments): URL-encode reply sk via :: separator
- c80fd9345 feat(discussion/arena): client-side score sort with 5s re-rank tick
- a5d5c4457 feat(discussion/arena): drag-resizable comments panel
- ff89fd524 feat(discussion/arena): collapse long comments to 3 lines with toggle

## Score formula

\`\`\`
score = log10(likes + 1) * 3        // popularity, log-dampened
      + log10(replies + 1) * 5      // discussion (weighted higher)
      + created_at / 86400          // additive freshness baseline
      + 4 * exp(-age_hours / 1.0)   // 1-hour fresh boost, smooth decay
\`\`\`

## Test plan

- [ ] Reply 좋아요/수정/삭제 동작 확인 (이전엔 500 났음)
- [ ] 댓글 작성 직후 새 댓글이 위로 올라오는지 확인 (fresh boost)
- [ ] 5초 가만히 두면 fresh boost 감쇠로 위치 변화 확인 가능
- [ ] 좋아요 많은 오래된 댓글이 새 댓글 위에 유지되는지 확인
- [ ] 좋아요 직후 자기 댓글이 즉시 점프하지 않는지 확인 (overlay는 ranking에 영향 없음)
- [ ] 데스크톱: comments-panel 좌측 6px 핸들 hover → col-resize 커서 → 드래그로 폭 조절
- [ ] 420px 미만으로 못 줄어드는지, 뷰포트 70% 넘게 못 늘리는지 확인
- [ ] 데스크톱에서 패널 넓힌 뒤 창을 모바일 폭으로 줄이면 bottom sheet로 정상 전환되는지 확인
- [ ] 댓글이 3줄 이하면 "더 보기" 버튼 안 보임
- [ ] 3줄 초과면 자동 truncate + "더 보기" 노출 → 클릭 → 풀 본문 + "접기" 토글
- [ ] 창 크기 줄여서 줄 수 변하면 버튼 표시 여부 자동 갱신 (ResizeObserver)
- [ ] \`cargo test --features "server,bypass" --lib -- use_discussion_arena::tests\` 통과 확인 (12개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)