### PR TITLE
refactor(discussion): unify reply flow via thread focus mode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ This is the product index. Each checkbox maps to **exactly one spec file** in `r
 
 ## Planned
 
-_None yet._
+- [ ] [Badge system (non-transferable recognition badges)](roadmap/badge.md)
 
 ## Shipped
 

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/component.rs
@@ -7,7 +7,7 @@ use crate::common::components::CommentImageGrid;
 use crate::common::utils::mention::{apply_mention_markup, parse_mention_segments, ContentSegment};
 use crate::features::spaces::pages::actions::actions::discussion::controllers::list_replies;
 use crate::features::spaces::pages::actions::actions::discussion::{
-    DiscussionCommentResponse, DiscussionStatus, SpacePostCommentTargetEntityType,
+    DiscussionCommentResponse, DiscussionStatus,
 };
 use crate::features::spaces::pages::index::action_pages::discussion::*;
 use crate::features::spaces::pages::index::action_pages::quiz::ActiveActionOverlaySignal;
@@ -30,17 +30,6 @@ extern "C" {
 fn reset_composer_height() {
     #[cfg(not(feature = "server"))]
     reset_composer_height_js();
-}
-
-// Matches the 750px CSS breakpoint that switches the arena into the
-// bottom-sheet layout.
-#[cfg(not(feature = "server"))]
-fn is_arena_mobile_viewport() -> bool {
-    let width_px = web_sys::window()
-        .and_then(|w| w.inner_width().ok())
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-    width_px > 0.0 && width_px < 750.0
 }
 
 #[component]
@@ -81,233 +70,6 @@ pub fn SpaceDiscussionCommentPage(
     }
 }
 
-/// In-sheet thread view for a single parent comment + its replies.
-/// Reads parent/replies loaders from the controller so swapping into
-/// the thread is a background refresh, not a fresh mount that would
-/// suspend up to the overlay boundary.
-#[component]
-fn ReplyThreadView(
-    space_id: ReadSignal<SpacePartition>,
-    discussion_id: ReadSignal<SpacePostEntityType>,
-) -> Element {
-    let tr: DiscussionArenaTranslate = use_translate();
-    let role = use_space_role()();
-    let space = use_space()();
-
-    let arena = use_discussion_arena(space_id, discussion_id)?;
-    let UseDiscussionArena {
-        mut parent_loader,
-        mut replies_loader,
-        members,
-        mut mention_query_raw,
-        mut like_comment,
-        ..
-    } = arena;
-    let parent = parent_loader();
-
-    // Local mirror of the loader so optimistic mutations have a writable
-    // source. Re-synced when the loader's identity changes.
-    let mut replies: Signal<Vec<DiscussionCommentResponse>> =
-        use_signal(move || replies_loader().items);
-    use_effect(move || {
-        let fresh = replies_loader().items;
-        if replies.peek().len() != fresh.len() {
-            replies.set(fresh);
-        } else if !replies
-            .peek()
-            .iter()
-            .zip(fresh.iter())
-            .all(|(a, b)| a.sk == b.sk)
-        {
-            replies.set(fresh);
-        }
-    });
-
-    let is_space_open = space.status != Some(SpaceStatus::Finished);
-    let can_respond = matches!(role, SpaceUserRole::Creator | SpaceUserRole::Participant);
-    let can_comment = can_respond && is_space_open;
-
-    let mut reply_text = use_signal(String::new);
-    let mut reply_tracked_mentions: Signal<Vec<(String, String)>> = use_signal(Vec::new);
-    let mut reply_pending_images: Signal<Vec<PendingImage>> = use_signal(Vec::new);
-
-    let on_mention_query_change = move |q: Option<String>| {
-        mention_query_raw.set(q);
-    };
-    let on_composer_focus = move || {
-        if mention_query_raw.peek().is_none() {
-            mention_query_raw.set(Some(String::new()));
-        }
-    };
-
-    let parent_sk_for_like = parent.sk.clone();
-    let on_parent_like = move |_| {
-        let sk_str = parent_sk_for_like.to_string();
-        let next = !arena.effective_liked(&parent_loader());
-        like_comment.call(sk_str, next);
-    };
-
-    // Read `parent_loader` inside so the memo rebuilds when the cached
-    // loader resolves with the real parent.
-    let reply_priority = use_memo(move || {
-        let p = parent_loader();
-        let parent_author_pk = p.author_pk.to_string();
-        let parent_content = p.content.clone();
-        let replies_vec = replies.read();
-        let tuples: Vec<(String, String)> = replies_vec
-            .iter()
-            .rev()
-            .map(|r| (r.author_pk.to_string(), r.content.clone()))
-            .collect();
-        let refs: Vec<(&str, &str)> = tuples
-            .iter()
-            .map(|(a, c)| (a.as_str(), c.as_str()))
-            .collect();
-        crate::common::utils::mention::build_mention_priority(
-            Some((parent_author_pk.as_str(), parent_content.as_str())),
-            &refs,
-        )
-    });
-    let reply_priority: ReadSignal<Vec<String>> = reply_priority.into();
-
-    // Same enrichment as `CommentItem` — prepend thread participants so the
-    // parent author + reply authors appear first in the mention dropdown
-    // regardless of the server's space-wide member pagination.
-    let reply_thread_members = use_memo(move || {
-        let p = parent_loader();
-        let mut seen = std::collections::HashSet::new();
-        let mut out: Vec<MentionCandidate> = Vec::new();
-        let parent_pk = p.author_pk.to_string();
-        seen.insert(parent_pk.clone());
-        out.push(MentionCandidate {
-            user_pk: parent_pk,
-            display_name: p.author_display_name.clone(),
-            username: p.author_username.clone(),
-            profile_url: p.author_profile_url.clone(),
-        });
-        for r in replies.read().iter().rev() {
-            let pk = r.author_pk.to_string();
-            if seen.insert(pk.clone()) {
-                out.push(MentionCandidate {
-                    user_pk: pk,
-                    display_name: r.author_display_name.clone(),
-                    username: r.author_username.clone(),
-                    profile_url: r.author_profile_url.clone(),
-                });
-            }
-        }
-        for m in members() {
-            if seen.insert(m.user_pk.clone()) {
-                out.push(m);
-            }
-        }
-        out
-    });
-    let reply_thread_members: ReadSignal<Vec<MentionCandidate>> = reply_thread_members.into();
-
-    // Render replies oldest-first so the newest reply lands at the bottom
-    // (chat-style). Server returns likes DESC, so we re-sort client-side.
-    let sorted_replies = use_memo(move || {
-        let mut v = replies();
-        v.sort_by_key(|r| r.created_at);
-        v
-    });
-
-    let parent_sk_for_submit = parent.sk.to_string();
-    let mut reply_comment_action = arena.reply_comment;
-    let on_submit_reply = move |_| {
-        let raw_text = reply_text().trim().to_string();
-        let images: Vec<String> = reply_pending_images
-            .read()
-            .iter()
-            .filter_map(|img| img.remote_url.clone())
-            .collect();
-        if raw_text.is_empty() && images.is_empty() {
-            return;
-        }
-        let content = apply_mention_markup(&raw_text, &reply_tracked_mentions.read());
-        reply_comment_action.call(parent_sk_for_submit.clone(), content, images);
-        reply_text.set(String::new());
-        reply_tracked_mentions.set(Vec::new());
-        reply_pending_images.set(Vec::new());
-    };
-
-    let parent_time_ago = format_time_ago(parent.created_at);
-
-    rsx! {
-        div { class: "reply-thread", "data-testid": "reply-thread",
-            div { class: "reply-thread__scroll",
-                div { class: "reply-thread__parent",
-                    div { class: "comment-item",
-                        img {
-                            class: "comment-item__avatar",
-                            src: "{parent.author_profile_url}",
-                            alt: "{parent.author_display_name}",
-                        }
-                        div { class: "comment-item__body",
-                            div { class: "comment-item__top",
-                                span { class: "comment-item__name", "{parent.author_display_name}" }
-                                span { class: "comment-item__time", "{parent_time_ago}" }
-                            }
-                            CommentText { content: parent.content.clone() }
-                            CommentImageGrid { images: parent.images.clone() }
-                            div { class: "comment-item__actions",
-                                button {
-                                    class: "comment-action",
-                                    "aria-pressed": arena.effective_liked(&parent),
-                                    disabled: like_comment.pending(),
-                                    onclick: on_parent_like,
-                                    svg {
-                                        view_box: "0 0 24 24",
-                                        fill: if arena.effective_liked(&parent) { "currentColor" } else { "none" },
-                                        stroke: "currentColor",
-                                        stroke_width: "2",
-                                        stroke_linecap: "round",
-                                        stroke_linejoin: "round",
-                                        path { d: "M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" }
-                                    }
-                                    span { "{arena.effective_likes(&parent)}" }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                div { class: "reply-thread__list",
-                    for reply in sorted_replies().iter().filter(|r| !arena.is_deleted(r)) {
-                        ReplyItem {
-                            key: "{reply.sk}",
-                            reply: reply.clone(),
-                            space_id,
-                            discussion_id,
-                            can_comment,
-                        }
-                    }
-                }
-            }
-
-            if can_comment {
-                div { class: "reply-thread__composer",
-                    CommentComposer {
-                        text: reply_text,
-                        tracked_mentions: reply_tracked_mentions,
-                        pending_images: reply_pending_images,
-                        members: reply_thread_members,
-                        on_submit: on_submit_reply,
-                        placeholder: tr.reply_placeholder.to_string(),
-                        compact: true,
-                        disabled: reply_text().trim().is_empty()
-                                                                                                                                                                                                                                                                                                                                                    && reply_pending_images.read().is_empty(),
-                        on_mention_query_change,
-                        on_composer_focus,
-                        priority_user_pks: reply_priority,
-                    }
-                }
-            }
-        }
-    }
-}
-
 #[component]
 pub fn DiscussionArenaPage(
     space_id: ReadSignal<SpacePartition>,
@@ -333,9 +95,10 @@ pub fn DiscussionArenaPage(
     let post = disc.post.clone();
     let space_action = disc.space_action.clone();
 
-    let status = crate::features::spaces::pages::actions::actions::discussion::SpacePost::status_from(
-        space_action.status.as_ref(),
-    );
+    let status =
+        crate::features::spaces::pages::actions::actions::discussion::SpacePost::status_from(
+            space_action.status.as_ref(),
+        );
     let is_in_progress = status == DiscussionStatus::InProgress;
     let can_respond = matches!(role, SpaceUserRole::Creator | SpaceUserRole::Participant);
     let can_execute = crate::features::spaces::pages::actions::can_execute_space_action(
@@ -356,10 +119,25 @@ pub fn DiscussionArenaPage(
     //  - `polled_new` gains a new entry
     //  - `sort_tick` ticks (every 5s, drives time-decay reorder)
     let comments: Memo<Vec<DiscussionCommentResponse>> = use_memo(move || {
-        // Touch sort_tick so the memo re-evaluates each tick.
         let _ = sort_tick();
         let now = crate::common::utils::time::get_now_timestamp();
         merge_and_rank_comments(comments_query.items(), polled_new(), now)
+    });
+
+    // Quote preview is derived from the currently loaded comments — avoids
+    // needing a separate loader roundtrip and gives instant content for the
+    // "Replying to X" banner. If the parent isn't in the loaded pages (e.g.
+    // very old comment scrolled past), the banner falls back to None and the
+    // composer just loses its quote chrome — reply still works.
+    let reply_quote: Memo<Option<(String, String)>> = use_memo(move || {
+        let thread_id = active_reply_thread()?;
+        let all = comments();
+        all.iter().find_map(|c| {
+            SpacePostCommentEntityType::try_from(c.sk.clone())
+                .ok()
+                .filter(|e| e.0 == thread_id)
+                .map(|_| (c.author_display_name.clone(), c.content.clone()))
+        })
     });
 
     // `overlay_ctx` is only present when mounted as the arena overlay;
@@ -444,7 +222,11 @@ pub fn DiscussionArenaPage(
     };
 
     let mut add_comment_action = arena.add_comment;
-    let mut on_submit_comment = move |_| {
+    let mut reply_comment_action = arena.reply_comment;
+    // Single submit handler: branches on `active_reply_thread`. In thread mode,
+    // rebuild the full prefixed sk from the stored bare id so the reply action
+    // gets the same format the SubPartition parser accepts.
+    let mut on_submit = move |_| {
         let raw_text = comment_text().trim().to_string();
         let images: Vec<String> = pending_images
             .read()
@@ -455,12 +237,28 @@ pub fn DiscussionArenaPage(
             return;
         }
         let content = apply_mention_markup(&raw_text, &tracked_mentions.read());
-        add_comment_action.call(content, images);
-        space_ctx.actions.restart();
+
+        match active_reply_thread() {
+            Some(parent_id) => {
+                let parent_sk = EntityType::SpacePostComment(parent_id).to_string();
+                reply_comment_action.call(parent_sk, content, images);
+            }
+            None => {
+                add_comment_action.call(content, images);
+                space_ctx.actions.restart();
+            }
+        }
+
         comment_text.set(String::new());
         tracked_mentions.set(Vec::new());
         pending_images.set(Vec::new());
     };
+
+    let on_cancel_reply = move |_| {
+        active_reply_thread.set(None);
+    };
+
+    let in_thread = active_reply_thread().is_some();
 
     rsx! {
         document::Link { rel: "stylesheet", href: asset!("./style.css") }
@@ -605,87 +403,66 @@ pub fn DiscussionArenaPage(
                         onclick: move |_| sheet_expanded.toggle(),
                         div { class: "sheet-handle__bar" }
                         div { class: "sheet-handle__row",
-                            if active_reply_thread().is_some() {
-                                button {
-                                    class: "sheet-handle__back",
-                                    "data-testid": "reply-thread-back",
-                                    aria_label: "{tr.replies_back_aria}",
-                                    onclick: move |e| {
-                                        e.stop_propagation();
-                                        active_reply_thread.set(None);
-                                    },
-                                    svg {
-                                        view_box: "0 0 24 24",
-                                        fill: "none",
-                                        stroke: "currentColor",
-                                        stroke_width: "2",
-                                        stroke_linecap: "round",
-                                        stroke_linejoin: "round",
-                                        polyline { points: "15 18 9 12 15 6" }
-                                    }
-                                }
-                            } else {
-                                div { class: "sheet-handle__left",
-                                    span { class: "sheet-handle__title", "{tr.comments_title}" }
-                                    span { class: "sheet-handle__count", "{post.comments}" }
-                                }
-                                svg {
-                                    class: "sheet-handle__chevron",
-                                    view_box: "0 0 24 24",
-                                    fill: "none",
-                                    stroke: "currentColor",
-                                    stroke_width: "2",
-                                    stroke_linecap: "round",
-                                    stroke_linejoin: "round",
-                                    polyline { points: "6 9 12 15 18 9" }
-                                }
+                            div { class: "sheet-handle__left",
+                                span { class: "sheet-handle__title", "{tr.comments_title}" }
+                                span { class: "sheet-handle__count", "{post.comments}" }
+                            }
+                            svg {
+                                class: "sheet-handle__chevron",
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "2",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                polyline { points: "6 9 12 15 18 9" }
                             }
                         }
                     }
 
-                    if let Some(thread_id) = active_reply_thread() {
-                        ReplyThreadView {
-                            key: "{thread_id}",
-                            space_id,
-                            discussion_id,
+                    div { class: "comments-panel__body",
+                        div { class: "comments-panel__header",
+                            span { class: "comments-panel__title", "{tr.comments_title}" }
+                            span { class: "comments-panel__count", "{post.comments}" }
                         }
-                    } else {
-                        div { class: "comments-panel__body",
-                            div { class: "comments-panel__header",
-                                span { class: "comments-panel__title", "{tr.comments_title}" }
-                                span { class: "comments-panel__count", "{post.comments}" }
-                            }
 
-                            div { class: "comments-scroll",
-                                div { class: "comment-list",
-                                    for comment in comments().iter().filter(|c| !arena.is_deleted(c)) {
-                                        CommentItem {
-                                            key: "{comment.sk}",
-                                            comment: comment.clone(),
-                                            space_id,
-                                            discussion_id,
-                                            can_comment,
-                                            deep_link_target,
-                                        }
+                        // `data-thread-active` drives the CSS filter that hides
+                        // non-active comment entries while a thread is open.
+                        // Comments keep their DOM — no remount — so loaders,
+                        // scroll position and per-item state survive.
+                        div {
+                            class: "comments-scroll",
+                            "data-thread-active": in_thread,
+                            div { class: "comment-list",
+                                for comment in comments().iter().filter(|c| !arena.is_deleted(c)) {
+                                    CommentItem {
+                                        key: "{comment.sk}",
+                                        comment: comment.clone(),
+                                        space_id,
+                                        discussion_id,
+                                        can_comment,
+                                        deep_link_target,
                                     }
-                                    {comments_query.more_element()}
                                 }
+                                {comments_query.more_element()}
                             }
+                        }
 
-                            if can_comment {
-                                CommentComposer {
-                                    text: comment_text,
-                                    tracked_mentions,
-                                    pending_images,
-                                    members,
-                                    on_submit: move |_| on_submit_comment(()),
-                                    placeholder: tr.comment_placeholder.to_string(),
-                                    disabled: comment_text().trim().is_empty()
-                                        && pending_images.read().is_empty(),
-                                    on_mention_query_change,
-                                    on_composer_focus,
-                                    priority_user_pks: top_priority,
-                                }
+                        if can_comment {
+                            CommentComposer {
+                                text: comment_text,
+                                tracked_mentions,
+                                pending_images,
+                                members,
+                                on_submit: move |_| on_submit(()),
+                                placeholder: if in_thread { tr.reply_placeholder.to_string() } else { tr.comment_placeholder.to_string() },
+                                disabled: comment_text().trim().is_empty()
+                                                                    && pending_images.read().is_empty(),
+                                on_mention_query_change,
+                                on_composer_focus,
+                                priority_user_pks: top_priority,
+                                reply_quote: reply_quote(),
+                                on_cancel_reply,
                             }
                         }
                     }
@@ -695,8 +472,10 @@ pub fn DiscussionArenaPage(
     }
 }
 
-/// Shared composer for the top-level box and per-comment reply box.
-/// `compact` toggles the nested-context chrome via `data-compact`.
+/// Shared composer pinned to the bottom of the comments panel. Doubles as
+/// the reply composer via the optional `reply_quote` — when present, the
+/// caller has set `active_reply_thread`, and the `on_submit` closure that
+/// owns the action branches to `reply_comment` instead of `add_comment`.
 #[component]
 fn CommentComposer(
     text: Signal<String>,
@@ -705,11 +484,14 @@ fn CommentComposer(
     members: ReadSignal<Vec<MentionCandidate>>,
     on_submit: EventHandler<()>,
     placeholder: String,
-    #[props(default)] compact: bool,
     disabled: bool,
     #[props(default)] on_mention_query_change: EventHandler<Option<String>>,
     #[props(default)] on_composer_focus: EventHandler<()>,
     #[props(default)] priority_user_pks: ReadSignal<Vec<String>>,
+    /// `(author_display_name, preview_text)` when in reply mode. Drives the
+    /// "Replying to X" banner above the textarea.
+    #[props(default)] reply_quote: Option<(String, String)>,
+    #[props(default)] on_cancel_reply: EventHandler<()>,
 ) -> Element {
     let tr: DiscussionArenaTranslate = use_translate();
 
@@ -752,23 +534,42 @@ fn CommentComposer(
         }
     };
 
-    // Keep `.comment-input__*` hook classes on the top-level variant so
-    // existing Playwright selectors keep resolving.
-    let textarea_class = if compact {
-        "reply-input__field"
-    } else {
-        "reply-input__field comment-input__textarea"
-    };
-    let send_class = if compact {
-        "reply-input__send"
-    } else {
-        "reply-input__send comment-input__submit"
-    };
     rsx! {
-        div {
-            class: "comment-input",
-            "data-compact": compact,
-            onpaste: on_paste,
+        div { class: "comment-input", onpaste: on_paste,
+            if let Some((quote_author, quote_text)) = reply_quote.as_ref() {
+                div { class: "comment-input__quote",
+                    div { class: "comment-input__quote-body",
+                        div { class: "comment-input__quote-label", "{tr.replying_to} {quote_author}" }
+                        div { class: "comment-input__quote-text", "{quote_text}" }
+                    }
+                    button {
+                        class: "comment-input__quote-close",
+                        "data-testid": "comment-input-quote-close",
+                        aria_label: "{tr.cancel_reply_aria}",
+                        onclick: move |_| on_cancel_reply.call(()),
+                        svg {
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            line {
+                                x1: "18",
+                                y1: "6",
+                                x2: "6",
+                                y2: "18",
+                            }
+                            line {
+                                x1: "6",
+                                y1: "6",
+                                x2: "18",
+                                y2: "18",
+                            }
+                        }
+                    }
+                }
+            }
             ImageUploadPreview { images: pending_images }
             div { class: "reply-input",
                 MentionAutocomplete {
@@ -778,7 +579,7 @@ fn CommentComposer(
                     on_query_change: move |q| on_mention_query_change.call(q),
                     priority_user_pks,
                     textarea {
-                        class: "{textarea_class}",
+                        class: "reply-input__field comment-input__textarea",
                         placeholder: "{placeholder}",
                         rows: "1",
                         value: "{text}",
@@ -787,15 +588,10 @@ fn CommentComposer(
                         },
                         onkeydown: on_keydown,
                         onfocus: move |_| on_composer_focus.call(()),
-                        onmounted: move |e: MountedEvent| async move {
-                            if compact {
-                                let _ = e.set_focus(true).await;
-                            }
-                        },
                     }
                 }
                 button {
-                    class: "{send_class}",
+                    class: "reply-input__send comment-input__submit",
                     disabled,
                     onclick: move |_| on_submit.call(()),
                     svg {
@@ -820,15 +616,14 @@ fn CommentComposer(
 }
 
 /// Renders comment content with mention highlighting and a "Show more"
-/// toggle when the rendered text exceeds 10 visual lines. Used by the
-/// parent in `ReplyThreadView`, top-level `CommentItem`, and `ReplyItem`
-/// so the truncation behavior stays consistent everywhere.
+/// toggle when the rendered text exceeds 10 visual lines. Used by top-level
+/// `CommentItem` and `ReplyItem` so the truncation behavior stays consistent.
 ///
 /// Truncation is purely visual (CSS `-webkit-line-clamp: 10` when
-/// `data-expanded="false"`); JS measures `scrollHeight > clientHeight`
-/// and sets `data-truncatable="true"` to reveal the toggle button. This
-/// matches what the user actually sees regardless of viewport width or
-/// language, instead of a brittle character count.
+/// `data-expanded="false"`); JS measures `scrollHeight > clientHeight` and
+/// sets `data-truncatable="true"` to reveal the toggle button. This matches
+/// what the user actually sees regardless of viewport width or language,
+/// instead of a brittle character count.
 #[component]
 fn CommentText(content: String) -> Element {
     let tr: DiscussionArenaTranslate = use_translate();
@@ -1056,85 +851,18 @@ fn CommentItem(
     let tr: DiscussionArenaTranslate = use_translate();
 
     let arena = use_discussion_arena(space_id, discussion_id)?;
-    let UseDiscussionArena {
-        members,
-        mut mention_query_raw,
-        mut active_reply_thread,
-        mut sheet_expanded,
-        ..
-    } = arena;
-    let on_mention_query_change = move |q: Option<String>| {
-        mention_query_raw.set(q);
-    };
-    let on_composer_focus = move || {
-        if mention_query_raw.peek().is_none() {
-            mention_query_raw.set(Some(String::new()));
-        }
-    };
+    let mut active_reply_thread = arena.active_reply_thread;
+    let mut sheet_expanded = arena.sheet_expanded;
+    let reply_refresh_tick = arena.reply_refresh_tick;
 
+    // `show_replies` keeps inline reply expansion independent of thread-focus
+    // mode. Entering thread mode force-expands so the active thread's replies
+    // are visible even before the user toggles.
     let mut show_replies = use_signal(|| false);
-    let mut reply_text = use_signal(String::new);
-    let mut reply_pending_images: Signal<Vec<PendingImage>> = use_signal(Vec::new);
-    let mut reply_tracked_mentions: Signal<Vec<(String, String)>> = use_signal(Vec::new);
     let mut replies: Signal<Vec<DiscussionCommentResponse>> = use_signal(Vec::new);
 
     let comment_sk = use_signal(|| comment.sk.clone());
     let reply_count = comment.replies;
-
-    let parent_author_pk = comment.author_pk.to_string();
-    let parent_content = comment.content.clone();
-    let reply_priority = use_memo(move || {
-        let replies_vec = replies.read();
-        let tuples: Vec<(String, String)> = replies_vec
-            .iter()
-            .rev()
-            .map(|r| (r.author_pk.to_string(), r.content.clone()))
-            .collect();
-        let refs: Vec<(&str, &str)> = tuples
-            .iter()
-            .map(|(a, c)| (a.as_str(), c.as_str()))
-            .collect();
-        crate::common::utils::mention::build_mention_priority(
-            Some((parent_author_pk.as_str(), parent_content.as_str())),
-            &refs,
-        )
-    });
-    let reply_priority: ReadSignal<Vec<String>> = reply_priority.into();
-
-    // Reply composer's candidate list prepends the thread's own participants
-    // (parent author + existing reply authors) so they surface even when the
-    // space has more members than `list_space_members` returns on its first
-    // 50-member page.
-    let parent_cand = MentionCandidate {
-        user_pk: comment.author_pk.to_string(),
-        display_name: comment.author_display_name.clone(),
-        username: comment.author_username.clone(),
-        profile_url: comment.author_profile_url.clone(),
-    };
-    let reply_thread_members = use_memo(move || {
-        let mut seen = std::collections::HashSet::new();
-        let mut out: Vec<MentionCandidate> = Vec::new();
-        seen.insert(parent_cand.user_pk.clone());
-        out.push(parent_cand.clone());
-        for r in replies.read().iter().rev() {
-            let pk = r.author_pk.to_string();
-            if seen.insert(pk.clone()) {
-                out.push(MentionCandidate {
-                    user_pk: pk,
-                    display_name: r.author_display_name.clone(),
-                    username: r.author_username.clone(),
-                    profile_url: r.author_profile_url.clone(),
-                });
-            }
-        }
-        for m in members() {
-            if seen.insert(m.user_pk.clone()) {
-                out.push(m);
-            }
-        }
-        out
-    });
-    let reply_thread_members: ReadSignal<Vec<MentionCandidate>> = reply_thread_members.into();
 
     // Render replies oldest-first so the newest reply lands at the bottom
     // (chat-style). Server returns likes DESC, so we re-sort client-side.
@@ -1149,20 +877,44 @@ fn CommentItem(
         .map(|e| e.0)
         .unwrap_or_else(|_| comment.sk.to_string());
     let is_deep_link = deep_link_target().as_deref() == Some(comment_dom_id.as_str());
+    let is_thread_active = active_reply_thread().as_deref() == Some(comment_dom_id.as_str());
+
+    let dom_id_for_reply = comment_dom_id.clone();
+    let on_reply_click = move |_| {
+        // Toggle: a second click on the Reply button of the already-active
+        // thread exits thread-focus mode — same behavior as the quote-preview
+        // X button in the composer. Clone into the outer closure body so the
+        // inner async future moves only its own `String` (keeps FnMut).
+        let already_active =
+            active_reply_thread().as_deref() == Some(dom_id_for_reply.as_str());
+        let id = dom_id_for_reply.clone();
+        async move {
+            if already_active {
+                active_reply_thread.set(None);
+                return;
+            }
+            // Enter thread-focus mode for this comment. Force-expand so the
+            // user lands on the existing thread if there are any.
+            active_reply_thread.set(Some(id));
+            sheet_expanded.set(true);
+            show_replies.set(true);
+            if replies().is_empty() && reply_count > 0 {
+                let comment_sk_entity: SpacePostCommentEntityType =
+                    comment_sk().try_into().unwrap_or_default();
+                match list_replies(space_id(), discussion_id(), comment_sk_entity, None).await
+                {
+                    Ok(data) => {
+                        replies.set(data.items);
+                    }
+                    Err(err) => {
+                        tracing::error!("Failed to load replies: {:?}", err);
+                    }
+                }
+            }
+        }
+    };
 
     let on_toggle_replies = move |_| async move {
-        // Mobile swaps the panel into the in-sheet thread view instead
-        // of expanding inline. Force-expand so the swap is visible if
-        // the user tapped Reply on a collapsed sheet.
-        #[cfg(not(feature = "server"))]
-        if is_arena_mobile_viewport() {
-            let comment_id = SpacePostCommentEntityType::try_from(comment_sk())
-                .map(|e| e.0)
-                .unwrap_or_default();
-            active_reply_thread.set(Some(comment_id));
-            sheet_expanded.set(true);
-            return;
-        }
         let next = !show_replies();
         show_replies.set(next);
         if next && replies().is_empty() && reply_count > 0 {
@@ -1179,35 +931,35 @@ fn CommentItem(
         }
     };
 
-    let mut reply_comment_action = arena.reply_comment;
-    let on_submit_reply = move |_| async move {
-        let raw_text = reply_text().trim().to_string();
-        let images: Vec<String> = reply_pending_images
-            .read()
-            .iter()
-            .filter_map(|img| img.remote_url.clone())
-            .collect();
-        if raw_text.is_empty() && images.is_empty() {
+    // When a reply is posted via the global composer (in thread mode), the
+    // arena bumps `reply_refresh_tick`. The thread-active CommentItem refetches
+    // its local reply list so the new reply appears without a full page reload.
+    let dom_id_for_refresh = comment_dom_id.clone();
+    use_effect(move || {
+        let tick = reply_refresh_tick();
+        if tick == 0 {
             return;
         }
-        let content = apply_mention_markup(&raw_text, &reply_tracked_mentions.read());
-        reply_comment_action
-            .call(comment_sk().to_string(), content, images)
-            .await;
-        reply_text.set(String::new());
-        reply_tracked_mentions.set(Vec::new());
-        reply_pending_images.set(Vec::new());
-        // Inline replies are a local fetch — pull the fresh page so the
-        // new reply shows up without waiting for a full loader restart.
-        let comment_sk_entity: SpacePostCommentEntityType =
-            comment_sk().try_into().unwrap_or_default();
-        if let Ok(data) = list_replies(space_id(), discussion_id(), comment_sk_entity, None).await {
-            replies.set(data.items);
+        let thread_active = active_reply_thread()
+            .as_deref()
+            .map(|s| s == dom_id_for_refresh.as_str())
+            .unwrap_or(false);
+        if !thread_active {
+            return;
         }
-    };
+        spawn(async move {
+            let comment_sk_entity: SpacePostCommentEntityType =
+                comment_sk().try_into().unwrap_or_default();
+            if let Ok(data) =
+                list_replies(space_id(), discussion_id(), comment_sk_entity, None).await
+            {
+                replies.set(data.items);
+            }
+        });
+    });
 
     rsx! {
-        div { class: "comment-entry",
+        div { class: "comment-entry", "data-thread-active": is_thread_active,
             CommentCardBody {
                 comment: comment.clone(),
                 space_id,
@@ -1219,7 +971,7 @@ fn CommentItem(
                     button {
                         class: "comment-action comment-action--reply",
                         "data-testid": "comment-action-reply",
-                        onclick: on_toggle_replies,
+                        onclick: on_reply_click,
                         svg {
                             view_box: "0 0 24 24",
                             fill: "none",
@@ -1268,23 +1020,6 @@ fn CommentItem(
                         }
                     }
                 }
-
-                if can_comment {
-                    CommentComposer {
-                        text: reply_text,
-                        tracked_mentions: reply_tracked_mentions,
-                        pending_images: reply_pending_images,
-                        members: reply_thread_members,
-                        on_submit: move |_| on_submit_reply(()),
-                        placeholder: tr.reply_placeholder.to_string(),
-                        compact: true,
-                        disabled: reply_text().trim().is_empty()
-                            && reply_pending_images.read().is_empty(),
-                        on_mention_query_change,
-                        on_composer_focus,
-                        priority_user_pks: reply_priority,
-                    }
-                }
             }
         }
     }
@@ -1314,7 +1049,7 @@ fn format_time_ago(timestamp: i64) -> String {
 }
 
 /// Reply variant — a thin wrapper around `CommentCardBody` with no extra
-/// chrome (no reply-toggle, no nested composer).
+/// chrome (no reply-toggle, no reply button — replies can't be replied to).
 #[component]
 fn ReplyItem(
     reply: DiscussionCommentResponse,

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
@@ -114,6 +114,12 @@ pub struct UseDiscussionArena {
     pub delete_comment: Action<(String,), ()>,
     pub add_comment: Action<(String, Vec<String>), ()>,
     pub reply_comment: Action<(String, String, Vec<String>), ()>,
+
+    /// Bumped whenever a reply successfully posts. CommentItem watches this
+    /// to reload its local `replies` signal — the global composer submits
+    /// outside the CommentItem's scope, so we need a cross-component signal
+    /// to tell the thread-active item that its reply list is stale.
+    pub reply_refresh_tick: Signal<u32>,
 }
 
 impl UseDiscussionArena {
@@ -329,6 +335,7 @@ pub fn use_discussion_arena(
         use_signal(std::collections::HashMap::new);
     let mut deleted_sks: Signal<std::collections::HashSet<String>> =
         use_signal(std::collections::HashSet::new);
+    let mut reply_refresh_tick: Signal<u32> = use_signal(|| 0);
 
     let mut toast = use_toast();
     let like_comment = use_action(move |sk_str: String, next: bool| async move {
@@ -471,6 +478,7 @@ pub fn use_discussion_arena(
                     comments_query.refresh();
                     replies_loader.restart();
                     parent_loader.restart();
+                    reply_refresh_tick.with_mut(|t| *t = t.wrapping_add(1));
                 }
                 Err(e) => {
                     tracing::error!("reply comment: {:?}", e);
@@ -504,6 +512,7 @@ pub fn use_discussion_arena(
         delete_comment,
         add_comment: add_comment_action,
         reply_comment: reply_comment_action,
+        reply_refresh_tick,
     }))
 }
 

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/i18n.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/i18n.rs
@@ -107,8 +107,12 @@ translate! {
         en: "Replies",
         ko: "답글",
     },
-    replies_back_aria: {
-        en: "Back",
-        ko: "뒤로",
+    replying_to: {
+        en: "Replying to",
+        ko: "답글 대상:",
+    },
+    cancel_reply_aria: {
+        en: "Cancel reply",
+        ko: "답글 취소",
     },
 }

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/style.css
@@ -519,26 +519,84 @@ body.comments-panel-resizing {
 }
 
 /* ── Comment Input ─────────────────────────────── */
-/* The top-level composer (pinned to the bottom of the comments panel)
-   always gets the padded + divider chrome. The compact reply composer
-   only inherits the same chrome on mobile — on desktop it stays bare so
-   the `.reply-input` pill appears inline under the comment without an
-   extra panel frame (matching the pre-unification look). */
-.comment-input:not([data-compact="true"]) {
-  padding: 16px 20px;
+/* Single composer pinned to the bottom of the comments panel. Handles
+   both top-level comments and replies (via optional quote preview) — the
+   thread-focus mode in `.comments-scroll` provides the visual context
+   for which entity the next submit will attach to. */
+.comment-input {
+  padding: 14px 20px 16px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
   border-top: 1px solid var(--border);
+  background: var(--panel-bg);
 }
-/* Kill the reply-box offsets when the top-level wrapper provides its
-   own positioning — those margins only make sense for the bare inline
-   reply pill nested under a parent comment on desktop. */
-.comment-input:not([data-compact="true"]) > .reply-input {
+.comment-input > .reply-input {
   margin-left: 0;
   margin-right: 0;
   margin-top: 0;
+}
+
+/* ── Reply quote preview ──────────────────────────
+   Rendered above the textarea when `reply_quote` is set. Cancel button
+   clears `active_reply_thread`, which both hides this banner and exits
+   thread-focus mode on the comment list. */
+.comment-input__quote {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 8px 8px 12px;
+  border-left: 3px solid var(--discuss-color);
+  background: var(--discuss-bg);
+  border-radius: 0 8px 8px 0;
+}
+.comment-input__quote-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.comment-input__quote-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--discuss-color);
+}
+.comment-input__quote-text {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-style: italic;
+}
+.comment-input__quote-close {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  flex-shrink: 0;
+  padding: 0;
+}
+.comment-input__quote-close:hover {
+  background: var(--surface-raised);
+  color: var(--text-muted);
+}
+.comment-input__quote-close svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* ── Comments Scroll Area ──────────────────────── */
@@ -572,6 +630,55 @@ body.comments-panel-resizing {
    keeps the existing flex/gap layout untouched (wrapper is visually transparent). */
 .comment-entry {
   display: contents;
+}
+
+/* ── Thread focus mode ─────────────────────────────
+   Set on `.comments-scroll` when a user clicks Reply on a comment. Filters
+   the list so only the active thread (parent + its replies) is visible
+   while keeping the DOM intact — loaders, scroll position, and per-item
+   state all survive. Exit happens via the composer's quote-close button
+   (clears `active_reply_thread`). */
+.comments-scroll[data-thread-active="true"]
+  .comment-list
+  > .comment-entry:not([data-thread-active="true"]) {
+  display: none !important;
+}
+.comments-scroll[data-thread-active="true"] .load-more {
+  display: none;
+}
+.comments-scroll[data-thread-active="true"]
+  .comment-entry[data-thread-active="true"]
+  > .comment-item {
+  position: relative;
+  background: var(--discuss-bg);
+  border-bottom: 1px solid var(--discuss-border);
+  padding-top: 24px;
+}
+.comments-scroll[data-thread-active="true"]
+  .comment-entry[data-thread-active="true"]
+  > .comment-item::before {
+  content: "Thread";
+  position: absolute;
+  top: 8px;
+  left: 20px;
+  font-family: "Orbitron", sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--discuss-color);
+}
+.comments-scroll[data-thread-active="true"]
+  .comment-entry[data-thread-active="true"]
+  > .reply-toggle {
+  display: none !important;
+}
+.comments-scroll[data-thread-active="true"]
+  .comment-entry[data-thread-active="true"]
+  > .comment-replies {
+  margin-left: 0;
+  padding-left: 0;
+  border-left: none;
 }
 
 /* ── Comment Item ──────────────────────────────── */
@@ -1161,23 +1268,6 @@ body.comments-panel-resizing {
   .comment-input > .reply-input {
     margin-left: 0;
   }
-  /* Mobile only: the compact reply composer (inside the bottom-sheet
-     thread view) gets the same padded + divider chrome as the top-level
-     composer so the sheet reads as a stack of matching sections.
-     Desktop keeps the bare inline pill — see the base rules above. */
-  .comment-input[data-compact="true"] {
-    padding: 16px 20px;
-    flex-shrink: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    border-top: 1px solid var(--border);
-  }
-  .comment-input[data-compact="true"] > .reply-input {
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: 0;
-  }
 }
 
 /* Mention dropdown: script.js sets data-mention-flip="up" when the
@@ -1217,72 +1307,6 @@ body.comments-panel-resizing {
   }
 }
 
-/* ── In-sheet reply thread view ─────────────────────────────
-   Rendered inside the comments panel when a user taps a comment's
-   Reply action on mobile. Fills the panel (flex column) with a header
-   on top, scrollable parent + replies, and a pinned composer at the
-   bottom. Cards reuse `.comment-item` / `.reply-input` so styling
-   stays consistent with the inline arena view. */
-
-@keyframes reply-thread-slide-in {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
-.reply-thread {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  background: var(--surface);
-  color: var(--text);
-  animation: reply-thread-slide-in 0.32s cubic-bezier(0.32, 0.72, 0, 1);
-}
-.sheet-handle__back {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-  padding: 0;
-  flex-shrink: 0;
-}
-.sheet-handle__back:hover {
-  background: var(--surface-raised);
-  color: var(--text);
-}
-.sheet-handle__back svg {
-  width: 18px;
-  height: 18px;
-}
-.reply-thread__scroll {
-  flex: 1;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  padding: 12px 0 16px;
-}
-/* The parent comment sits in its own highlighted block above the thread
-   (matches YouTube/Reddit's mobile replies view where the comment you
-   tapped stays visible as context). Scrolls naturally with the replies
-   underneath; long bodies stay readable via the `더보기` toggle inside
-   `CommentText`. */
-.reply-thread__parent {
-  padding: 4px 0 12px;
-  border-bottom: 1px solid var(--border);
-  background: var(--surface-raised);
-}
-
 /* `CommentText` wrapper. `data-expanded` is Dioxus-controlled (toggle
    button); `data-truncatable` is JS-controlled (set after measuring
    that the rendered text exceeds 3 lines). The expand button is hidden
@@ -1320,21 +1344,5 @@ body.comments-panel-resizing {
 }
 .comment-item__expand:hover {
   text-decoration: underline;
-}
-.reply-thread__list {
-  padding: 4px 0 0;
-}
-.reply-thread__list .comment-item {
-  /* Indent replies so they visually hang off the parent, matching the
-     inline `.comment-replies` offset on the discussion page. */
-  padding-left: 20px;
-}
-/* The inner `.comment-input[data-compact="true"]` supplies the border +
-   padding for this pinned composer. This wrapper only adds the iOS home
-   indicator inset so the composer doesn't end up under the handle. */
-.reply-thread__composer {
-  flex-shrink: 0;
-  background: var(--surface);
-  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 

--- a/docs/superpowers/specs/2026-04-24-badge-design.md
+++ b/docs/superpowers/specs/2026-04-24-badge-design.md
@@ -1,0 +1,409 @@
+# Badge System · System Design
+
+**Roadmap**: [roadmap/badge.md](../../../roadmap/badge.md)
+**Design**: [/app/ratel/assets/design/badge/](../../../app/ratel/assets/design/badge/)
+**Author / Date**: doyooon · 2026-04-24
+
+## Summary
+
+Ship a non-transferable badge system that recognises civic participation across the whole platform. The catalog is code-resident (Rust enum + static array). Award detection runs asynchronously over DynamoDB Streams → EventBridge into a single `BadgeEvaluator` service. The Trophy Vault page (`/badges`) shows the entire catalog with progress; the Trophy Case strip on each profile shows up to 6 most-recently earned badges. Badge awards emit one inbox notification to the earner via the existing `UserInboxNotification` flow.
+
+## Scope
+
+### In scope (Phase 1)
+
+- New feature module `app/ratel/src/features/badges/` (top-level, sibling to `notifications`).
+- Two new entities: `UserBadge` (awarded ledger) and `UserBadgeProgress` (denormalised counters).
+- Static catalog with **all 22 badges from the design**, of which 3 (Marathoner, Signal Boost, Beta Pilot) ship with a `BadgeTrigger::ComingSoon` placeholder — they render in the vault as permanently locked with a "Coming Soon" affordance, no progress bar (see [Coming Soon affordance](#coming-soon-affordance)).
+- 4 new server functions: `list_catalog`, `list_my_earned`, `get_my_progress`, `list_user_earned`.
+- 2 new routes: `BadgeVaultPage { }` and `UserBadgeVaultPage { username }`.
+- `UseBadges` controller hook with category filter signal.
+- Trophy Case strip component embedded into the existing profile page.
+- New `InboxKind::BadgeAwarded` variant + corresponding `InboxPayload` branch.
+- `BadgeEvaluator` service that listens to existing entity streams and awards badges atomically.
+
+### Out of scope (deferred to Phase 2)
+
+- **Marathoner data layer** — daily-activity entity + streak reset semantics. Phase 1 ships the visual placeholder only.
+- **Signal Boost data layer** — Hot-list event emission. Phase 1 ships the visual placeholder only.
+- **Beta Pilot data layer** — `Feedback` entity + submission UI. Phase 1 ships the visual placeholder only.
+- **Backfill** of historical activity for existing users at launch — separate one-shot migration tracked outside this doc.
+- User-defined badges, leaderboards, per-team scopes, secondary market — all explicit non-goals in the spec.
+
+## Data model
+
+### New entity: `UserBadge`
+
+`features/badges/models/user_badge.rs`
+
+```rust
+#[derive(DynamoEntity, Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[dynamo(prefix = "UB")]
+pub struct UserBadge {
+    pub pk: Partition,           // USER#{user_id}
+    pub sk: EntityType,          // USER_BADGE#{badge_id}     ← idempotency key
+
+    pub badge_id: BadgeId,
+
+    // GSI1: list a user's awards in reverse chronological order.
+    // Backs the 6-up Trophy Case strip and "View all" earned-only listing.
+    #[dynamo(index = "gsi1", sk)]
+    pub awarded_at: i64,
+    #[dynamo(prefix = "UB", name = "find_by_user_recent", index = "gsi1", pk)]
+    pub user_pk: Partition,
+}
+```
+
+- Main-table read `UserBadge::get(user_pk, USER_BADGE#{badge_id})` is the **idempotency check** — `attribute_not_exists(sk)` conditional write guarantees `BadgeEvaluator` cannot award the same badge twice even under concurrent stream events.
+- GSI1 query `find_by_user_recent` powers profile / Trophy Vault listings.
+
+### New entity: `UserBadgeProgress`
+
+`features/badges/models/user_badge_progress.rs`
+
+```rust
+#[derive(DynamoEntity, Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[dynamo(prefix = "UBP")]
+pub struct UserBadgeProgress {
+    pub pk: Partition,           // USER#{user_id}
+    pub sk: EntityType,          // USER_BADGE_PROGRESS         ← singleton per user
+
+    pub spaces_joined: i64,
+    pub spaces_created_ongoing: i64,
+    pub poll_votes_cast: i64,
+    pub discussion_comments: i64,
+    pub quizzes_perfect: i64,
+    pub follow_quests_completed: i64,
+    pub prereq_passed_within_1h: i64,
+    pub fast_joins_within_1h: i64,
+    pub rewards_accumulated_cr: i64,
+
+    pub updated_at: i64,
+}
+```
+
+- One row per user, named-field counters (atomic `ADD` updates per field — no map-nested attribute paths).
+- Adding a new badge that needs a new counter is a schema change to this struct + a new EventBridge rule. Acceptable churn for Phase 1; revisit if the catalog explodes.
+- `followers_count` and `followings_count` already exist on `User` — those badges read from `User`, not `UserBadgeProgress`.
+
+### `EntityType` additions
+
+```rust
+// common/types/entity_type.rs
+pub enum EntityType {
+    ...,
+    UserBadge(String),         // sk = USER_BADGE#{badge_id}
+    UserBadgeProgress,         // sk = USER_BADGE_PROGRESS (singleton)
+}
+```
+
+`pk` for both entities is the existing `Partition::User(user_id)` variant — co-located with `User`, `UserInboxNotification`, `UserReward`, etc. No new `Partition` variants are introduced; if a future phase needs cross-user lookup we add them then.
+
+### `InboxKind` / `InboxPayload` additions
+
+```rust
+// common/types/inbox_kind.rs
+pub enum InboxKind {
+    ...,
+    BadgeAwarded,
+}
+
+pub enum InboxPayload {
+    ...,
+    BadgeAwarded {
+        badge_id: BadgeId,
+        badge_name: String,
+        badge_rarity: BadgeRarity,
+        badge_category: BadgeCategory,
+        criterion_text: String,
+    },
+}
+
+impl InboxPayload {
+    pub fn url(&self) -> &str {
+        match self {
+            ...,
+            Self::BadgeAwarded { .. } => "/badges",
+        }
+    }
+}
+```
+
+## Catalog representation
+
+`features/badges/types/catalog.rs`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::Display, strum::EnumString)]
+pub enum BadgeId {
+    // Participation
+    FirstSteps, ActiveVoice, Kingmaker, Legislator, PrereqMaster, Deliberator,
+    // Creator
+    Curator, Architect, QuestDesigner, Foundation,
+    // Social
+    Connector, CommunityPillar, VoiceOfReason, MindMeld,
+    // Achievement
+    Scholar, RewardHunter, TrailBlazer, Marathoner,
+    // Special
+    FoundingVoice, EarlyBird, SignalBoost, BetaPilot,
+}
+
+pub enum BadgeCategory { Participation, Creator, Social, Achievement, Special }
+pub enum BadgeRarity { Legendary, Rare, Common }
+
+pub enum BadgeTrigger {
+    SpacesJoined { count: i64 },
+    PollVotesCast { count: i64 },
+    SpacesCreatedOngoing { count: i64 },
+    SpaceParticipantsAtLeast { count: i64 },     // Foundation: any one space ≥ N
+    QuestActionsAllFour,                         // QuestDesigner
+    Followers { count: i64 },                    // reads User.followers_count
+    Followings { count: i64 },                   // reads User.followings_count
+    DiscussionComments { count: i64 },
+    QuizzesPerfect { count: i64 },
+    FollowQuestsCompleted { count: i64 },
+    PrereqPassedWithin1h { count: i64 },
+    JoinedWithinWindow { from: i64, to: i64 },   // FoundingVoice
+    FastJoinsWithin1h { count: i64 },            // EarlyBird
+    RewardsAccumulatedCr { cr: i64 },            // RewardHunter
+
+    /// Placeholder for badges whose data source is not yet available.
+    /// `BadgeEvaluator` skips these; the UI renders them as locked with a
+    /// "Coming Soon" affordance. Used by Marathoner / SignalBoost / BetaPilot in Phase 1.
+    ComingSoon,
+}
+
+pub struct BadgeDef {
+    pub id: BadgeId,
+    pub name: &'static str,
+    pub category: BadgeCategory,
+    pub rarity: BadgeRarity,
+    pub criterion_text: &'static str,
+    pub icon: BadgeIcon,           // enum mapping to a lucide / custom icon
+    pub trigger: BadgeTrigger,
+}
+
+pub static BADGE_CATALOG: &[BadgeDef] = &[
+    BadgeDef { id: BadgeId::FirstSteps, name: "First Steps", category: BadgeCategory::Participation, rarity: BadgeRarity::Common,
+        criterion_text: "Join your first space and complete a prerequisite.",
+        icon: BadgeIcon::CheckCircle, trigger: BadgeTrigger::SpacesJoined { count: 1 } },
+    // ... 18 more active entries, names & criteria copied verbatim from badges.html
+
+    // Coming Soon — visual only in Phase 1 (data layer deferred to Phase 2)
+    BadgeDef { id: BadgeId::Marathoner, name: "Marathoner", category: BadgeCategory::Achievement, rarity: BadgeRarity::Legendary,
+        criterion_text: "Participate in at least one space every day for 30 days.",
+        icon: BadgeIcon::Lightning, trigger: BadgeTrigger::ComingSoon },
+    BadgeDef { id: BadgeId::SignalBoost, name: "Signal Boost", category: BadgeCategory::Special, rarity: BadgeRarity::Legendary,
+        criterion_text: "Have one of your posts featured on the home arena Hot list.",
+        icon: BadgeIcon::Megaphone, trigger: BadgeTrigger::ComingSoon },
+    BadgeDef { id: BadgeId::BetaPilot, name: "Beta Pilot", category: BadgeCategory::Special, rarity: BadgeRarity::Rare,
+        criterion_text: "Submit 3 bug reports or feedback items during mainnet beta.",
+        icon: BadgeIcon::CheckCircle, trigger: BadgeTrigger::ComingSoon },
+];
+```
+
+### Coming Soon affordance
+
+Badges with `BadgeTrigger::ComingSoon` are skipped by `BadgeEvaluator` (no progress tracked, no awards possible). The Trophy Vault renders them in the locked style with these differences from a normal locked badge:
+
+- The progress bar is replaced by a small `COMING SOON` chip in the meta line position.
+- The hover tooltip appends `· Available in a future release.` to the criterion text.
+- They participate in their category count (so Special still shows `5 / 5` in catalog totals) but are excluded from any "earned by N users" stat.
+- They never appear in the Trophy Case strip on the profile (which lists only earned badges).
+
+The catalog is the **single source of truth**. The frontend fetches it via `GET /api/badges/catalog` (server-rendered from `BADGE_CATALOG`) so we never duplicate badge metadata in TypeScript-style fixtures.
+
+## Award flow (DynamoDB Stream → EventBridge → Lambda)
+
+### Architecture
+
+```
+Entity INSERT/MODIFY (e.g. SpaceParticipant)
+  → CDK Pipe filter (sk prefix)
+  → EventBridge with DetailType::BadgeProgress{Source}
+  → Rule routes to app-shell Lambda
+  → EventBridgeEnvelope::proc()
+  → BadgeEvaluator::on_progress(user_pk, counter_kind, delta)
+      ├ atomic UPDATE UserBadgeProgress ADD counter delta  (returns ALL_NEW)
+      ├ for each badge with this trigger:
+      │   if old < threshold && new >= threshold:
+      │     UserBadge.create_if_absent(user_pk, badge_id)   ← conditional write
+      │     UserInboxNotification.send(user_pk, BadgeAwarded {...})
+      └ done
+```
+
+### Stream sources (Phase 1)
+
+| Source entity (sk prefix) | Counter incremented | Badges that listen |
+|---|---|---|
+| `SP#` SpaceParticipant INSERT | `spaces_joined` | FirstSteps, ActiveVoice, Legislator, Deliberator |
+| `SPA#` SpacePollUserAnswer INSERT | `poll_votes_cast` | Kingmaker |
+| `DC#` Discussion comment INSERT | `discussion_comments` | VoiceOfReason, MindMeld |
+| `SQA#` SpaceQuizAttempt MODIFY (score=100) | `quizzes_perfect` | Scholar |
+| `UF#` UserFollow INSERT | (read `User.followers_count` directly) | Connector, CommunityPillar |
+| Space MODIFY (status → Ongoing) | `spaces_created_ongoing` | Curator, Architect |
+| Space MODIFY (status → Finish) | (paginated `SpaceParticipant::find_by_space` COUNT for `Foundation`) | Foundation |
+| `UR#` UserReward INSERT | `rewards_accumulated_cr` | RewardHunter |
+| `SP#` INSERT with `informed_agreed=true` within 1h of join | `prereq_passed_within_1h` | PrereqMaster |
+| `SP#` INSERT with `created_at - space.published_at < 1h` | `fast_joins_within_1h` | EarlyBird |
+
+Time-window badges (FoundingVoice) and the QuestDesigner all-four-types check evaluate at the same trigger points but read additional context (User.created_at; SpaceAction count of types per space).
+
+### `DetailType` additions
+
+```rust
+pub enum DetailType {
+    ...,
+    BadgeProgressSpaceJoined,
+    BadgeProgressPollVoted,
+    BadgeProgressDiscussionComment,
+    BadgeProgressQuizPerfect,
+    BadgeProgressUserFollow,
+    BadgeProgressSpaceStatusChange,
+    BadgeProgressSpaceFinish,
+    BadgeProgressUserReward,
+}
+```
+
+Each rule routes to the same Lambda. `EventBridgeEnvelope::proc()` dispatches into `BadgeEvaluator::on_event(...)` with the parsed entity.
+
+### Idempotency
+
+- `UserBadge` write uses `condition_expression = "attribute_not_exists(sk)"`. Concurrent stream events for the same threshold crossing → exactly one write succeeds, others get `ConditionalCheckFailed` and silently no-op.
+- `UserInboxNotification` is only emitted on the successful path, so we never spam.
+- `UserBadgeProgress` updates use atomic `ADD` — duplicate-delivery (EventBridge at-least-once) inflates counters. Mitigation: use the source entity's `pk + sk` as a deduplication key in a small TTL table, OR accept the rare over-count for Phase 1 (a user can earn one extra "10 spaces joined" if a stream record duplicates — they'd just earn the badge a few entries earlier than reality). **Decision: accept for Phase 1**, revisit if user reports inflated counters.
+
+### Local-dev parity
+
+Each new branch is mirrored in `common/stream_handler.rs` so Docker/local-dev runs the same evaluation without EventBridge. Pattern matches existing `NOTIFICATION#` branch.
+
+## API surface
+
+All routes are server functions in `features/badges/controllers/`.
+
+| Route | Method | Auth | Returns |
+|---|---|---|---|
+| `/api/badges/catalog` | GET | none (public catalog) | `Vec<BadgeCatalogResponse>` |
+| `/api/badges/me/earned` | GET | logged-in | `ListResponse<UserBadgeResponse>` (recent first) |
+| `/api/badges/me/progress` | GET | logged-in | `UserBadgeProgressResponse` |
+| `/api/users/{user_id}/badges/earned` | GET | none (public) | `ListResponse<UserBadgeResponse>` |
+
+Path param `user_id: UserPartition` (SubPartition — clients pass just the id, no `USER#` prefix).
+
+`UserBadgeProgressResponse` is intentionally **only** exposed on `/me/...` — never for other users (privacy constraint in spec).
+
+`BadgeCatalogResponse` includes the full `BadgeDef` data plus a server-side `current_count: i64` of how many users have earned it (computed once at boot; cached). Phase 1 may ship without `current_count` and add it later if useful for UI.
+
+## Frontend architecture
+
+### Module layout
+
+```
+features/badges/
+├── mod.rs
+├── i18n.rs
+├── controllers/      ← server functions
+├── models/           ← UserBadge, UserBadgeProgress
+├── types/
+│   ├── catalog.rs    ← BadgeId, BadgeDef, BADGE_CATALOG, BadgeTrigger
+│   ├── icon.rs       ← BadgeIcon → lucide_dioxus mapping
+│   ├── error.rs
+│   └── response.rs
+├── services/
+│   └── badge_evaluator.rs   ← runs in Lambda + stream_handler
+├── hooks/
+│   └── use_badges.rs        ← UseBadges controller
+└── views/
+    ├── trophy_vault/        ← Route::BadgeVaultPage page
+    │   ├── component.rs, style.css, page.html, i18n.rs
+    │   ├── filter_bar/      ← sub-component
+    │   ├── badge_medallion/ ← reused for own-vault and other-user-vault
+    │   └── progress_ring/
+    └── trophy_case_strip/   ← embedded in profile page
+        ├── component.rs, style.css
+        └── badge_mini/      ← compact medallion
+```
+
+### `UseBadges` controller hook
+
+```rust
+#[derive(Clone, Copy, DioxusController)]
+pub struct UseBadges {
+    pub catalog: Loader<Vec<BadgeCatalogResponse>>,
+    pub my_earned: Loader<Vec<UserBadgeResponse>>,
+    pub my_progress: Loader<UserBadgeProgressResponse>,
+    pub category_filter: Signal<Option<BadgeCategory>>,
+}
+
+#[track_caller]
+pub fn use_badges() -> Result<UseBadges, RenderError> { /* try_use_context + provide_root_context */ }
+```
+
+For viewing **another user's** vault we use a separate, simpler hook `use_user_badges(user_id: ReadSignal<UserPartition>)` returning only `earned` (no progress, no catalog rebuild needed — the catalog hook is shared).
+
+### Routes
+
+```rust
+// route.rs
+#[layout(RootLayout)]
+    #[route("/badges")]
+    BadgeVaultPage { },
+
+#[nest("/:username")]
+    #[route("/badges")]
+    UserBadgeVaultPage { username: String },
+```
+
+### Profile integration
+
+`features/users/views/profile/component.rs` (or wherever the profile page lives — to be confirmed during scaffolding) renders `TrophyCaseStrip { user_id }` between the stats grid and the activity feed. `TrophyCaseStrip` consumes the appropriate hook based on whether `user_id == current_user`.
+
+### Activity feed integration
+
+The user-facing activity feed already renders inbox notifications — no new code needed. The new `BadgeAwarded` `InboxPayload` variant is rendered with the rose-coloured icon + the headline / subtitle defined in [Functional requirement 18](../../../roadmap/badge.md#notification--activity-feed) (see notification panel component).
+
+## Test plan
+
+### Server function integration tests — `app/ratel/src/tests/badge_tests.rs`
+
+- `test_catalog_lists_all_active_badges`
+- `test_my_earned_empty_for_new_user`
+- `test_my_progress_zero_for_new_user`
+- `test_other_user_earned_excludes_progress` — `/api/users/{id}/badges/earned` responds 200; no endpoint exists at `/api/users/{id}/badges/progress`
+- `test_evaluator_awards_first_steps_on_first_join` — direct call to `BadgeEvaluator::on_event(SpaceParticipant INSERT)`, assert `UserBadge` row + 1 inbox notification
+- `test_evaluator_idempotent_on_duplicate_event` — calling the evaluator twice for the same event yields one badge, one notification
+- `test_evaluator_does_not_revoke_on_decrement` — even if `UserBadgeProgress.spaces_joined` is manually decremented below threshold, the badge remains
+- `test_founding_voice_within_window` and `test_founding_voice_outside_window`
+
+### Playwright — extend or create
+
+- New spec `playwright/tests/web/badges.spec.js`:
+  - `Step 1: profile shows empty Trophy Case for a brand-new user`
+  - `Step 2: vote in a poll, verify Trophy Case shows the awarded badge after navigation back to profile`
+  - `Step 3: navigate to /badges, verify category filter narrows the grid`
+  - `Step 4: hover a locked badge, verify criterion tooltip text`
+  - `Step 5: visit another user's /:username/badges page, verify only earned badges render and no progress bar appears`
+
+## Open questions / risks
+
+### Carried over from spec
+
+- **Streak counting (Marathoner)** — deferred from Phase 1. Need a `UserActivityDay` entity or a daily heartbeat job before this badge is implementable.
+- **Hot-list event (Signal Boost)** — deferred. Awaiting Hot-list to expose `DetailType::PostFeaturedOnHot`.
+- **Feedback entity (Beta Pilot)** — deferred. Requires either a `Feedback` model + submission UI, or a manual ingest from Slack / GitHub.
+- **Backfill at launch** — handled by separate one-shot migration outside this doc; the migration calls `BadgeEvaluator::backfill(user)` for each existing user, which reads existing entity counts (one-time COUNT) into `UserBadgeProgress` and triggers any badges already earned.
+
+### New (Stage 3)
+
+- **Foundation badge cost** — counting `SP#{space_pk}` rows on space-finish is O(participants). Phase 1 ships the simple paginated COUNT (a 500-participant space resolves in one page; even 50k pages in <5s on Lambda). **Refactor trigger**: when a space exceeds ~5k participants in production, snapshot `participant_count` onto `Space` and read from there.
+- **Counter inflation on at-least-once delivery** — accepted for Phase 1 (see [Idempotency](#idempotency)). EventBridge / DynamoDB Streams guarantee at-least-once, so duplicate events occasionally inflate `UserBadgeProgress` counters. Worst-case effect: a user earns a counter-based badge a few activities earlier than reality. No incorrect badges are awarded; thresholds simply trigger slightly early. **Refactor trigger**: if users report visibly inflated counts, add a small dedup table keyed by source-entity pk+sk with TTL = 24h.
+- **`BadgeIcon` mapping** — the design uses ~20 distinct lucide icons. Catalog stores a `BadgeIcon` enum; the frontend maps each variant to a `lucide_dioxus::*` component. Adding a new badge that needs a new icon requires adding both an enum variant and the render mapping — flag this in code review if it becomes a friction point.
+
+## References
+
+- [roadmap/badge.md](../../../roadmap/badge.md) — Stage 1 spec
+- [/app/ratel/assets/design/badge/badges.html](../../../app/ratel/assets/design/badge/badges.html) — Trophy Vault visual contract
+- [/app/ratel/assets/design/badge/profile.html](../../../app/ratel/assets/design/badge/profile.html) — Trophy Case strip visual contract
+- [.claude/rules/conventions/implementing-event-bridge.md](../../../.claude/rules/conventions/implementing-event-bridge.md) — Pipe + Rule + handler pattern
+- [.claude/rules/conventions/hooks-and-actions.md](../../../.claude/rules/conventions/hooks-and-actions.md) — `UseBadges` controller pattern
+- Notification reference implementation: `app/ratel/src/features/notifications/hooks/use_inbox.rs`

--- a/roadmap/badge.md
+++ b/roadmap/badge.md
@@ -1,6 +1,6 @@
 # Badge System
 
-**Status**: Ready for design (Stage 2)
+**Status**: Ready for development (Stage 3)
 **Slug**: `badge`
 **Primary use case**: Motivate recurring civic participation by recognizing public activity with non-transferable badges
 
@@ -28,7 +28,7 @@ Give every Ratel user a **badge ledger** on their profile that grows as their pu
 - **No user-defined custom badges in Phase 1.** The catalog is author-controlled (platform-defined) so we can reason about consistency and abuse. User-defined achievements are a Phase 2 consideration.
 - **No retroactive revocation on downward activity.** If a user earns "10 spaces joined" and later deletes an account they had voted in, the badge does not un-award itself. Badges are monotonic: earning is terminal.
 - **No per-team or per-space badge scopes in Phase 1.** Badges are global (whole-Ratel) only.
-- **No leaderboards.** We rank activity for hot spaces; we do not rank users by badge count publicly..
+- **No leaderboards.** We rank activity for hot spaces; we do not rank users by badge count publicly.
 - **No ad-hoc admin backfills.** Criteria are data-driven evaluations, not staff-issued honorifics. (One exception: time-boxed "Special" badges tied to a launch window; those are parameterized by date range, not by name.)
 - **No notifications spam.** At most one notification per newly-earned badge, and only to the earner — never to the user's followers.
 
@@ -46,3 +46,88 @@ Give every Ratel user a **badge ledger** on their profile that grows as their pu
 
 - As a citizen considering whether to trust a comment or follow a profile, I want to see **what badges that user has** so I can quickly assess their engagement level.
 - As a visitor to a public profile, I want to see only **earned** badges of the viewed user.
+
+## Functional requirements
+
+### Catalog & criteria
+
+1. The system SHALL maintain a platform-defined badge catalog organized into exactly five categories: Participation, Creator, Social, Achievement, Special.
+2. Each catalog entry SHALL specify: name, category, rarity (`legendary` | `rare` | `common`), criterion description (one sentence), threshold (integer or boolean condition), icon, and an optional time window (Special badges only).
+3. The catalog SHALL be code-resident (a Rust enum / constant) — not a user-editable database table — so changes ship via deploy.
+
+### Awarding
+
+4. When a user's measurable activity crosses a badge's threshold, the system SHALL award that badge to that user **exactly once** and record the award timestamp.
+5. The system SHALL NOT revoke an awarded badge if the underlying counter later decreases (badges are monotonic).
+6. Special badges with a time window SHALL only award when the qualifying activity occurred within the configured window. Users who satisfy the criterion outside the window SHALL NOT be eligible.
+7. When a badge is awarded, the system SHALL emit exactly one in-app notification to the earner only.
+
+### Self-view (Trophy Vault page)
+
+8. A logged-in user SHALL be able to navigate to a "Trophy Vault" page that shows the entire catalog (earned + unearned).
+9. The page SHALL display a hero with `{earned} / {total}` count and a progress ring sized to that ratio.
+10. The page SHALL provide filter chips per category — All, Participation, Creator, Social, Achievement, Special — each showing that category's total count.
+11. Each badge SHALL render as a hex medallion with the rarity-coloured frame, a banner with the badge name, and a hover tooltip containing the criterion text.
+12. Earned badges SHALL show the award date in relative form for awards within the last 24 hours ("2h ago"), and absolute "MMM DD" for older awards.
+13. Unearned badges SHALL render desaturated with a lock overlay, a progress bar filled to `progress / threshold`, and a meta line of the form `X / Y · Z to go`. When `progress >= threshold` but the badge has not yet been awarded, the meta line SHALL read `Unlock pending`.
+
+### Self-view (Profile integration)
+
+14. The user's own profile page SHALL include a "Trophy Case" section containing a 6-up strip of the most recently earned badges, ordered by award timestamp descending.
+15. The Trophy Case section SHALL show the `{earned} / {total}` summary alongside the section heading and a "View all" link to the Trophy Vault page.
+
+### Other-user view
+
+16. When viewing another user's profile, the Trophy Case SHALL display only that user's earned badges (max 6, most recent first); locked / in-progress badges SHALL NOT be visible.
+17. The "View all" link on another user's profile SHALL navigate to that user's read-only Trophy Vault, which shows only earned badges and SHALL NOT show progress for unearned badges.
+
+### Notification & activity feed
+
+18. A badge award SHALL appear in the earner's activity feed (`Recent Signal`) as a row with the rose-coloured badge icon, headline `Earned badge <strong>{name}</strong> — {criterion}`, and subtitle `{rarity capitalized} rarity · {category}`.
+19. The notification triggered by an award SHALL deep-link the earner to the Trophy Vault page.
+
+### Catalog Phase 1
+
+20. The Phase 1 catalog SHALL include at least the badges illustrated in the design across all five categories. The final list lives in code; the design files (`badges.html`, `profile.html`) are the visual contract for naming, rarity, and criterion text.
+
+## Acceptance criteria
+
+- [ ] A logged-in user can navigate from their profile to a "Trophy Vault" page via the "View all" link.
+- [ ] The Trophy Vault page renders all 5 categories with the badge counts shown in the design.
+- [ ] Each badge in the vault shows: rarity-themed frame, name banner, criterion tooltip on hover.
+- [ ] Earned badges display the award date; unearned badges display a progress bar and `X / Y · Z to go` meta line.
+- [ ] Filter chips for each category narrow the vault to badges in that category only.
+- [ ] When a user crosses a badge threshold, they receive one in-app notification with the badge name, and the badge appears in their Trophy Case strip on their profile.
+- [ ] The Trophy Case on the user's own profile shows up to 6 most recently earned badges plus the `X / Y earned` summary.
+- [ ] Visiting another user's profile shows their Trophy Case (earned only); the read-only Trophy Vault for that user shows no progress on unearned badges.
+- [ ] The activity feed shows a badge-award entry within seconds of the award being granted.
+- [ ] A badge once earned is never removed when the underlying counter decreases.
+- [ ] A Special "Founding Voice" badge is only awarded to users who joined within the configured launch window; users joining after the window do not receive it even if they meet other criteria.
+
+## Constraints
+
+- **Performance**: The Trophy Vault page SHALL load within 1.5s (p95) for a user with the full catalog.
+- **Async evaluation**: Badge-award evaluation SHALL run asynchronously. The user-facing action that triggers the award (vote, comment, etc.) SHALL NOT block on badge calculation.
+- **Notification latency**: A badge notification SHALL appear in the user's inbox within 60 seconds of the qualifying action.
+- **Storage**: A user's badge ledger is append-only; storage SHALL scale linearly with the total catalog size, not with user activity.
+- **Catalog scale**: Phase 1 catalog is bounded to ~50 badges total. Larger catalogs are out of scope.
+- **Infrastructure**: Badge awarding logic runs entirely on Ratel infrastructure (DynamoDB + EventBridge). No external paid achievement service.
+- **Privacy**: Only earned badges are visible on another user's profile. Progress toward unearned badges is private to the earner.
+
+## Open questions
+
+- **Streak counting (`Marathoner`)**: The Marathoner badge requires "participate every day for 30 days". Stage 3 must define what counts as "participate" (any action vs. specific actions like vote/comment) and how the streak resets on a missed day (hard reset vs grace period).
+- **Featured-on-Hot detection (`Signal Boost`)**: The Signal Boost badge requires being featured on the home Hot list. The Hot-list feature does not yet emit a stable event we can listen for. Stage 3 must either (a) wait for Hot-list to expose an event, or (b) gate this badge behind a temporary admin trigger.
+- **Feedback tracking entity (`Beta Pilot`)**: The Beta Pilot badge requires submitting 3 bug reports or feedback items. Ratel does not yet have a `Feedback` entity that records user-submitted bug reports. Stage 3 must decide whether to add one (which then unlocks both this badge and a future "Submit feedback" UI) or to defer this badge to Phase 2.
+- **Backfill at launch**: Should historical activity (votes cast, spaces joined before launch) count toward badges? Default assumption: backfill once at launch, then evaluate forward.
+
+## References
+
+- **Design (mockups)**: [`app/ratel/assets/design/badge/`](../app/ratel/assets/design/badge/)
+  - `badges.html` — full Trophy Vault catalog page
+  - `profile.html` — Trophy Case strip on user profile
+- **Existing surfaces this feature integrates with**:
+  - `User` model (`app/ratel/src/features/users/`) — badge ledger lives alongside user data
+  - Notifications inbox (`app/ratel/src/features/notifications/`) — badge awards emit one notification
+  - Profile page — Trophy Case strip is a new section
+- **Comparable products**: GitHub Achievements, Duolingo streak/league, Stack Overflow badges

--- a/roadmap/badge.v1.md
+++ b/roadmap/badge.v1.md
@@ -1,0 +1,48 @@
+# Badge System
+
+**Status**: Ready for design (Stage 2)
+**Slug**: `badge`
+**Primary use case**: Motivate recurring civic participation by recognizing public activity with non-transferable badges
+
+## Problem
+
+Ratel rewards **spaces** — a participant completes a space's quests, gets credit, and leaves. There's nothing that ties a user's activity **across spaces** together or signals "this person is a regular" to either the user themselves or to others viewing their profile. The closest signal today is the `points` field on `User`.
+
+Concrete pain points the team has surfaced:
+
+- Users who have participated in dozens of spaces look identical on their profile to users who joined yesterday.
+- There's no lightweight "streak / milestone" feedback loop to pull a user back for a second or third session after the first reward is claimed.
+- Space creators and followers have no at-a-glance heuristic for "is this account real / engaged / new?" when deciding whether to trust them.
+- Non-monetary recognition is absent — everything boils down to credit (CR). Users who care about the civic mission more than the credit payout have nothing to show for it.
+
+Products like GitHub (Achievements, profile trophies), Duolingo (streak + league badges), and Stack Overflow (badges tied to specific activity thresholds) demonstrate that cheap, non-transferable recognition is a surprisingly durable motivator. Ratel has all the raw activity data already; it's just not surfaced as recognition.
+
+## Goal
+
+Give every Ratel user a **badge ledger** on their profile that grows as their public activity crosses predefined thresholds, and design the badge catalog so it recognizes the full arc of civic participation (joining → deliberating → creating → networking → staying consistent). Badges are **recognition only** — they **do not grant CR or any other in-app economic benefit**.
+
+## Non-goals
+
+- **No CR / points / monetary reward.** Earning a badge is its own reward. The existing `user.points` counter is unaffected by badges and continues to reflect only space-reward credit.
+- **No trading / gifting / selling.** Badges are bound to the user account that earned them; there is no secondary market, transfer, or "gift-to-friend" flow.
+- **No user-defined custom badges in Phase 1.** The catalog is author-controlled (platform-defined) so we can reason about consistency and abuse. User-defined achievements are a Phase 2 consideration.
+- **No retroactive revocation on downward activity.** If a user earns "10 spaces joined" and later deletes an account they had voted in, the badge does not un-award itself. Badges are monotonic: earning is terminal.
+- **No per-team or per-space badge scopes in Phase 1.** Badges are global (whole-Ratel) only.
+- **No leaderboards.** We rank activity for hot spaces; we do not rank users by badge count publicly..
+- **No ad-hoc admin backfills.** Criteria are data-driven evaluations, not staff-issued honorifics. (One exception: time-boxed "Special" badges tied to a launch window; those are parameterized by date range, not by name.)
+- **No notifications spam.** At most one notification per newly-earned badge, and only to the earner — never to the user's followers.
+
+## User stories
+
+### Viewer (self)
+
+- As a logged-in user, I want to see **which badges I have earned and which I have not** on my profile, so I know what kinds of activity Ratel recognizes.
+- As a logged-in user, I want to see **progress toward the next badge** (e.g., "8 / 10 spaces joined") so that I have a concrete next step.
+- As a logged-in user, I want to see **when and why** a badge was awarded (date + a sentence explaining the criterion) so it's legible and shareable.
+- As a logged-in user, I want to receive an **in-app notification the moment I earn a new badge**, so the reward loop feels immediate.
+- As a logged-in user, I want badges to render **on my existing profile page** next to my stats, not tucked away in a settings subsection.
+
+### Viewer (of another user)
+
+- As a citizen considering whether to trust a comment or follow a profile, I want to see **what badges that user has** so I can quickly assess their engagement level.
+- As a visitor to a public profile, I want to see only **earned** badges of the viewed user.


### PR DESCRIPTION
## Summary

- Replace `ReplyThreadView` (mobile-only full-panel swap) and desktop inline reply composer with a single bottom composer + CSS-driven thread focus mode.
- Reply button toggles `active_reply_thread`; CSS hides other entries and labels the active one **"Thread"**. The composer shows a *"Replying to X"* quote preview whose X button (or a second click on the same Reply button) exits thread mode.
- No component remount on enter/exit — loaders, scroll position, and per-item state all survive the transition.

## Why

The previous flow had two divergent code paths (mobile full-screen swap vs. desktop inline expand) and each reply-mode transition remounted a subtree (`ReplyThreadView` or inline composer), causing visible loader flicker. Unifying around a single DOM filtered by `data-thread-active` removes the jank and collapses ~230 lines of duplicate state.

## Design

- `active_reply_thread: Signal<Option<String>>` — now drives both platforms; `in_thread` controls `data-thread-active` on `.comments-scroll`, each matching `.comment-entry` gets the same attribute.
- `reply_refresh_tick: Signal<u32>` — bumped inside `reply_comment_action` on success so the thread-active `CommentItem` reloads its local `replies` signal via a `use_effect`.
- Composer quote preview is derived from `comments_query.items()` lookup — no extra loader roundtrip.
- Submit handler branches on `active_reply_thread`: `Some` → `reply_comment`, `None` → `add_comment`.

## Test plan

- [ ] Open a discussion overlay on desktop, click a comment's **Reply** button → verify other comments fade out, active one shows *Thread* label, composer placeholder becomes "Write a reply..."
- [ ] Click the **X** on the quote preview → thread exits, full comment list returns.
- [ ] Click **Reply** a second time on the active thread → exits thread mode (toggle).
- [ ] Submit a reply → new reply appears in `.comment-replies` without a visible reload.
- [ ] Edit/delete via context menu on both top-level and reply items.
- [ ] Repeat on mobile viewport (≤ 750px): sheet-handle toggle still works; thread mode shares the same CSS filter.
- [ ] Existing Playwright suites (`discussion-comment-deep-link.spec.js`, `team-space-full-lifecycle.spec.js`, `team-space-with-signup-users.spec.js`) pass unchanged — all selectors preserved.

## Follow-ups (not in this PR)

- `parent_loader` / `replies_loader` in `use_discussion_arena` are now unused (kept to preserve hook order — safe to drop in a later cleanup).
- Transition animations can be layered on `data-thread-active` (e.g. opacity + max-height fade-out of hidden entries) if the instant `display:none` feels abrupt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)