### PR TITLE
refactor(editor): migrate TiptapEditor callers to native RichEditor

### DIFF
--- a/app/ratel/src/common/components/editor/component.rs
+++ b/app/ratel/src/common/components/editor/component.rs
@@ -26,7 +26,8 @@ pub fn Editor(props: EditorProps) -> Element {
     // force a remount when the editor needs to be reset.
     let content = use_hook(|| props.content.clone());
     let placeholder = props.placeholder.clone();
-    let editable = if props.editable { "true" } else { "false" };
+    let is_editable = props.editable;
+    let editable = if is_editable { "true" } else { "false" };
     let extra_class = props.class.clone();
 
     rsx! {
@@ -56,718 +57,720 @@ pub fn Editor(props: EditorProps) -> Element {
                     }
                 },
             }
-            div {
-                aria_label: "Editor toolbar",
-                class: "re-toolbar",
-                role: "toolbar",
-                div { class: "re-toolbar__group",
-                    button {
-                        aria_label: "Undo",
-                        class: "re-tb-btn",
-                        "data-cmd": "undo",
-                        "data-tip": "Undo",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M3 7v6h6" }
-                            path { d: "M21 17a9 9 0 0 0-15-6.7L3 13" }
-                        }
-                    }
-                    button {
-                        aria_label: "Redo",
-                        class: "re-tb-btn",
-                        "data-cmd": "redo",
-                        "data-tip": "Redo",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M21 7v6h-6" }
-                            path { d: "M3 17a9 9 0 0 1 15-6.7L21 13" }
-                        }
-                    }
-                }
-                div { class: "re-toolbar__group",
-                    div { class: "re-block", "data-open": "false",
+            if is_editable {
+                div {
+                    aria_label: "Editor toolbar",
+                    class: "re-toolbar",
+                    role: "toolbar",
+                    div { class: "re-toolbar__group",
                         button {
-                            aria_expanded: "false",
-                            aria_haspopup: "listbox",
-                            class: "re-block__btn",
+                            aria_label: "Undo",
+                            class: "re-tb-btn",
+                            "data-cmd": "undo",
+                            "data-tip": "Undo",
                             r#type: "button",
-                            span { class: "re-block__label", "Paragraph" }
                             svg {
                                 fill: "none",
                                 stroke: "currentColor",
                                 stroke_linecap: "round",
                                 stroke_linejoin: "round",
-                                stroke_width: "2.5",
+                                stroke_width: "2",
                                 view_box: "0 0 24 24",
-                                polyline { points: "6 9 12 15 18 9" }
+                                path { d: "M3 7v6h6" }
+                                path { d: "M21 17a9 9 0 0 0-15-6.7L3 13" }
                             }
                         }
-                        div { class: "re-block__menu", role: "listbox",
+                        button {
+                            aria_label: "Redo",
+                            class: "re-tb-btn",
+                            "data-cmd": "redo",
+                            "data-tip": "Redo",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                path { d: "M21 7v6h-6" }
+                                path { d: "M3 17a9 9 0 0 1 15-6.7L21 13" }
+                            }
+                        }
+                    }
+                    div { class: "re-toolbar__group",
+                        div { class: "re-block", "data-open": "false",
                             button {
-                                class: "re-block__item",
-                                "data-block": "P",
+                                aria_expanded: "false",
+                                aria_haspopup: "listbox",
+                                class: "re-block__btn",
                                 r#type: "button",
-                                span { "Paragraph" }
-                                span { class: "re-block__item-hint", "P" }
+                                span { class: "re-block__label", "Paragraph" }
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2.5",
+                                    view_box: "0 0 24 24",
+                                    polyline { points: "6 9 12 15 18 9" }
+                                }
                             }
-                            button {
-                                class: "re-block__item re-block__item--h1",
-                                "data-block": "H1",
-                                r#type: "button",
-                                span { "Heading 1" }
-                                span { class: "re-block__item-hint", "H1" }
-                            }
-                            button {
-                                class: "re-block__item re-block__item--h2",
-                                "data-block": "H2",
-                                r#type: "button",
-                                span { "Heading 2" }
-                                span { class: "re-block__item-hint", "H2" }
-                            }
-                            button {
-                                class: "re-block__item re-block__item--h3",
-                                "data-block": "H3",
-                                r#type: "button",
-                                span { "Heading 3" }
-                                span { class: "re-block__item-hint", "H3" }
-                            }
-                            button {
-                                class: "re-block__item re-block__item--quote",
-                                "data-block": "BLOCKQUOTE",
-                                r#type: "button",
-                                span { "Quote" }
-                                span { class: "re-block__item-hint", "\"" }
-                            }
-                            button {
-                                class: "re-block__item re-block__item--code",
-                                "data-block": "PRE",
-                                r#type: "button",
-                                span { "Code block" }
-                                span { class: "re-block__item-hint", "{{ }}" }
-                            }
-                        }
-                    }
-                }
-                div { class: "re-toolbar__group",
-                    button {
-                        aria_label: "Bold",
-                        class: "re-tb-btn",
-                        "data-cmd": "bold",
-                        "data-tip": "Bold",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2.4",
-                            view_box: "0 0 24 24",
-                            path { d: "M6 4h8a4 4 0 0 1 0 8H6z" }
-                            path { d: "M6 12h9a4 4 0 0 1 0 8H6z" }
-                        }
-                    }
-                    button {
-                        aria_label: "Italic",
-                        class: "re-tb-btn",
-                        "data-cmd": "italic",
-                        "data-tip": "Italic",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "19",
-                                x2: "10",
-                                y1: "4",
-                                y2: "4",
-                            }
-                            line {
-                                x1: "14",
-                                x2: "5",
-                                y1: "20",
-                                y2: "20",
-                            }
-                            line {
-                                x1: "15",
-                                x2: "9",
-                                y1: "4",
-                                y2: "20",
+                            div { class: "re-block__menu", role: "listbox",
+                                button {
+                                    class: "re-block__item",
+                                    "data-block": "P",
+                                    r#type: "button",
+                                    span { "Paragraph" }
+                                    span { class: "re-block__item-hint", "P" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--h1",
+                                    "data-block": "H1",
+                                    r#type: "button",
+                                    span { "Heading 1" }
+                                    span { class: "re-block__item-hint", "H1" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--h2",
+                                    "data-block": "H2",
+                                    r#type: "button",
+                                    span { "Heading 2" }
+                                    span { class: "re-block__item-hint", "H2" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--h3",
+                                    "data-block": "H3",
+                                    r#type: "button",
+                                    span { "Heading 3" }
+                                    span { class: "re-block__item-hint", "H3" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--quote",
+                                    "data-block": "BLOCKQUOTE",
+                                    r#type: "button",
+                                    span { "Quote" }
+                                    span { class: "re-block__item-hint", "\"" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--code",
+                                    "data-block": "PRE",
+                                    r#type: "button",
+                                    span { "Code block" }
+                                    span { class: "re-block__item-hint", "{{ }}" }
+                                }
                             }
                         }
                     }
-                    button {
-                        aria_label: "Underline",
-                        class: "re-tb-btn",
-                        "data-cmd": "underline",
-                        "data-tip": "Underline",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M6 4v6a6 6 0 0 0 12 0V4" }
-                            line {
-                                x1: "4",
-                                x2: "20",
-                                y1: "20",
-                                y2: "20",
+                    div { class: "re-toolbar__group",
+                        button {
+                            aria_label: "Bold",
+                            class: "re-tb-btn",
+                            "data-cmd": "bold",
+                            "data-tip": "Bold",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2.4",
+                                view_box: "0 0 24 24",
+                                path { d: "M6 4h8a4 4 0 0 1 0 8H6z" }
+                                path { d: "M6 12h9a4 4 0 0 1 0 8H6z" }
+                            }
+                        }
+                        button {
+                            aria_label: "Italic",
+                            class: "re-tb-btn",
+                            "data-cmd": "italic",
+                            "data-tip": "Italic",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "19",
+                                    x2: "10",
+                                    y1: "4",
+                                    y2: "4",
+                                }
+                                line {
+                                    x1: "14",
+                                    x2: "5",
+                                    y1: "20",
+                                    y2: "20",
+                                }
+                                line {
+                                    x1: "15",
+                                    x2: "9",
+                                    y1: "4",
+                                    y2: "20",
+                                }
+                            }
+                        }
+                        button {
+                            aria_label: "Underline",
+                            class: "re-tb-btn",
+                            "data-cmd": "underline",
+                            "data-tip": "Underline",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                path { d: "M6 4v6a6 6 0 0 0 12 0V4" }
+                                line {
+                                    x1: "4",
+                                    x2: "20",
+                                    y1: "20",
+                                    y2: "20",
+                                }
+                            }
+                        }
+                        button {
+                            aria_label: "Strikethrough",
+                            class: "re-tb-btn",
+                            "data-cmd": "strikeThrough",
+                            "data-tip": "Strikethrough",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "4",
+                                    x2: "20",
+                                    y1: "12",
+                                    y2: "12",
+                                }
+                                path { d: "M16 6c-1.5-1.3-3.5-2-6-2-3 0-5 1.5-5 4 0 2 1.5 3 5 4" }
+                                path { d: "M8 18c1.5 1.3 3.5 2 6 2 3 0 5-1.5 5-4 0-1-.4-1.8-1-2.4" }
+                            }
+                        }
+                        button {
+                            aria_label: "Inline code",
+                            class: "re-tb-btn",
+                            "data-cmd": "code-inline",
+                            "data-tip": "Inline code",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                polyline { points: "16 18 22 12 16 6" }
+                                polyline { points: "8 6 2 12 8 18" }
                             }
                         }
                     }
-                    button {
-                        aria_label: "Strikethrough",
-                        class: "re-tb-btn",
-                        "data-cmd": "strikeThrough",
-                        "data-tip": "Strikethrough",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "4",
-                                x2: "20",
-                                y1: "12",
-                                y2: "12",
-                            }
-                            path { d: "M16 6c-1.5-1.3-3.5-2-6-2-3 0-5 1.5-5 4 0 2 1.5 3 5 4" }
-                            path { d: "M8 18c1.5 1.3 3.5 2 6 2 3 0 5-1.5 5-4 0-1-.4-1.8-1-2.4" }
-                        }
-                    }
-                    button {
-                        aria_label: "Inline code",
-                        class: "re-tb-btn",
-                        "data-cmd": "code-inline",
-                        "data-tip": "Inline code",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            polyline { points: "16 18 22 12 16 6" }
-                            polyline { points: "8 6 2 12 8 18" }
-                        }
-                    }
-                }
-                div { class: "re-toolbar__group",
-                    button {
-                        aria_label: "Align left",
-                        class: "re-tb-btn",
-                        "data-cmd": "justifyLeft",
-                        "data-tip": "Align left",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "17",
-                                x2: "3",
-                                y1: "10",
-                                y2: "10",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "6",
-                                y2: "6",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "14",
-                                y2: "14",
-                            }
-                            line {
-                                x1: "17",
-                                x2: "3",
-                                y1: "18",
-                                y2: "18",
+                    div { class: "re-toolbar__group",
+                        button {
+                            aria_label: "Align left",
+                            class: "re-tb-btn",
+                            "data-cmd": "justifyLeft",
+                            "data-tip": "Align left",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "17",
+                                    x2: "3",
+                                    y1: "10",
+                                    y2: "10",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "6",
+                                    y2: "6",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "14",
+                                    y2: "14",
+                                }
+                                line {
+                                    x1: "17",
+                                    x2: "3",
+                                    y1: "18",
+                                    y2: "18",
+                                }
                             }
                         }
-                    }
-                    button {
-                        aria_label: "Align center",
-                        class: "re-tb-btn",
-                        "data-cmd": "justifyCenter",
-                        "data-tip": "Align center",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "18",
-                                x2: "6",
-                                y1: "10",
-                                y2: "10",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "6",
-                                y2: "6",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "14",
-                                y2: "14",
-                            }
-                            line {
-                                x1: "18",
-                                x2: "6",
-                                y1: "18",
-                                y2: "18",
-                            }
-                        }
-                    }
-                    button {
-                        aria_label: "Align right",
-                        class: "re-tb-btn",
-                        "data-cmd": "justifyRight",
-                        "data-tip": "Align right",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "21",
-                                x2: "7",
-                                y1: "10",
-                                y2: "10",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "6",
-                                y2: "6",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "14",
-                                y2: "14",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "7",
-                                y1: "18",
-                                y2: "18",
+                        button {
+                            aria_label: "Align center",
+                            class: "re-tb-btn",
+                            "data-cmd": "justifyCenter",
+                            "data-tip": "Align center",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "18",
+                                    x2: "6",
+                                    y1: "10",
+                                    y2: "10",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "6",
+                                    y2: "6",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "14",
+                                    y2: "14",
+                                }
+                                line {
+                                    x1: "18",
+                                    x2: "6",
+                                    y1: "18",
+                                    y2: "18",
+                                }
                             }
                         }
-                    }
-                    button {
-                        aria_label: "Justify",
-                        class: "re-tb-btn",
-                        "data-cmd": "justifyFull",
-                        "data-tip": "Justify",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "10",
-                                y2: "10",
+                        button {
+                            aria_label: "Align right",
+                            class: "re-tb-btn",
+                            "data-cmd": "justifyRight",
+                            "data-tip": "Align right",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "21",
+                                    x2: "7",
+                                    y1: "10",
+                                    y2: "10",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "6",
+                                    y2: "6",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "14",
+                                    y2: "14",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "7",
+                                    y1: "18",
+                                    y2: "18",
+                                }
                             }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "6",
-                                y2: "6",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "14",
-                                y2: "14",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "18",
-                                y2: "18",
+                        }
+                        button {
+                            aria_label: "Justify",
+                            class: "re-tb-btn",
+                            "data-cmd": "justifyFull",
+                            "data-tip": "Justify",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "10",
+                                    y2: "10",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "6",
+                                    y2: "6",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "14",
+                                    y2: "14",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "18",
+                                    y2: "18",
+                                }
                             }
                         }
                     }
-                }
-                div { class: "re-toolbar__group",
-                    button {
-                        aria_label: "Bullet list",
-                        class: "re-tb-btn",
-                        "data-cmd": "insertUnorderedList",
-                        "data-tip": "Bullet list",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "8",
-                                x2: "21",
-                                y1: "6",
-                                y2: "6",
+                    div { class: "re-toolbar__group",
+                        button {
+                            aria_label: "Bullet list",
+                            class: "re-tb-btn",
+                            "data-cmd": "insertUnorderedList",
+                            "data-tip": "Bullet list",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "8",
+                                    x2: "21",
+                                    y1: "6",
+                                    y2: "6",
+                                }
+                                line {
+                                    x1: "8",
+                                    x2: "21",
+                                    y1: "12",
+                                    y2: "12",
+                                }
+                                line {
+                                    x1: "8",
+                                    x2: "21",
+                                    y1: "18",
+                                    y2: "18",
+                                }
+                                circle { cx: "4", cy: "6", r: "1" }
+                                circle { cx: "4", cy: "12", r: "1" }
+                                circle { cx: "4", cy: "18", r: "1" }
                             }
-                            line {
-                                x1: "8",
-                                x2: "21",
-                                y1: "12",
-                                y2: "12",
-                            }
-                            line {
-                                x1: "8",
-                                x2: "21",
-                                y1: "18",
-                                y2: "18",
-                            }
-                            circle { cx: "4", cy: "6", r: "1" }
-                            circle { cx: "4", cy: "12", r: "1" }
-                            circle { cx: "4", cy: "18", r: "1" }
                         }
-                    }
-                    button {
-                        aria_label: "Numbered list",
-                        class: "re-tb-btn",
-                        "data-cmd": "insertOrderedList",
-                        "data-tip": "Numbered list",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "10",
-                                x2: "21",
-                                y1: "6",
-                                y2: "6",
+                        button {
+                            aria_label: "Numbered list",
+                            class: "re-tb-btn",
+                            "data-cmd": "insertOrderedList",
+                            "data-tip": "Numbered list",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "10",
+                                    x2: "21",
+                                    y1: "6",
+                                    y2: "6",
+                                }
+                                line {
+                                    x1: "10",
+                                    x2: "21",
+                                    y1: "12",
+                                    y2: "12",
+                                }
+                                line {
+                                    x1: "10",
+                                    x2: "21",
+                                    y1: "18",
+                                    y2: "18",
+                                }
+                                path { d: "M4 6h1v4" }
+                                path { d: "M4 10h2" }
+                                path { d: "M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" }
                             }
-                            line {
-                                x1: "10",
-                                x2: "21",
-                                y1: "12",
-                                y2: "12",
-                            }
-                            line {
-                                x1: "10",
-                                x2: "21",
-                                y1: "18",
-                                y2: "18",
-                            }
-                            path { d: "M4 6h1v4" }
-                            path { d: "M4 10h2" }
-                            path { d: "M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" }
                         }
-                    }
-                    button {
-                        aria_label: "Outdent",
-                        class: "re-tb-btn",
-                        "data-cmd": "outdent",
-                        "data-tip": "Outdent",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "5",
-                                y2: "5",
+                        button {
+                            aria_label: "Outdent",
+                            class: "re-tb-btn",
+                            "data-cmd": "outdent",
+                            "data-tip": "Outdent",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "5",
+                                    y2: "5",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "3",
+                                    y1: "19",
+                                    y2: "19",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "11",
+                                    y1: "9",
+                                    y2: "9",
+                                }
+                                line {
+                                    x1: "21",
+                                    x2: "11",
+                                    y1: "15",
+                                    y2: "15",
+                                }
+                                polyline { points: "7 9 3 12 7 15" }
                             }
-                            line {
-                                x1: "21",
-                                x2: "3",
-                                y1: "19",
-                                y2: "19",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "11",
-                                y1: "9",
-                                y2: "9",
-                            }
-                            line {
-                                x1: "21",
-                                x2: "11",
-                                y1: "15",
-                                y2: "15",
-                            }
-                            polyline { points: "7 9 3 12 7 15" }
                         }
-                    }
-                    button {
-                        aria_label: "Indent",
-                        class: "re-tb-btn",
-                        "data-cmd": "indent",
-                        "data-tip": "Indent",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "3",
-                                x2: "21",
-                                y1: "5",
-                                y2: "5",
-                            }
-                            line {
-                                x1: "3",
-                                x2: "21",
-                                y1: "19",
-                                y2: "19",
-                            }
-                            line {
-                                x1: "13",
-                                x2: "3",
-                                y1: "9",
-                                y2: "9",
-                            }
-                            line {
-                                x1: "13",
-                                x2: "3",
-                                y1: "15",
-                                y2: "15",
-                            }
-                            polyline { points: "17 9 21 12 17 15" }
-                        }
-                    }
-                }
-                div { class: "re-toolbar__group",
-                    button {
-                        aria_label: "Insert link",
-                        class: "re-tb-btn",
-                        "data-cmd": "link",
-                        "data-tip": "Insert link",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" }
-                            path { d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" }
-                        }
-                    }
-                    button {
-                        aria_label: "Remove link",
-                        class: "re-tb-btn",
-                        "data-cmd": "unlink",
-                        "data-tip": "Remove link",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M18.84 12.25l1.72-1.71a5 5 0 0 0-7.07-7.07l-1.72 1.71" }
-                            path { d: "M5.16 11.75L3.44 13.46a5 5 0 0 0 7.07 7.07l1.71-1.71" }
-                            line {
-                                x1: "2",
-                                x2: "22",
-                                y1: "2",
-                                y2: "22",
+                        button {
+                            aria_label: "Indent",
+                            class: "re-tb-btn",
+                            "data-cmd": "indent",
+                            "data-tip": "Indent",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "3",
+                                    x2: "21",
+                                    y1: "5",
+                                    y2: "5",
+                                }
+                                line {
+                                    x1: "3",
+                                    x2: "21",
+                                    y1: "19",
+                                    y2: "19",
+                                }
+                                line {
+                                    x1: "13",
+                                    x2: "3",
+                                    y1: "9",
+                                    y2: "9",
+                                }
+                                line {
+                                    x1: "13",
+                                    x2: "3",
+                                    y1: "15",
+                                    y2: "15",
+                                }
+                                polyline { points: "17 9 21 12 17 15" }
                             }
                         }
                     }
-                    button {
-                        aria_label: "Insert image",
-                        class: "re-tb-btn",
-                        "data-cmd": "image",
-                        "data-tip": "Insert image",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            rect {
-                                height: "18",
-                                rx: "2",
-                                width: "18",
-                                x: "3",
-                                y: "3",
-                            }
-                            circle { cx: "8.5", cy: "8.5", r: "1.5" }
-                            polyline { points: "21 15 16 10 5 21" }
-                        }
-                    }
-                    button {
-                        aria_label: "Embed YouTube",
-                        class: "re-tb-btn",
-                        "data-cmd": "youtube",
-                        "data-tip": "Embed YouTube",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M22 8.5a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v7a4 4 0 0 0 4 4h12a4 4 0 0 0 4-4z" }
-                            polygon { points: "10 8 16 12 10 16 10 8" }
-                        }
-                    }
-                    button {
-                        aria_label: "Insert table",
-                        class: "re-tb-btn",
-                        "data-cmd": "table",
-                        "data-tip": "Insert table",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            rect {
-                                height: "18",
-                                rx: "2",
-                                width: "18",
-                                x: "3",
-                                y: "3",
-                            }
-                            line {
-                                x1: "3",
-                                x2: "21",
-                                y1: "9",
-                                y2: "9",
-                            }
-                            line {
-                                x1: "3",
-                                x2: "21",
-                                y1: "15",
-                                y2: "15",
-                            }
-                            line {
-                                x1: "9",
-                                x2: "9",
-                                y1: "3",
-                                y2: "21",
-                            }
-                            line {
-                                x1: "15",
-                                x2: "15",
-                                y1: "3",
-                                y2: "21",
+                    div { class: "re-toolbar__group",
+                        button {
+                            aria_label: "Insert link",
+                            class: "re-tb-btn",
+                            "data-cmd": "link",
+                            "data-tip": "Insert link",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                path { d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" }
+                                path { d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" }
                             }
                         }
-                    }
-                    button {
-                        aria_label: "Horizontal rule",
-                        class: "re-tb-btn",
-                        "data-cmd": "hr",
-                        "data-tip": "Horizontal rule",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            line {
-                                x1: "4",
-                                x2: "20",
-                                y1: "12",
-                                y2: "12",
+                        button {
+                            aria_label: "Remove link",
+                            class: "re-tb-btn",
+                            "data-cmd": "unlink",
+                            "data-tip": "Remove link",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                path { d: "M18.84 12.25l1.72-1.71a5 5 0 0 0-7.07-7.07l-1.72 1.71" }
+                                path { d: "M5.16 11.75L3.44 13.46a5 5 0 0 0 7.07 7.07l1.71-1.71" }
+                                line {
+                                    x1: "2",
+                                    x2: "22",
+                                    y1: "2",
+                                    y2: "22",
+                                }
+                            }
+                        }
+                        button {
+                            aria_label: "Insert image",
+                            class: "re-tb-btn",
+                            "data-cmd": "image",
+                            "data-tip": "Insert image",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                rect {
+                                    height: "18",
+                                    rx: "2",
+                                    width: "18",
+                                    x: "3",
+                                    y: "3",
+                                }
+                                circle { cx: "8.5", cy: "8.5", r: "1.5" }
+                                polyline { points: "21 15 16 10 5 21" }
+                            }
+                        }
+                        button {
+                            aria_label: "Embed YouTube",
+                            class: "re-tb-btn",
+                            "data-cmd": "youtube",
+                            "data-tip": "Embed YouTube",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                path { d: "M22 8.5a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v7a4 4 0 0 0 4 4h12a4 4 0 0 0 4-4z" }
+                                polygon { points: "10 8 16 12 10 16 10 8" }
+                            }
+                        }
+                        button {
+                            aria_label: "Insert table",
+                            class: "re-tb-btn",
+                            "data-cmd": "table",
+                            "data-tip": "Insert table",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                rect {
+                                    height: "18",
+                                    rx: "2",
+                                    width: "18",
+                                    x: "3",
+                                    y: "3",
+                                }
+                                line {
+                                    x1: "3",
+                                    x2: "21",
+                                    y1: "9",
+                                    y2: "9",
+                                }
+                                line {
+                                    x1: "3",
+                                    x2: "21",
+                                    y1: "15",
+                                    y2: "15",
+                                }
+                                line {
+                                    x1: "9",
+                                    x2: "9",
+                                    y1: "3",
+                                    y2: "21",
+                                }
+                                line {
+                                    x1: "15",
+                                    x2: "15",
+                                    y1: "3",
+                                    y2: "21",
+                                }
+                            }
+                        }
+                        button {
+                            aria_label: "Horizontal rule",
+                            class: "re-tb-btn",
+                            "data-cmd": "hr",
+                            "data-tip": "Horizontal rule",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                line {
+                                    x1: "4",
+                                    x2: "20",
+                                    y1: "12",
+                                    y2: "12",
+                                }
                             }
                         }
                     }
-                }
-                div { class: "re-toolbar__group",
-                    button {
-                        aria_label: "Clear formatting",
-                        class: "re-tb-btn",
-                        "data-cmd": "removeFormat",
-                        "data-tip": "Clear formatting",
-                        r#type: "button",
-                        svg {
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            stroke_width: "2",
-                            view_box: "0 0 24 24",
-                            path { d: "M4 7V4h16v3" }
-                            line {
-                                x1: "5",
-                                x2: "11",
-                                y1: "20",
-                                y2: "20",
-                            }
-                            line {
-                                x1: "13",
-                                x2: "8",
-                                y1: "4",
-                                y2: "20",
-                            }
-                            line {
-                                x1: "3",
-                                x2: "21",
-                                y1: "3",
-                                y2: "21",
+                    div { class: "re-toolbar__group",
+                        button {
+                            aria_label: "Clear formatting",
+                            class: "re-tb-btn",
+                            "data-cmd": "removeFormat",
+                            "data-tip": "Clear formatting",
+                            r#type: "button",
+                            svg {
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                view_box: "0 0 24 24",
+                                path { d: "M4 7V4h16v3" }
+                                line {
+                                    x1: "5",
+                                    x2: "11",
+                                    y1: "20",
+                                    y2: "20",
+                                }
+                                line {
+                                    x1: "13",
+                                    x2: "8",
+                                    y1: "4",
+                                    y2: "20",
+                                }
+                                line {
+                                    x1: "3",
+                                    x2: "21",
+                                    y1: "3",
+                                    y2: "21",
+                                }
                             }
                         }
                     }
@@ -781,213 +784,215 @@ pub fn Editor(props: EditorProps) -> Element {
                 spellcheck: "true",
                 dangerous_inner_html: "{content}",
             }
-            div { class: "re-statusbar",
-                div { class: "re-statusbar__chips",
-                    span { class: "re-statusbar__chip",
-                        "Words "
-                        strong { class: "re-word-count", "0" }
+            if is_editable {
+                div { class: "re-statusbar",
+                    div { class: "re-statusbar__chips",
+                        span { class: "re-statusbar__chip",
+                            "Words "
+                            strong { class: "re-word-count", "0" }
+                        }
+                        span { class: "re-statusbar__chip",
+                            "Chars "
+                            strong { class: "re-char-count", "0" }
+                        }
                     }
-                    span { class: "re-statusbar__chip",
-                        "Chars "
-                        strong { class: "re-char-count", "0" }
-                    }
+                    div { class: "re-statusbar__chip re-ime-state", "composing…" }
                 }
-                div { class: "re-statusbar__chip re-ime-state", "composing…" }
-            }
-            div { class: "re-modal-mask", "data-modal": "link",
-                div {
-                    aria_label: "Insert link",
-                    class: "re-modal",
-                    role: "dialog",
-                    div { class: "re-modal__title", "Insert link" }
-                    div { class: "re-modal__field",
-                        label { "URL" }
-                        input {
-                            autocomplete: "off",
-                            class: "re-link-url",
-                            placeholder: "https://example.com",
-                            r#type: "url",
-                        }
-                    }
-                    div { class: "re-modal__actions",
-                        button {
-                            class: "re-btn",
-                            "data-close-modal": "false",
-                            r#type: "button",
-                            "Cancel"
-                        }
-                        button {
-                            class: "re-btn re-btn--primary re-link-confirm",
-                            r#type: "button",
-                            "Insert"
-                        }
-                    }
-                }
-            }
-            div { class: "re-modal-mask", "data-modal": "image",
-                div {
-                    aria_label: "Insert image",
-                    class: "re-modal",
-                    role: "dialog",
-                    div { class: "re-modal__title", "Insert image" }
-
-                    label { class: "re-dropzone", "data-dragging": "false",
-                        input {
-                            class: "re-image-file",
-                            accept: "image/*",
-                            hidden: true,
-                            r#type: "file",
-                        }
-                        svg {
-                            class: "re-dropzone__icon",
-                            view_box: "0 0 24 24",
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_width: "1.5",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            rect {
-                                x: "3",
-                                y: "3",
-                                width: "18",
-                                height: "18",
-                                rx: "2",
-                            }
-                            circle { cx: "8.5", cy: "8.5", r: "1.5" }
-                            polyline { points: "21 15 16 10 5 21" }
-                        }
-                        div { class: "re-dropzone__title", "Drag & drop an image" }
-                        div { class: "re-dropzone__hint",
-                            "or tap to browse — PNG, JPG, GIF, WebP"
-                        }
-                    }
-
-                    label { class: "re-camera-btn",
-                        input {
-                            class: "re-image-camera",
-                            accept: "image/*",
-                            capture: "environment",
-                            hidden: true,
-                            r#type: "file",
-                        }
-                        svg {
-                            view_box: "0 0 24 24",
-                            fill: "none",
-                            stroke: "currentColor",
-                            stroke_width: "1.8",
-                            stroke_linecap: "round",
-                            stroke_linejoin: "round",
-                            path { d: "M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" }
-                            circle { cx: "12", cy: "13", r: "4" }
-                        }
-                        span { "Take a photo" }
-                    }
-
-                    div { class: "re-modal__divider",
-                        span { "OR PASTE A URL" }
-                    }
-
-                    div { class: "re-modal__field",
-                        input {
-                            class: "re-image-url",
-                            placeholder: "https://example.com/image.png",
-                            r#type: "url",
-                        }
-                    }
-
-                    div { class: "re-modal__actions",
-                        button {
-                            class: "re-btn",
-                            "data-close-modal": "false",
-                            r#type: "button",
-                            "Cancel"
-                        }
-                        button {
-                            class: "re-btn re-btn--primary re-image-confirm",
-                            r#type: "button",
-                            "Insert URL"
-                        }
-                    }
-                }
-            }
-            div { class: "re-modal-mask", "data-modal": "youtube",
-                div {
-                    aria_label: "Embed YouTube",
-                    class: "re-modal",
-                    role: "dialog",
-                    div { class: "re-modal__title", "Embed YouTube video" }
-                    div { class: "re-modal__field",
-                        label { "YouTube URL or ID" }
-                        input {
-                            class: "re-youtube-url",
-                            placeholder: "https://youtu.be/dQw4w9WgXcQ",
-                            r#type: "text",
-                        }
-                    }
-                    div { class: "re-modal__actions",
-                        button {
-                            class: "re-btn",
-                            "data-close-modal": "false",
-                            r#type: "button",
-                            "Cancel"
-                        }
-                        button {
-                            class: "re-btn re-btn--primary re-youtube-confirm",
-                            r#type: "button",
-                            "Embed"
-                        }
-                    }
-                }
-            }
-            div { class: "re-modal-mask", "data-modal": "table",
-                div {
-                    aria_label: "Insert table",
-                    class: "re-modal",
-                    role: "dialog",
-                    div { class: "re-modal__title", "Insert table" }
-                    div { class: "re-modal__row",
+                div { class: "re-modal-mask", "data-modal": "link",
+                    div {
+                        aria_label: "Insert link",
+                        class: "re-modal",
+                        role: "dialog",
+                        div { class: "re-modal__title", "Insert link" }
                         div { class: "re-modal__field",
-                            label { "Rows" }
+                            label { "URL" }
                             input {
-                                class: "re-table-rows",
-                                max: "20",
-                                min: "1",
-                                r#type: "number",
-                                value: "3",
+                                autocomplete: "off",
+                                class: "re-link-url",
+                                placeholder: "https://example.com",
+                                r#type: "url",
+                            }
+                        }
+                        div { class: "re-modal__actions",
+                            button {
+                                class: "re-btn",
+                                "data-close-modal": "false",
+                                r#type: "button",
+                                "Cancel"
+                            }
+                            button {
+                                class: "re-btn re-btn--primary re-link-confirm",
+                                r#type: "button",
+                                "Insert"
+                            }
+                        }
+                    }
+                }
+                div { class: "re-modal-mask", "data-modal": "image",
+                    div {
+                        aria_label: "Insert image",
+                        class: "re-modal",
+                        role: "dialog",
+                        div { class: "re-modal__title", "Insert image" }
+
+                        label { class: "re-dropzone", "data-dragging": "false",
+                            input {
+                                class: "re-image-file",
+                                accept: "image/*",
+                                hidden: true,
+                                r#type: "file",
+                            }
+                            svg {
+                                class: "re-dropzone__icon",
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "1.5",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                rect {
+                                    x: "3",
+                                    y: "3",
+                                    width: "18",
+                                    height: "18",
+                                    rx: "2",
+                                }
+                                circle { cx: "8.5", cy: "8.5", r: "1.5" }
+                                polyline { points: "21 15 16 10 5 21" }
+                            }
+                            div { class: "re-dropzone__title", "Drag & drop an image" }
+                            div { class: "re-dropzone__hint",
+                                "or tap to browse — PNG, JPG, GIF, WebP"
+                            }
+                        }
+
+                        label { class: "re-camera-btn",
+                            input {
+                                class: "re-image-camera",
+                                accept: "image/*",
+                                capture: "environment",
+                                hidden: true,
+                                r#type: "file",
+                            }
+                            svg {
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "1.8",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                path { d: "M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" }
+                                circle { cx: "12", cy: "13", r: "4" }
+                            }
+                            span { "Take a photo" }
+                        }
+
+                        div { class: "re-modal__divider",
+                            span { "OR PASTE A URL" }
+                        }
+
+                        div { class: "re-modal__field",
+                            input {
+                                class: "re-image-url",
+                                placeholder: "https://example.com/image.png",
+                                r#type: "url",
+                            }
+                        }
+
+                        div { class: "re-modal__actions",
+                            button {
+                                class: "re-btn",
+                                "data-close-modal": "false",
+                                r#type: "button",
+                                "Cancel"
+                            }
+                            button {
+                                class: "re-btn re-btn--primary re-image-confirm",
+                                r#type: "button",
+                                "Insert URL"
+                            }
+                        }
+                    }
+                }
+                div { class: "re-modal-mask", "data-modal": "youtube",
+                    div {
+                        aria_label: "Embed YouTube",
+                        class: "re-modal",
+                        role: "dialog",
+                        div { class: "re-modal__title", "Embed YouTube video" }
+                        div { class: "re-modal__field",
+                            label { "YouTube URL or ID" }
+                            input {
+                                class: "re-youtube-url",
+                                placeholder: "https://youtu.be/dQw4w9WgXcQ",
+                                r#type: "text",
+                            }
+                        }
+                        div { class: "re-modal__actions",
+                            button {
+                                class: "re-btn",
+                                "data-close-modal": "false",
+                                r#type: "button",
+                                "Cancel"
+                            }
+                            button {
+                                class: "re-btn re-btn--primary re-youtube-confirm",
+                                r#type: "button",
+                                "Embed"
+                            }
+                        }
+                    }
+                }
+                div { class: "re-modal-mask", "data-modal": "table",
+                    div {
+                        aria_label: "Insert table",
+                        class: "re-modal",
+                        role: "dialog",
+                        div { class: "re-modal__title", "Insert table" }
+                        div { class: "re-modal__row",
+                            div { class: "re-modal__field",
+                                label { "Rows" }
+                                input {
+                                    class: "re-table-rows",
+                                    max: "20",
+                                    min: "1",
+                                    r#type: "number",
+                                    value: "3",
+                                }
+                            }
+                            div { class: "re-modal__field",
+                                label { "Columns" }
+                                input {
+                                    class: "re-table-cols",
+                                    max: "10",
+                                    min: "1",
+                                    r#type: "number",
+                                    value: "3",
+                                }
                             }
                         }
                         div { class: "re-modal__field",
-                            label { "Columns" }
-                            input {
-                                class: "re-table-cols",
-                                max: "10",
-                                min: "1",
-                                r#type: "number",
-                                value: "3",
+                            label { class: "re-modal__checkbox",
+                                input {
+                                    checked: "false",
+                                    class: "re-table-header",
+                                    r#type: "checkbox",
+                                }
+                                " First row is header\n        "
                             }
                         }
-                    }
-                    div { class: "re-modal__field",
-                        label { class: "re-modal__checkbox",
-                            input {
-                                checked: "false",
-                                class: "re-table-header",
-                                r#type: "checkbox",
+                        div { class: "re-modal__actions",
+                            button {
+                                class: "re-btn",
+                                "data-close-modal": "false",
+                                r#type: "button",
+                                "Cancel"
                             }
-                            " First row is header\n        "
-                        }
-                    }
-                    div { class: "re-modal__actions",
-                        button {
-                            class: "re-btn",
-                            "data-close-modal": "false",
-                            r#type: "button",
-                            "Cancel"
-                        }
-                        button {
-                            class: "re-btn re-btn--primary re-table-confirm",
-                            r#type: "button",
-                            "Insert"
+                            button {
+                                class: "re-btn re-btn--primary re-table-confirm",
+                                r#type: "button",
+                                "Insert"
+                            }
                         }
                     }
                 }

--- a/app/ratel/src/common/components/editor/script.js
+++ b/app/ratel/src/common/components/editor/script.js
@@ -32,6 +32,12 @@
     editor.setAttribute("contenteditable", editable ? "true" : "false");
     refreshEmptyState();
 
+    // Viewer mode skips all toolbar/modal/IME wiring — those DOM nodes
+    // are not rendered when `editable=false`, so querying them would
+    // throw. Read-only surfaces just need contenteditable=false and the
+    // empty-state flag set above.
+    if (!editable) return;
+
     // ── IME-safe input handling ────────────────────────────
     var composing = false;
     editor.addEventListener("compositionstart", function () {

--- a/app/ratel/src/common/components/editor/style.css
+++ b/app/ratel/src/common/components/editor/style.css
@@ -550,3 +550,42 @@
     font-size: 16px;
   }
 }
+
+/* ─── Viewer mode (editable="false") ──────────────────────────
+   Strip chrome sizing constraints so the editor behaves like inline
+   prose. No toolbar/statusbar/modal CSS resets needed — those DOM
+   nodes are not rendered by the Dioxus component in viewer mode. */
+.ratel-editor[data-editable="false"] {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
+}
+.ratel-editor[data-editable="false"] .re-content {
+  min-height: 0;
+  max-height: none;
+  overflow: visible;
+  padding: 0;
+}
+
+/* ─── Tiptap legacy YouTube embed compatibility ───────────────
+   Older posts stored Tiptap's `<div data-youtube-video><iframe/></div>`
+   wrapper. The new editor emits `<div class="yt-wrap">`, but existing
+   content needs the same 16:9 aspect-ratio container to render
+   correctly here. */
+.ratel-editor .re-content div[data-youtube-video] {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  margin: 0.75rem 0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #000;
+}
+.ratel-editor .re-content div[data-youtube-video] iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/app/ratel/src/features/posts/components/post_detail/content.rs
+++ b/app/ratel/src/features/posts/components/post_detail/content.rs
@@ -2,7 +2,7 @@ use crate::features::posts::controllers::dto::*;
 use crate::features::posts::models::PostArtworkMetadata;
 use crate::features::posts::types::*;
 use crate::features::posts::*;
-use crate::common::components::TiptapEditor;
+use crate::common::components::editor::Editor as RichEditor;
 use dioxus::prelude::*;
 
 #[component]
@@ -52,7 +52,7 @@ pub fn PostContent(
                                 h2 { class: "text-lg font-semibold text-text-primary",
                                     "Description"
                                 }
-                                TiptapEditor {
+                                RichEditor {
                                     class: "w-full bg-transparent",
                                     content: html_contents.clone(),
                                     editable: false,
@@ -68,7 +68,7 @@ pub fn PostContent(
         rsx! {
             div { class: "flex flex-col py-5 px-4 w-full border rounded-[10px] bg-card-bg border-card-border",
                 div { class: "flex flex-col gap-5 w-full",
-                    TiptapEditor {
+                    RichEditor {
                         class: "w-full bg-transparent",
                         content: html_contents.clone(),
                         editable: false,

--- a/app/ratel/src/features/spaces/pages/actions/actions/discussion/views/editor/content_card/component.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/discussion/views/editor/content_card/component.rs
@@ -1,3 +1,4 @@
+use crate::common::components::editor::Editor as RichEditor;
 use crate::common::components::{FileUploader, UploadedFileMeta};
 use crate::common::types::extract_filename_from_url;
 use crate::features::spaces::pages::actions::actions::discussion::views::editor::DiscussionEditorTranslate;
@@ -186,8 +187,8 @@ pub fn ContentCard() -> Element {
                         }
                     }
                     div { class: "editor",
-                        crate::common::components::TiptapEditor {
-                            class: "[&_[data-tiptap-toolbar]]:border-b [&_[data-tiptap-toolbar]]:border-[rgba(255,255,255,0.06)] [&_[contenteditable='true']]:min-h-[220px] [&_[contenteditable='true']]:px-[22px] [&_[contenteditable='true']]:py-[20px] [&_[contenteditable='true']]:outline-none",
+                        RichEditor {
+                            class: "[&_.re-toolbar]:border-b [&_.re-toolbar]:border-[rgba(255,255,255,0.06)] [&_.re-content]:min-h-[220px] [&_.re-content]:px-[22px] [&_.re-content]:py-[20px] [&_.re-content]:outline-none",
                             content: html_contents(),
                             editable: true,
                             placeholder: "",
@@ -213,7 +214,7 @@ pub fn ContentCard() -> Element {
                     }
 
                     div { "data-testid": "attachment-list",
-                        for (idx , file) in files().iter().enumerate() {
+                        for (idx, file) in files().iter().enumerate() {
                             {
                                 let file_id = file.id.clone();
                                 let file_name = file.name.clone();

--- a/app/ratel/src/features/spaces/pages/actions/actions/quiz/views/main/creator/content_card/component.rs
+++ b/app/ratel/src/features/spaces/pages/actions/actions/quiz/views/main/creator/content_card/component.rs
@@ -1,3 +1,4 @@
+use crate::common::components::editor::Editor as RichEditor;
 use crate::common::components::{FileUploader, UploadedFileMeta};
 use crate::common::types::extract_filename_from_url;
 use crate::features::spaces::pages::actions::actions::quiz::*;
@@ -181,8 +182,7 @@ pub fn ContentCard() -> Element {
                         span { class: "section__hint", "{tr.section_content_hint}" }
                     }
                     div { class: "field",
-                        div {
-                            style: "display:flex;align-items:center;justify-content:space-between;gap:8px",
+                        div { style: "display:flex;align-items:center;justify-content:space-between;gap:8px",
                             label { class: "field__label", "{tr.title_label}" }
                             AutosaveStatusBadge { status: title_status() }
                         }
@@ -200,8 +200,8 @@ pub fn ContentCard() -> Element {
                         }
                     }
                     div { class: "editor",
-                        crate::common::components::TiptapEditor {
-                            class: "[&_[data-tiptap-toolbar]]:border-b [&_[data-tiptap-toolbar]]:border-[rgba(255,255,255,0.06)] [&_[contenteditable='true']]:min-h-[180px] [&_[contenteditable='true']]:px-[22px] [&_[contenteditable='true']]:py-[20px] [&_[contenteditable='true']]:outline-none",
+                        RichEditor {
+                            class: "[&_.re-toolbar]:border-b [&_.re-toolbar]:border-[rgba(255,255,255,0.06)] [&_.re-content]:min-h-[180px] [&_.re-content]:px-[22px] [&_.re-content]:py-[20px] [&_.re-content]:outline-none",
                             content: description(),
                             editable: true,
                             placeholder: "",
@@ -227,7 +227,7 @@ pub fn ContentCard() -> Element {
                     }
 
                     div { "data-testid": "attachment-list",
-                        for (idx , file) in files().iter().enumerate() {
+                        for (idx, file) in files().iter().enumerate() {
                             {
                                 let file_id = file.id.clone();
                                 let file_name = file.name.clone();
@@ -242,9 +242,7 @@ pub fn ContentCard() -> Element {
                                         }
                                         div { class: "file-row__info",
                                             div { class: "file-row__name", "{file_name}" }
-                                            div { class: "file-row__meta",
-                                                "{ext_label} \u{00B7} {file_size}"
-                                            }
+                                            div { class: "file-row__meta", "{ext_label} \u{00B7} {file_size}" }
                                         }
                                         button {
                                             class: "icon-btn",
@@ -258,9 +256,7 @@ pub fn ContentCard() -> Element {
                                                     match remove_quiz_file(
                                                             space_id(),
                                                             quiz_id(),
-                                                            RemoveQuizFileRequest {
-                                                                file_url,
-                                                            },
+                                                            RemoveQuizFileRequest { file_url },
                                                         )
                                                         .await
                                                     {

--- a/app/ratel/src/features/spaces/pages/overview/views/overview_content.rs
+++ b/app/ratel/src/features/spaces/pages/overview/views/overview_content.rs
@@ -1,7 +1,6 @@
 use super::*;
-use crate::common::components::{
-    Button, ButtonShape, ButtonSize, ButtonStyle, SpaceCard, TiptapEditor,
-};
+use crate::common::components::editor::Editor as RichEditor;
+use crate::common::components::{Button, ButtonShape, ButtonSize, ButtonStyle, SpaceCard};
 use crate::common::icons::{edit::Edit1, other_devices::Save};
 use crate::common::lucide_dioxus::Users;
 use crate::features::posts::controllers::like_post::like_post_handler;
@@ -215,8 +214,8 @@ pub fn OverviewContent(
                 }
 
                 SpaceCard { class: "border-none shadow-none !bg-transparent !p-0",
-                    TiptapEditor {
-                        class: "w-full h-fit [&>div]:border-0 [&>div]:bg-transparent [&_[contenteditable='true']]:px-0 [&_[contenteditable='true']]:py-0 [&_[contenteditable='true']]:text-[15px]/[24px] [&_[contenteditable='true']]:tracking-[0.5px] [&_[contenteditable='true']]:text-title-text",
+                    RichEditor {
+                        class: "w-full h-fit [&>div]:border-0 [&>div]:bg-transparent [&_.re-content]:px-0 [&_.re-content]:py-0 [&_.re-content]:text-[15px]/[24px] [&_.re-content]:tracking-[0.5px] [&_.re-content]:text-title-text",
                         content: content(),
                         editable: allow_edit,
                         placeholder: tr.placeholder,

--- a/app/ratel/src/features/spaces/pages/report/views/creator_page.rs
+++ b/app/ratel/src/features/spaces/pages/report/views/creator_page.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::common::{
-    components::{Button, ButtonStyle, TiptapEditor, Typo, Variant, Weight},
+    components::{editor::Editor as RichEditor, Button, ButtonStyle, Typo, Variant, Weight},
     icons::{edit::Edit1, other_devices::Save},
 };
 use dioxus::prelude::spawn;
@@ -57,7 +57,11 @@ pub fn CreatorPage(space_id: SpacePartition) -> Element {
                         let mut is_loading = is_loading.clone();
                         let mut error = error.clone();
                         spawn(async move {
-                            match crate::features::spaces::pages::report::controllers::create_ai_report(space_pk).await {
+                            match crate::features::spaces::pages::report::controllers::create_ai_report(
+                                    space_pk,
+                                )
+                                .await
+                            {
                                 Ok(resp) => {
                                     content.set(resp.html_contents);
                                 }
@@ -108,12 +112,12 @@ pub fn CreatorPage(space_id: SpacePartition) -> Element {
                                     let mut editable = editable.clone();
                                     spawn(async move {
                                         match crate::features::spaces::pages::report::controllers::update_analyze(
-                                            space_pk,
-                                            crate::features::spaces::pages::report::controllers::UpdateAnalyzeHtmlRequest {
-                                                html_contents: html,
-                                            },
-                                        )
-                                        .await
+                                                space_pk,
+                                                crate::features::spaces::pages::report::controllers::UpdateAnalyzeHtmlRequest {
+                                                    html_contents: html,
+                                                },
+                                            )
+                                            .await
                                         {
                                             Ok(_) => editable.set(false),
                                             Err(err) => error.set(Some(err.to_string())),
@@ -127,7 +131,7 @@ pub fn CreatorPage(space_id: SpacePartition) -> Element {
                     }
                 }
                 div { class: "flex flex-col w-full min-h-0 flex-1 overflow-hidden",
-                    TiptapEditor {
+                    RichEditor {
                         class: "w-full h-fit",
                         content: content(),
                         editable: editable(),

--- a/app/ratel/src/features/spaces/pages/report/views/viewer_page.rs
+++ b/app/ratel/src/features/spaces/pages/report/views/viewer_page.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::components::editor::Editor as RichEditor;
 
 #[component]
 pub fn ViewerPage(space_id: SpacePartition) -> Element {
@@ -35,7 +36,7 @@ pub fn ViewerPage(space_id: SpacePartition) -> Element {
                     div { class: "flex items-center gap-3" }
                 }
                 div { class: "flex flex-col w-full min-h-0 flex-1 overflow-hidden",
-                    TiptapEditor {
+                    RichEditor {
                         class: "w-full h-fit",
                         content: content(),
                         editable: editable(),

--- a/playwright/tests/web/team-space-full-lifecycle.spec.js
+++ b/playwright/tests/web/team-space-full-lifecycle.spec.js
@@ -283,13 +283,13 @@ test.describe.serial("Full space lifecycle with rewards", () => {
       "Discussion: Roadmap Planning"
     );
 
-    // Wait for the <tiptap-editor> web component to mount + initialize
-    // its internal editor so setContent() actually takes effect.
+    // Wait for the .ratel-editor root to mount and be bound by
+    // script.js (it marks `data-bound="true"` once wiring completes).
     await getEditor(page);
     await page.waitForFunction(
       () => {
-        const el = document.querySelector("tiptap-editor");
-        return !!el && typeof el.setContent === "function" && !!el._editor;
+        const root = document.querySelector(".ratel-editor");
+        return !!root && root.dataset.bound === "true";
       },
       null,
       { timeout: 15000 }
@@ -339,22 +339,21 @@ test.describe.serial("Full space lifecycle with rewards", () => {
       "RFCs. Use <code>@team-name</code> to ping a specific group.</p>",
     ].join("");
 
-    // The <tiptap-editor> web component exposes setContent() which runs
-    // `editor.commands.setContent` internally. We call it and then also
-    // dispatch the `change` CustomEvent the editor normally emits on
-    // user input so Dioxus's onchange handler picks up the HTML and
-    // triggers the standard 3s html_contents autosave.
+    // The ratel-editor doesn't expose a scripting API — we write the
+    // HTML directly into `.re-content` (the visible contenteditable
+    // surface) and then fire the hidden `.re-bridge` input so Dioxus's
+    // `on_content_change` handler picks up the payload and the standard
+    // 3s html_contents autosave kicks in.
     await page.evaluate((html) => {
-      const el = document.querySelector("tiptap-editor");
-      if (!el) throw new Error("tiptap-editor not found");
-      el.setContent(html);
-      el.dispatchEvent(
-        new CustomEvent("change", {
-          detail: html,
-          bubbles: true,
-          composed: true,
-        })
-      );
+      const root = document.querySelector(".ratel-editor");
+      if (!root) throw new Error("ratel-editor not found");
+      const content = root.querySelector(".re-content");
+      const bridge = root.querySelector(".re-bridge");
+      if (!content || !bridge) throw new Error("ratel-editor DOM incomplete");
+      content.innerHTML = html;
+      content.dataset.empty = "false";
+      bridge.value = html;
+      bridge.dispatchEvent(new Event("input", { bubbles: true }));
     }, richHtml);
 
     // Blur to commit any focused field, then wait for the html autosave


### PR DESCRIPTION
## Summary

- Replaced all six remaining `TiptapEditor` callers with the native `RichEditor` (`common/components/editor`), leaving only the migration-ready component in place. Consolidates rich-text editing on one JS implementation, drops the dependency on the legacy `<tiptap-editor>` web component, and preserves Korean-IME caret stability everywhere we edit content.
- Extended the native editor to support viewer mode: toolbar / statusbar / 4 modals render only when `editable=true`, `script.js` early-returns before touching toolbar DOM in viewer mode, and added a CSS override that strips min/max-height, border, and padding from read-only surfaces so embedded content (post detail, space overview viewers) flows as inline prose.
- Added a compatibility shim for Tiptap's legacy `<div data-youtube-video/>` wrapper so existing posts continue to render YouTube embeds at 16:9. Rewrote the Tailwind selector overrides used in quiz / discussion / overview content cards from the Tiptap-specific markers (`[data-tiptap-toolbar]`, `[contenteditable='true']`) to the native `.re-toolbar` / `.re-content` classes.

## Test plan

- [x] `cargo check --features web` passes
- [x] `cargo check --features server` passes
- [x] `dx check --web` passes
- [x] `dx fmt` applied to all modified Rust files
- [x] Playwright `team-space-full-lifecycle.spec.js` "Create discussion with reward" step updated to drive the new `.re-content` / `.re-bridge` pipeline instead of the removed `<tiptap-editor>.setContent()` / `_editor` handles
- [ ] Manual viewer-mode render check — post detail, space overview (non-creator role), space report viewer all show the body without toolbar / statusbar / modal chrome
- [ ] Manual legacy-content compatibility check — existing Tiptap-authored posts (headings, lists, blockquote, tables, inline styles, `<div data-youtube-video>` embeds) render correctly in the viewer
- [ ] Manual editor QA — bold / italic / heading dropdown / align / lists / link modal / image modal (drag+drop, file, URL) / YouTube modal / table modal / HR / clear formatting / Ctrl+B/I/U/K shortcuts
- [ ] Manual autosave regression — quiz and discussion `ContentCard` still flip to "Saved" after the 3s debounce
- [ ] Full Playwright regression on the editor-heavy specs: `arena-action-editor`, `space-scenario`, `space-with-lots-actions`, `space-admin-arena`, `team-space-full-lifecycle`, `team-space-with-signup-users`

## Notes

- `common::components::TiptapEditor` and the `app/interops/web-components/src/tiptap_editor.rs` wrapper are still in the tree — they are unused after this PR. A follow-up will delete the wrapper, the 374 KB `tiptap-editor.js` asset bundle, and the `js/src/tiptap-editor/` source so the npm build drops its Tiptap dependency.
- Mobile (`cargo check --features mobile`) currently fails on pre-existing issues in `login_modal` and `use_interval` that are unrelated to this change (reproduced on the base branch via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)