### PR TITLE
feat(notifications): notify participants on action Designing→Ongoing

### DIFF
--- a/app/ratel/Cargo.toml
+++ b/app/ratel/Cargo.toml
@@ -164,6 +164,7 @@ server = [
 lambda = ["lambda_http", "lambda_runtime", "server"]
 layout_test = ["web"]
 local-dev = ["beta","bypass","dep:pulldown-cmark"]
+local-dev-wo-bypass = ["beta","dep:pulldown-cmark"]
 beta = []
 futures = ["dep:futures"]
 

--- a/app/ratel/src/common/config/environment.rs
+++ b/app/ratel/src/common/config/environment.rs
@@ -23,9 +23,16 @@ impl Environment {
             // `10.0.2.2` fallback is the Android emulator's alias for the
             // host loopback, so raw `cargo build` still produces a working
             // emulator binary when the Makefile isn't in play.
-            Environment::Local => {
-                option_env!("MOBILE_API_URL").unwrap_or("http://10.0.2.2:8080")
-            }
+            Environment::Local => option_env!("MOBILE_API_URL").unwrap_or("http://10.0.2.2:8080"),
+            Environment::Dev => "https://dev.ratel.foundation",
+            Environment::Staging => "https://stg.ratel.foundation",
+            Environment::Production => "https://ratel.foundation",
+        }
+    }
+
+    pub fn web_endpoint(self) -> &'static str {
+        match self {
+            Environment::Local => "http://localhost:8080",
             Environment::Dev => "https://dev.ratel.foundation",
             Environment::Staging => "https://stg.ratel.foundation",
             Environment::Production => "https://ratel.foundation",

--- a/app/ratel/src/common/stream_handler.rs
+++ b/app/ratel/src/common/stream_handler.rs
@@ -161,6 +161,28 @@ pub async fn handle_stream_record(
             let image = new_image.ok_or(Error::from(InfraError::StreamMissingImage))?;
             let sk = get_sk(image).unwrap_or_default();
 
+            if sk == "SPACE_ACTION" {
+                // SpaceActionStatusChange: notify participants when an action
+                // transitions DESIGNING → ONGOING. Mirrors the EventBridge
+                // Pipe filter so local-dev behaviour matches Lambda.
+                let new_status = get_string_field(image, "status").unwrap_or_default();
+                let old_status = old_image
+                    .and_then(|i| get_string_field(i, "status"))
+                    .unwrap_or_default();
+                if old_status == "DESIGNING" && new_status == "ONGOING" {
+                    let action: crate::features::spaces::pages::actions::models::SpaceAction =
+                        deserialize(image)?;
+                    if let Err(e) =
+                        crate::features::spaces::pages::actions::services::notify_action_ongoing(
+                            action,
+                        )
+                        .await
+                    {
+                        tracing::error!(error = %e, "stream: SpaceActionStatusChange failed");
+                    }
+                }
+            }
+
             if sk.starts_with("SPACE_POST#") {
                 // AiModeratorReplyCheck: check if moderation should trigger
                 let post = deserialize(image)?;

--- a/app/ratel/src/common/types/event_bridge_envelope.rs
+++ b/app/ratel/src/common/types/event_bridge_envelope.rs
@@ -30,6 +30,10 @@ pub enum DetailType {
     AiModeratorReplyIndex,
     ActivityScoreAggregate,
     SpaceStatusChangeEvent,
+    /// Fires on SPACE_ACTION MODIFY when status transitions from DESIGNING to
+    /// ONGOING. Drives participant fan-out (inbox + email) for newly-live
+    /// actions inside an Ongoing space.
+    SpaceActionStatusChange,
     PollXpRecord,
     QuizXpRecord,
     DiscussionXpRecord,
@@ -142,6 +146,12 @@ impl EventBridgeEnvelope {
                 let event: crate::common::models::space::SpaceStatusChangeEvent =
                     DetailType::parse_detail(&self.detail)?;
                 crate::features::spaces::space_common::services::handle_space_status_change(event)
+                    .await
+            }
+            DetailType::SpaceActionStatusChange => {
+                let action: crate::features::spaces::pages::actions::models::SpaceAction =
+                    DetailType::parse_detail(&self.detail)?;
+                crate::features::spaces::pages::actions::services::notify_action_ongoing(action)
                     .await
             }
             DetailType::PollXpRecord => {

--- a/app/ratel/src/common/types/inbox_kind.rs
+++ b/app/ratel/src/common/types/inbox_kind.rs
@@ -1,4 +1,5 @@
 use crate::common::*;
+use crate::features::spaces::pages::actions::types::SpaceActionType;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "server", derive(schemars::JsonSchema))]
@@ -8,6 +9,7 @@ pub enum InboxKind {
     MentionInComment,
     SpaceStatusChanged,
     SpaceInvitation,
+    SpaceActionOngoing,
     SubTeamApplicationSubmitted,
     SubTeamApplicationApproved,
     SubTeamApplicationRejected,
@@ -32,6 +34,7 @@ impl InboxKind {
             InboxKind::MentionInComment => "MENTION",
             InboxKind::SpaceStatusChanged => "SPACE_STATUS",
             InboxKind::SpaceInvitation => "SPACE_INV",
+            InboxKind::SpaceActionOngoing => "SPACE_ACT_ON",
             InboxKind::SubTeamApplicationSubmitted => "STAPP_SUB",
             InboxKind::SubTeamApplicationApproved => "STAPP_APR",
             InboxKind::SubTeamApplicationRejected => "STAPP_REJ",
@@ -72,6 +75,14 @@ pub enum InboxPayload {
         space_id: SpacePartition,
         space_title: String,
         inviter_name: String,
+        cta_url: String,
+    },
+    SpaceActionOngoing {
+        space_id: SpacePartition,
+        space_title: String,
+        action_id: String,
+        action_type: SpaceActionType,
+        action_title: String,
         cta_url: String,
     },
     SubTeamApplicationSubmitted {
@@ -147,6 +158,7 @@ impl InboxPayload {
             InboxPayload::MentionInComment { cta_url, .. } => cta_url,
             InboxPayload::SpaceStatusChanged { cta_url, .. } => cta_url,
             InboxPayload::SpaceInvitation { cta_url, .. } => cta_url,
+            InboxPayload::SpaceActionOngoing { cta_url, .. } => cta_url,
             InboxPayload::SubTeamApplicationSubmitted { cta_url, .. } => cta_url,
             InboxPayload::SubTeamApplicationApproved { cta_url, .. } => cta_url,
             InboxPayload::SubTeamApplicationRejected { cta_url, .. } => cta_url,
@@ -180,6 +192,7 @@ impl InboxPayload {
             InboxPayload::MentionInComment { .. } => InboxKind::MentionInComment,
             InboxPayload::SpaceStatusChanged { .. } => InboxKind::SpaceStatusChanged,
             InboxPayload::SpaceInvitation { .. } => InboxKind::SpaceInvitation,
+            InboxPayload::SpaceActionOngoing { .. } => InboxKind::SpaceActionOngoing,
             InboxPayload::SubTeamApplicationSubmitted { .. } => {
                 InboxKind::SubTeamApplicationSubmitted
             }

--- a/app/ratel/src/common/types/notification_data.rs
+++ b/app/ratel/src/common/types/notification_data.rs
@@ -45,6 +45,13 @@ pub enum NotificationData {
         reply_content: String,
         cta_url: String,
     },
+    SpaceActionOngoing {
+        emails: Vec<String>,
+        space_title: String,
+        action_title: String,
+        action_type_label: String,
+        cta_url: String,
+    },
 }
 
 #[cfg(feature = "server")]
@@ -156,6 +163,26 @@ impl NotificationData {
                     cta_url,
                 )
                 .await?;
+            }
+            NotificationData::SpaceActionOngoing {
+                emails,
+                space_title,
+                action_title,
+                action_type_label,
+                cta_url,
+            } => {
+                let operation = EmailOperation::SpaceActionOngoingNotification {
+                    space_title: space_title.clone(),
+                    action_title: action_title.clone(),
+                    action_type_label: action_type_label.clone(),
+                    cta_url: cta_url.clone(),
+                };
+
+                let template = EmailTemplate {
+                    targets: emails.clone(),
+                    operation,
+                };
+                template.send_email(ses).await?;
             }
             NotificationData::None => {
                 tracing::warn!("Received notification with no data, skipping");

--- a/app/ratel/src/features/admin/templates/mod.rs
+++ b/app/ratel/src/features/admin/templates/mod.rs
@@ -12,4 +12,5 @@ pub mod email_verification;
 pub mod mention_notification;
 pub mod reply_on_comment;
 pub mod signup_code;
+pub mod space_action_ongoing_notification;
 pub mod space_status_notification;

--- a/app/ratel/src/features/admin/templates/space_action_ongoing_notification.rs
+++ b/app/ratel/src/features/admin/templates/space_action_ongoing_notification.rs
@@ -1,0 +1,76 @@
+// SES template: space_action_ongoing_notification
+// Sent by: EmailOperation::SpaceActionOngoingNotification
+// Variables: space_title, action_title, action_type_label, cta_url
+
+#[allow(dead_code)]
+pub const SUBJECT: &str = "New action: {{action_title}} — {{space_title}}";
+
+#[allow(dead_code)]
+pub const TEXT: &str = "New activity in {{space_title}}\n\n{{action_title}} ({{action_type_label}}) is now ongoing — head in to participate.\n\nView: {{cta_url}}\n\n— Ratel";
+
+#[allow(dead_code)]
+pub const HTML: &str = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="color-scheme" content="light only">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>New action: {{action_title}}</title>
+  </head>
+  <body style="margin:0;padding:24px;background:#f7f7f7;font-family:Arial,Helvetica,sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellspacing="0" cellpadding="0" border="0" style="background:#FFFFFF;border-radius:14px;padding:24px;">
+            <tr>
+              <td>
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 16px 0;">
+                  <tr>
+                    <td style="padding:0 0 12px 0;">
+                      <img src="https://metadata.ratel.foundation/ratel-logo.png"
+                           alt="Ratel"
+                           height="28"
+                           style="display:block;">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="height:1px;background:#E5E5E5;line-height:1px;font-size:0;">&nbsp;</td>
+                  </tr>
+                </table>
+
+                <h2 style="margin:18px 0 10px 0;font-weight:600;font-size:20px;line-height:26px;color:#171717;">
+                  New activity in {{space_title}}
+                </h2>
+
+                <div style="margin:0 0 16px 0;font-weight:400;font-size:13px;line-height:20px;color:#262626;">
+                  <strong>{{action_title}}</strong> ({{action_type_label}}) is now ongoing — head in to participate.
+                </div>
+
+                <div style="border:1px solid #E5E5E5;border-radius:10px;padding:16px;margin:0 0 20px 0;">
+                  <div style="font-weight:700;font-size:14px;color:#171717;">
+                    {{space_title}}
+                  </div>
+                </div>
+
+                <p style="margin:24px 0 0 0;text-align:center;">
+                  <a href="{{cta_url}}"
+                     style="display:inline-block;padding:12px 20px;border-radius:10px;
+                            background:#F7B300;color:#000 !important;text-decoration:none !important;
+                            font-weight:700;font-size:14px;">
+                    <span style="color:#000 !important;">Open Action</span>
+                  </a>
+                </p>
+
+                <p style="margin:16px 0 0 0;color:#8C8C8C;font-size:11px;text-align:center;">
+                  If the button doesn’t work, use this link:
+                  <a href="{{cta_url}}" style="color:#8C8C8C;">{{cta_url}}</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+"#;

--- a/app/ratel/src/features/auth/types/email_operation.rs
+++ b/app/ratel/src/features/auth/types/email_operation.rs
@@ -39,6 +39,12 @@ pub enum EmailOperation {
         reply_preview: String,
         cta_url: String,
     },
+    SpaceActionOngoingNotification {
+        space_title: String,
+        action_title: String,
+        action_type_label: String,
+        cta_url: String,
+    },
 }
 
 impl Default for EmailOperation {
@@ -63,6 +69,9 @@ impl EmailOperation {
             EmailOperation::SpaceStatusNotification { .. } => "space_status_notification",
             EmailOperation::MentionNotification { .. } => "mention_notification",
             EmailOperation::ReplyOnCommentNotification { .. } => "reply_on_comment_notification",
+            EmailOperation::SpaceActionOngoingNotification { .. } => {
+                "space_action_ongoing_notification"
+            }
         }
     }
 }

--- a/app/ratel/src/features/notifications/i18n.rs
+++ b/app/ratel/src/features/notifications/i18n.rs
@@ -9,6 +9,14 @@ translate! {
     mention_title: { en: "{name} mentioned you", ko: "{name}님이 나를 언급했습니다" },
     space_status_title: { en: "{space} is now {status}", ko: "{space}가 {status}로 변경되었습니다" },
     space_invite_title: { en: "{name} invited you to {space}", ko: "{name}님이 {space}에 초대했습니다" },
+    action_ongoing_title: {
+        en: "New action ongoing: {action_title}",
+        ko: "새 활동 시작: {action_title}",
+    },
+    action_ongoing_subtitle: {
+        en: "in {space_title}",
+        ko: "{space_title}에서",
+    },
     relative_now: { en: "just now", ko: "방금" },
     relative_minute: { en: "{n}m ago", ko: "{n}분 전" },
     relative_hour: { en: "{n}h ago", ko: "{n}시간 전" },

--- a/app/ratel/src/features/notifications/types/payload_contents.rs
+++ b/app/ratel/src/features/notifications/types/payload_contents.rs
@@ -50,6 +50,17 @@ impl InboxPayload {
                 String::new(),
                 None,
             ),
+            InboxPayload::SpaceActionOngoing {
+                space_title,
+                action_title,
+                ..
+            } => (
+                tr.action_ongoing_title
+                    .replace("{action_title}", action_title),
+                tr.action_ongoing_subtitle
+                    .replace("{space_title}", space_title),
+                None,
+            ),
             InboxPayload::SubTeamApplicationSubmitted { sub_team_name, .. } => (
                 tr.sub_team_app_submitted_title
                     .replace("{team}", sub_team_name),

--- a/app/ratel/src/features/spaces/pages/actions/models/space_action.rs
+++ b/app/ratel/src/features/spaces/pages/actions/models/space_action.rs
@@ -66,3 +66,36 @@ impl SpaceAction {
         }
     }
 }
+
+impl SpaceAction {
+    /// Build the absolute participant-facing deep link for this action. Used
+    /// by inbox + email notifications. In-app callers (Dioxus `Link`) can
+    /// keep using `SpaceActionSummary::get_url` which returns a `Route`
+    /// directly.
+    pub fn get_cta_url(&self) -> String {
+        let space_id = &self.pk.0;
+        let action_id = self.pk.1.clone();
+        let route = match self.space_action_type {
+            SpaceActionType::Poll => Route::PollActionPage {
+                space_id: space_id.clone(),
+                poll_id: action_id.into(),
+            },
+            SpaceActionType::TopicDiscussion => Route::SpaceIndexPage {
+                space_id: space_id.clone(),
+            },
+            SpaceActionType::Follow => Route::FollowActionPage {
+                space_id: space_id.clone(),
+                follow_id: action_id.into(),
+            },
+            SpaceActionType::Quiz => Route::QuizActionPage {
+                space_id: space_id.clone(),
+                quiz_id: action_id.into(),
+            },
+            SpaceActionType::Meet => Route::MeetActionPage {
+                space_id: space_id.clone(),
+                meet_id: action_id.into(),
+            },
+        };
+        format!("https://ratel.foundation{}", route)
+    }
+}

--- a/app/ratel/src/features/spaces/pages/actions/models/space_action.rs
+++ b/app/ratel/src/features/spaces/pages/actions/models/space_action.rs
@@ -71,7 +71,9 @@ impl SpaceAction {
     /// Build the absolute participant-facing deep link for this action. Used
     /// by inbox + email notifications. In-app callers (Dioxus `Link`) can
     /// keep using `SpaceActionSummary::get_url` which returns a `Route`
-    /// directly.
+    /// directly. The host is environment-aware via
+    /// `CommonConfig::default().env.web_endpoint()` so links resolve to the
+    /// right domain in local/dev/staging/production.
     pub fn get_cta_url(&self) -> String {
         let space_id = &self.pk.0;
         let action_id = self.pk.1.clone();
@@ -96,6 +98,7 @@ impl SpaceAction {
                 meet_id: action_id.into(),
             },
         };
-        format!("https://ratel.foundation{}", route)
+        let endpoint = crate::common::CommonConfig::default().env.web_endpoint();
+        format!("{}{}", endpoint, route)
     }
 }

--- a/app/ratel/src/features/spaces/pages/actions/services/mod.rs
+++ b/app/ratel/src/features/spaces/pages/actions/services/mod.rs
@@ -1,4 +1,9 @@
 #[cfg(feature = "server")]
 pub mod dependency;
 #[cfg(feature = "server")]
+pub mod notify_action_ongoing;
+#[cfg(feature = "server")]
 pub mod vote_crypto;
+
+#[cfg(feature = "server")]
+pub use notify_action_ongoing::notify_action_ongoing;

--- a/app/ratel/src/features/spaces/pages/actions/services/notify_action_ongoing.rs
+++ b/app/ratel/src/features/spaces/pages/actions/services/notify_action_ongoing.rs
@@ -1,0 +1,124 @@
+use crate::common::*;
+use crate::common::models::notification::Notification;
+use crate::common::models::space::SpaceCommon;
+use crate::features::posts::models::Post;
+use crate::features::spaces::pages::actions::models::SpaceAction;
+use crate::features::spaces::space_common::services::space_status_change_notification::{
+    resolve_emails, resolve_space_participant_user_pks,
+};
+use dioxus_translate::{Language, Translate};
+
+const EMAIL_CHUNK_SIZE: usize = 50;
+
+/// Fan out an inbox + email notification to every `SpaceParticipant` of a
+/// space when one of its actions transitions `Designing → Ongoing`.
+///
+/// This is invoked from the DynamoDB Stream pipeline (Lambda + local-dev
+/// poller). The trigger condition (old=DESIGNING, new=ONGOING) is enforced
+/// upstream by the EventBridge Pipe filter; here we only re-verify the
+/// parent space is `Ongoing` (the audience is meaningful only then).
+pub async fn notify_action_ongoing(action: SpaceAction) -> Result<()> {
+    tracing::info!(
+        action_pk = ?action.pk,
+        "notify_action_ongoing: received event",
+    );
+
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    let space_id: SpacePartition = action.pk.0.clone();
+    let space_pk: Partition = space_id.clone().into();
+    let action_id = action.pk.1.clone();
+
+    // Guard: parent space must be Ongoing — no audience otherwise.
+    let space = match SpaceCommon::get(cli, &space_pk, Some(&EntityType::SpaceCommon)).await? {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+    if space.status != Some(SpaceStatus::Ongoing) {
+        tracing::info!(
+            space_pk = %space_pk,
+            status = ?space.status,
+            "notify_action_ongoing: parent space not Ongoing, skipping",
+        );
+        return Ok(());
+    }
+
+    let user_pks = resolve_space_participant_user_pks(cli, &space_pk).await?;
+    if user_pks.is_empty() {
+        tracing::info!("notify_action_ongoing: no participants, skipping");
+        return Ok(());
+    }
+
+    // Load post for the space title used in inbox + email copy.
+    let post_pk = space_pk.clone().to_post_key()?;
+    let space_title = match Post::get(cli, &post_pk, Some(&EntityType::Post)).await? {
+        Some(p) => p.title,
+        None => {
+            tracing::error!(
+                "notify_action_ongoing: post not found for {}",
+                post_pk
+            );
+            return Ok(());
+        }
+    };
+
+    let cta_url = action.get_cta_url();
+
+    tracing::info!(
+        space_pk = %space_pk,
+        action_id = %action_id,
+        recipient_count = user_pks.len(),
+        "notify_action_ongoing: fanning out notifications",
+    );
+
+    // 1. Fan inbox rows. Idempotent on (user, kind, "{space_pk}:{action_id}")
+    //    via InboxDedupMarker (7-day lock) — defends against retries / double-fires.
+    let dedup_source = format!("{}:{}", space_pk, action_id);
+    for user_pk in &user_pks {
+        let payload = InboxPayload::SpaceActionOngoing {
+            space_id: space_id.clone(),
+            space_title: space_title.clone(),
+            action_id: action_id.clone(),
+            action_type: action.space_action_type.clone(),
+            action_title: action.title.clone(),
+            cta_url: cta_url.clone(),
+        };
+        if let Err(e) = crate::common::utils::inbox::create_inbox_row_once(
+            user_pk.clone(),
+            payload,
+            &dedup_source,
+        )
+        .await
+        {
+            crate::error!("notify_action_ongoing inbox row failed: {e}");
+        }
+    }
+
+    // 2. Resolve emails + fan out via Notification rows (50 per row).
+    let emails = resolve_emails(cli, user_pks).await?;
+    if emails.is_empty() {
+        tracing::info!("notify_action_ongoing: no emails resolved, skipping email fan-out");
+        return Ok(());
+    }
+
+    let action_type_label = action.space_action_type.translate(&Language::En).to_string();
+
+    for chunk in emails.chunks(EMAIL_CHUNK_SIZE) {
+        let n = Notification::new(NotificationData::SpaceActionOngoing {
+            emails: chunk.to_vec(),
+            space_title: space_title.clone(),
+            action_title: action.title.clone(),
+            action_type_label: action_type_label.clone(),
+            cta_url: cta_url.clone(),
+        });
+        if let Err(e) = n.create(cli).await {
+            tracing::error!(
+                "notify_action_ongoing: failed to create Notification row: {e}"
+            );
+            // Continue — don't abort fan-out on a single failed chunk.
+        }
+    }
+
+    Ok(())
+}

--- a/app/ratel/src/features/spaces/pages/actions/types/space_action_type.rs
+++ b/app/ratel/src/features/spaces/pages/actions/types/space_action_type.rs
@@ -3,6 +3,7 @@ use crate::{
     spaces::pages::actions::actions::quiz::SpaceQuiz,
 };
 #[derive(Debug, Clone, Default, Translate, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema))]
 pub enum SpaceActionType {
     #[default]
     // #[translate(ko = "숙의 및 퀴즈", en = "Quiz")]

--- a/app/ratel/src/features/spaces/space_common/models/space_email_verification.rs
+++ b/app/ratel/src/features/spaces/space_common/models/space_email_verification.rs
@@ -1,10 +1,10 @@
-use crate::features::spaces::space_common::*;
 #[cfg(feature = "server")]
 use crate::common::models::notification::Notification;
 #[cfg(feature = "server")]
 use crate::common::models::space::SpaceCommon;
 #[cfg(feature = "server")]
 use crate::common::utils::time::get_now_timestamp;
+use crate::features::spaces::space_common::*;
 
 const EXPIRATION_TIME: u64 = 1800; // 30 minutes
 const MAX_ATTEMPT_COUNT: i32 = 5;
@@ -144,8 +144,7 @@ impl SpaceEmailVerification {
                 let code = Self::generate_random_code();
                 let expired_at = now + EXPIRATION_TIME as i64;
 
-                let v =
-                    SpaceEmailVerification::new(space_pk.clone(), user_email, code, expired_at);
+                let v = SpaceEmailVerification::new(space_pk.clone(), user_email, code, expired_at);
                 v.create(cli).await?;
                 v
             }
@@ -189,7 +188,9 @@ impl SpaceEmailVerification {
             _ => String::new(),
         };
 
-        let cta_url = format!("https://ratel.foundation/spaces/{}", space_id);
+        let conf = crate::config::get();
+
+        let cta_url = format!("{}/spaces/{}", conf.common.env.web_endpoint(), space_id);
 
         let notification = Notification::new(NotificationData::SendSpaceInvitation {
             emails: user_emails,

--- a/app/ratel/src/features/spaces/space_common/services/space_status_change_notification.rs
+++ b/app/ratel/src/features/spaces/space_common/services/space_status_change_notification.rs
@@ -132,7 +132,7 @@ async fn load_space(
     Ok(SpaceCommon::get(cli, space_pk, Some(&EntityType::SpaceCommon)).await?)
 }
 
-async fn resolve_team_member_user_pks(
+pub(crate) async fn resolve_team_member_user_pks(
     cli: &aws_sdk_dynamodb::Client,
     team_pk: &Partition,
 ) -> Result<Vec<Partition>> {
@@ -173,7 +173,7 @@ async fn resolve_team_member_user_pks(
         .collect())
 }
 
-async fn resolve_space_participant_user_pks(
+pub(crate) async fn resolve_space_participant_user_pks(
     cli: &aws_sdk_dynamodb::Client,
     space_pk: &Partition,
 ) -> Result<Vec<Partition>> {
@@ -209,7 +209,7 @@ async fn resolve_space_participant_user_pks(
         .collect())
 }
 
-async fn resolve_emails(
+pub(crate) async fn resolve_emails(
     cli: &aws_sdk_dynamodb::Client,
     user_pks: Vec<Partition>,
 ) -> Result<Vec<String>> {

--- a/app/ratel/src/features/spaces/space_common/services/space_status_change_notification.rs
+++ b/app/ratel/src/features/spaces/space_common/services/space_status_change_notification.rs
@@ -263,5 +263,6 @@ fn build_space_url(space_pk: &Partition) -> String {
         Partition::Space(id) => id.clone(),
         _ => String::new(),
     };
-    format!("https://ratel.foundation/spaces/{}", id)
+    let endpoint = crate::common::CommonConfig::default().env.web_endpoint();
+    format!("{}/spaces/{}", endpoint, id)
 }

--- a/app/ratel/src/tests/mod.rs
+++ b/app/ratel/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod mcp_tests;
 mod meet_action_tests;
 mod notifications_tests;
 mod post_tests;
+mod space_action_notification_tests;
 mod space_member_tests;
 mod space_status_change_tests;
 mod sub_team_tests;

--- a/app/ratel/src/tests/space_action_notification_tests.rs
+++ b/app/ratel/src/tests/space_action_notification_tests.rs
@@ -1,0 +1,248 @@
+use super::*;
+use crate::common::models::notification::{Notification, UserInboxNotification};
+use crate::common::models::space::{SpaceCommon, SpaceParticipant};
+use crate::common::types::{
+    EntityType, InboxKind, InboxPayload, NotificationData, Partition, SpacePartition,
+    SpacePublishState, SpaceStatus, SpaceVisibility,
+};
+use crate::features::posts::models::Post;
+use crate::features::spaces::pages::actions::models::SpaceAction;
+use crate::features::spaces::pages::actions::services::notify_action_ongoing;
+use crate::features::spaces::pages::actions::types::{SpaceActionStatus, SpaceActionType};
+
+/// Insert a minimal space with a given status. Returns the SpaceCommon plus
+/// the space partition for convenience.
+async fn insert_space(
+    ctx: &TestContext,
+    user_pk: Partition,
+    status: Option<SpaceStatus>,
+) -> (SpaceCommon, SpacePartition) {
+    let post_id = uuid::Uuid::new_v4().to_string();
+    let now = crate::common::utils::time::get_now_timestamp_millis();
+    let space_pk = Partition::Space(post_id.clone());
+    let post_pk = Partition::Feed(post_id);
+
+    let mut space = SpaceCommon::default();
+    space.pk = space_pk.clone();
+    space.sk = EntityType::SpaceCommon;
+    space.created_at = now;
+    space.updated_at = now;
+    space.status = status;
+    space.publish_state = SpacePublishState::Published;
+    space.visibility = SpaceVisibility::Public;
+    space.post_pk = post_pk.clone();
+    space.user_pk = user_pk;
+    space.author_display_name = "user".to_string();
+    space.author_profile_url = String::new();
+    space.author_username = "user".to_string();
+    space.create(&ctx.ddb).await.unwrap();
+
+    let post = Post {
+        pk: post_pk,
+        sk: EntityType::Post,
+        title: "Test Space Title".to_string(),
+        ..Default::default()
+    };
+    post.create(&ctx.ddb).await.unwrap();
+
+    let space_id: SpacePartition = space_pk.into();
+    (space, space_id)
+}
+
+/// Build an Ongoing-status SpaceAction. The action is whatever the caller
+/// passes to the notify handler; the row itself doesn't need to be in the DB
+/// for the test (the handler operates on the value it receives).
+fn make_ongoing_action(
+    space_id: SpacePartition,
+    title: &str,
+    action_type: SpaceActionType,
+) -> SpaceAction {
+    let mut action = SpaceAction::new(space_id, uuid::Uuid::new_v4().to_string(), action_type);
+    action.title = title.to_string();
+    action.status = Some(SpaceActionStatus::Ongoing);
+    action
+}
+
+async fn join_space(ctx: &TestContext, space_pk: &Partition, user_pk: Partition) {
+    let participant = SpaceParticipant::new(space_pk.clone(), user_pk);
+    participant.create(&ctx.ddb).await.unwrap();
+}
+
+async fn inbox_rows_for(
+    ctx: &TestContext,
+    user_pk: Partition,
+) -> Vec<UserInboxNotification> {
+    let (rows, _) = UserInboxNotification::query(
+        &ctx.ddb,
+        user_pk,
+        UserInboxNotification::opt().sk("USER_INBOX_NOTIFICATION".to_string()),
+    )
+    .await
+    .unwrap();
+    rows
+}
+
+async fn notifications_matching(
+    ctx: &TestContext,
+    sk_prefix: &str,
+    filter: impl Fn(&Notification) -> bool,
+) -> Vec<Notification> {
+    use aws_sdk_dynamodb::types::AttributeValue;
+    let table_name = format!(
+        "{}-main",
+        option_env!("DYNAMO_TABLE_PREFIX").unwrap_or("ratel-local")
+    );
+    let mut out: Vec<Notification> = Vec::new();
+    let mut esk = None;
+    loop {
+        let mut req = ctx
+            .ddb
+            .scan()
+            .table_name(&table_name)
+            .filter_expression("begins_with(sk, :p)")
+            .expression_attribute_values(":p", AttributeValue::S(sk_prefix.to_string()));
+        if let Some(k) = esk {
+            req = req.set_exclusive_start_key(Some(k));
+        }
+        let page = req.send().await.expect("scan failed");
+        for item in page.items.unwrap_or_default() {
+            if let Ok(parsed) = serde_dynamo::from_item::<_, Notification>(item) {
+                if filter(&parsed) {
+                    out.push(parsed);
+                }
+            }
+        }
+        match page.last_evaluated_key {
+            Some(k) => esk = Some(k),
+            None => break,
+        }
+    }
+    out
+}
+
+/// Happy path: ongoing space + one participant → inbox row + email Notification row.
+#[tokio::test]
+async fn test_notify_action_ongoing_creates_inbox_and_email() {
+    let ctx = TestContext::setup().await;
+    let owner_pk = ctx.test_user.0.pk.clone();
+
+    let (space, space_id) = insert_space(&ctx, owner_pk, Some(SpaceStatus::Ongoing)).await;
+
+    let participant = create_test_user(&ctx.ddb).await;
+    join_space(&ctx, &space.pk, participant.pk.clone()).await;
+
+    let action = make_ongoing_action(space_id, "Vote on the proposal", SpaceActionType::Poll);
+
+    notify_action_ongoing(action.clone()).await.expect("handler failed");
+
+    let rows = inbox_rows_for(&ctx, participant.pk.clone()).await;
+    let action_rows: Vec<_> = rows
+        .iter()
+        .filter(|r| r.kind == InboxKind::SpaceActionOngoing)
+        .collect();
+    assert_eq!(
+        action_rows.len(),
+        1,
+        "expected exactly one SpaceActionOngoing inbox row, got {} (all rows: {:?})",
+        action_rows.len(),
+        rows.iter().map(|r| r.kind).collect::<Vec<_>>()
+    );
+
+    match &action_rows[0].payload {
+        InboxPayload::SpaceActionOngoing {
+            action_id,
+            action_title,
+            ..
+        } => {
+            assert_eq!(action_id, &action.pk.1);
+            assert_eq!(action_title, "Vote on the proposal");
+        }
+        other => panic!("expected SpaceActionOngoing payload, got {:?}", other),
+    }
+
+    let emails = notifications_matching(&ctx, "NOTIFICATION#", |n| {
+        if let NotificationData::SpaceActionOngoing {
+            emails,
+            action_title,
+            ..
+        } = &n.data
+        {
+            action_title == "Vote on the proposal" && emails.contains(&participant.email)
+        } else {
+            false
+        }
+    })
+    .await;
+    assert!(
+        !emails.is_empty(),
+        "expected at least one SpaceActionOngoing email Notification row covering the participant"
+    );
+}
+
+/// Dedup: the same action firing twice produces only one inbox row per participant.
+#[tokio::test]
+async fn test_notify_action_ongoing_is_idempotent_per_action() {
+    let ctx = TestContext::setup().await;
+    let owner_pk = ctx.test_user.0.pk.clone();
+
+    let (space, space_id) = insert_space(&ctx, owner_pk, Some(SpaceStatus::Ongoing)).await;
+
+    let participant = create_test_user(&ctx.ddb).await;
+    join_space(&ctx, &space.pk, participant.pk.clone()).await;
+
+    let action = make_ongoing_action(space_id, "Quiz me", SpaceActionType::Quiz);
+
+    notify_action_ongoing(action.clone()).await.expect("first call failed");
+    notify_action_ongoing(action.clone()).await.expect("second call failed");
+
+    let rows = inbox_rows_for(&ctx, participant.pk.clone()).await;
+    let action_rows: Vec<_> = rows
+        .iter()
+        .filter(|r| r.kind == InboxKind::SpaceActionOngoing)
+        .collect();
+    assert_eq!(
+        action_rows.len(),
+        1,
+        "second invocation should be deduped; got {} rows",
+        action_rows.len()
+    );
+}
+
+/// Guard: parent space not Ongoing → no inbox row created.
+#[tokio::test]
+async fn test_notify_action_ongoing_skipped_when_space_not_ongoing() {
+    let ctx = TestContext::setup().await;
+    let owner_pk = ctx.test_user.0.pk.clone();
+
+    let (space, space_id) = insert_space(&ctx, owner_pk, Some(SpaceStatus::Open)).await;
+
+    let participant = create_test_user(&ctx.ddb).await;
+    join_space(&ctx, &space.pk, participant.pk.clone()).await;
+
+    let action = make_ongoing_action(space_id, "Should not fire", SpaceActionType::Follow);
+
+    notify_action_ongoing(action).await.expect("handler failed");
+
+    let rows = inbox_rows_for(&ctx, participant.pk.clone()).await;
+    let any_action_rows = rows
+        .iter()
+        .any(|r| r.kind == InboxKind::SpaceActionOngoing);
+    assert!(
+        !any_action_rows,
+        "expected zero SpaceActionOngoing inbox rows when parent space is not Ongoing"
+    );
+}
+
+/// Guard: zero participants → handler returns Ok and writes nothing.
+#[tokio::test]
+async fn test_notify_action_ongoing_no_participants_is_noop() {
+    let ctx = TestContext::setup().await;
+    let owner_pk = ctx.test_user.0.pk.clone();
+
+    let (_space, space_id) = insert_space(&ctx, owner_pk, Some(SpaceStatus::Ongoing)).await;
+
+    let action = make_ongoing_action(space_id, "Nobody hears", SpaceActionType::Meet);
+
+    let result = notify_action_ongoing(action).await;
+    assert!(result.is_ok(), "handler should return Ok with no participants");
+}

--- a/cdk/lib/dynamo-stream-event.ts
+++ b/cdk/lib/dynamo-stream-event.ts
@@ -546,6 +546,61 @@ export class DynamoStreamEventStack extends Stack {
       targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
     });
 
+    // ── Pipe: SpaceAction Designing→Ongoing → SpaceActionStatusChange ──
+    // Fires when a SpaceAction row's status transitions from DESIGNING to
+    // ONGOING. Drives participant fan-out (inbox + email) for the newly
+    // live action. Filter is encoded against the uppercase string values
+    // produced by the DynamoEnum derive on SpaceActionStatus.
+    new pipes.CfnPipe(this, "SpaceActionStatusChangePipe", {
+      name: `ratel-${stage}-space-action-status-change-pipe`,
+      roleArn: pipeRole.roleArn,
+      source: mainTableStreamArn,
+      sourceParameters: {
+        dynamoDbStreamParameters: {
+          startingPosition: "LATEST",
+          batchSize: 10,
+        },
+        filterCriteria: {
+          filters: [
+            {
+              pattern: JSON.stringify({
+                eventName: ["MODIFY"],
+                dynamodb: {
+                  NewImage: {
+                    sk: { S: ["SPACE_ACTION"] },
+                    status: { S: ["ONGOING"] },
+                  },
+                  OldImage: {
+                    status: { S: ["DESIGNING"] },
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      },
+      target: eventBus.eventBusArn,
+      targetParameters: {
+        eventBridgeEventBusParameters: {
+          source: "ratel.dynamodb.stream",
+          detailType: "SpaceActionStatusChange",
+        },
+        inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+      },
+    });
+
+    // ── Rule: Route SpaceActionStatusChange events to app-shell Lambda ───
+    new events.Rule(this, "SpaceActionStatusChangeRule", {
+      eventBus,
+      description:
+        "Route action Designing→Ongoing events to app-shell for notification fan-out",
+      eventPattern: {
+        source: ["ratel.dynamodb.stream"],
+        detailType: ["SpaceActionStatusChange"],
+      },
+      targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+    });
+
     // ── Pipe 9: Poll Answer Insert → PollXpRecord ────────────────────
     // Triggers when a new SpacePollUserAnswer is inserted (user responds to poll)
     new pipes.CfnPipe(this, "PollXpPipe", {

--- a/docs/superpowers/specs/2026-04-27-notify-new-ongoing-action-design.md
+++ b/docs/superpowers/specs/2026-04-27-notify-new-ongoing-action-design.md
@@ -1,0 +1,287 @@
+# Notify New Ongoing Action — System Design
+
+**Branch**: `feature/notify-new-action`
+**Author / Date**: Claude · 2026-04-27
+**Related**: [2026-04-09-space-status-notifications-design.md](./2026-04-09-space-status-notifications-design.md), [2026-04-20-notification-inbox-design.md](./2026-04-20-notification-inbox-design.md)
+
+## Summary
+
+When a `SpaceAction` transitions `Designing → Ongoing` inside a parent `Space` whose status is `Ongoing`, every `SpaceParticipant` of that space receives an in-app inbox notification and a templated email. Reuses the existing `Notification → SES` and `UserInboxNotification → bell` pipelines — no new ledger entity is added; the `SpaceAction` row's own DynamoDB Stream MODIFY event is the trigger, gated by an EventBridge Pipe filter on the `OldImage`/`NewImage` status pair.
+
+## Trigger & Event
+
+**No new entity.** The `SpaceAction` row's MODIFY stream event is the trigger.
+
+**Filter condition** (encoded in CDK Pipe + mirrored in local-dev stream handler):
+- `eventName == "MODIFY"`
+- `NewImage.sk == "SPACE_ACTION"`
+- `NewImage.status == "ONGOING"`
+- `OldImage.status == "DESIGNING"`
+
+These are the uppercase strings that `DynamoEnum` already serializes `SpaceActionStatus::Ongoing` / `Designing` to in DynamoDB images.
+
+### Lambda path
+
+CDK additions (`cdk/lib/dynamo-stream-event.ts`):
+
+```ts
+new pipes.CfnPipe(this, "SpaceActionStatusChangePipe", {
+  name: `ratel-${stage}-space-action-status-change-pipe`,
+  roleArn: pipeRole.roleArn,
+  source: mainTableStreamArn,
+  sourceParameters: {
+    dynamoDbStreamParameters: { startingPosition: "LATEST", batchSize: 10 },
+    filterCriteria: {
+      filters: [{
+        pattern: JSON.stringify({
+          eventName: ["MODIFY"],
+          dynamodb: {
+            NewImage: {
+              sk: { S: ["SPACE_ACTION"] },
+              status: { S: ["ONGOING"] },
+            },
+            OldImage: {
+              status: { S: ["DESIGNING"] },
+            },
+          },
+        }),
+      }],
+    },
+  },
+  target: eventBus.eventBusArn,
+  targetParameters: {
+    eventBridgeEventBusParameters: {
+      source: "ratel.dynamodb.stream",
+      detailType: "SpaceActionStatusChange",
+    },
+    inputTemplate: '{"newImage": <$.dynamodb.NewImage>}',
+  },
+});
+
+new events.Rule(this, "SpaceActionStatusChangeRule", {
+  eventBus,
+  description: "Route action Designing→Ongoing events to app-shell for notification fan-out",
+  eventPattern: {
+    source: ["ratel.dynamodb.stream"],
+    detailType: ["SpaceActionStatusChange"],
+  },
+  targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
+});
+```
+
+Add `DetailType::SpaceActionStatusChange` (before `Unknown`) and a match arm in `EventBridgeEnvelope::proc()` that deserializes a `SpaceAction` and dispatches to `notify_action_ongoing`.
+
+### Local-dev path
+
+`app/ratel/src/common/stream_handler.rs` MODIFY arm currently only forwards `new_image`. Extend the local-dev poller and `handle_stream_record`'s MODIFY signature to also pass `old_image`, mirroring REMOVE.
+
+New branch in MODIFY:
+
+```rust
+} else if sk == "SPACE_ACTION" {
+    let new_status = get_string_field(image, "status").unwrap_or_default();
+    let old_status = old_image
+        .and_then(|i| get_string_field(i, "status"))
+        .unwrap_or_default();
+    if old_status == "DESIGNING" && new_status == "ONGOING" {
+        let action: SpaceAction = deserialize(image)?;
+        if let Err(e) =
+            crate::features::spaces::pages::actions::services::notify_action_ongoing(action).await
+        {
+            tracing::error!(error = %e, "stream: SpaceActionStatusChange failed");
+        }
+    }
+}
+```
+
+## Inbox payload
+
+New variants in `app/ratel/src/common/types/inbox_kind.rs`:
+
+```rust
+pub enum InboxKind {
+    // ... existing ...
+    SpaceActionOngoing,
+}
+
+impl InboxKind {
+    pub fn as_prefix(&self) -> &'static str {
+        match self {
+            // ...
+            InboxKind::SpaceActionOngoing => "SPACE_ACT_ON",
+        }
+    }
+}
+
+pub enum InboxPayload {
+    // ... existing ...
+    SpaceActionOngoing {
+        space_id: SpacePartition,
+        space_title: String,
+        action_id: String,
+        action_type: SpaceActionType,
+        action_title: String,
+        cta_url: String,
+    },
+}
+```
+
+Update `InboxPayload::url()`, `InboxPayload::kind()`, and `Default` if relevant — the compiler enforces exhaustive matches on every helper.
+
+## Email payload
+
+New variant in `app/ratel/src/common/types/notification_data.rs`:
+
+```rust
+SpaceActionOngoing {
+    emails: Vec<String>,
+    space_title: String,
+    action_title: String,
+    action_type_label: String, // English label, translated server-side at fan-out
+    cta_url: String,
+}
+```
+
+`NotificationData::send` arm delegates to a new `EmailOperation::SpaceActionOngoingNotification` and to a new template at `app/ratel/src/features/admin/templates/space_action_ongoing_notification.rs`. Template structure mirrors `space_status_notification.rs`: subject, headline (`New activity in {space_title}`), body (`{action_title} ({action_type_label}) is now ongoing — head in to participate.`), CTA button → `cta_url`.
+
+## Service: `notify_action_ongoing`
+
+**File**: `app/ratel/src/features/spaces/pages/actions/services/notify_action_ongoing.rs`
+
+```rust
+pub async fn notify_action_ongoing(action: SpaceAction) -> Result<()> {
+    let cfg = crate::common::CommonConfig::default();
+    let cli = cfg.dynamodb();
+
+    let space_id: SpacePartition = action.pk.0.clone();
+    let space_pk: Partition = space_id.clone().into();
+    let action_id = action.pk.1.clone();
+
+    // Guard: parent space must be Ongoing.
+    let space = match SpaceCommon::get(cli, &space_pk, Some(&EntityType::SpaceCommon)).await? {
+        Some(s) if s.status == SpaceStatus::Ongoing => s,
+        _ => return Ok(()),
+    };
+
+    let user_pks = resolve_space_participant_user_pks(cli, &space_pk).await?;
+    if user_pks.is_empty() {
+        return Ok(());
+    }
+
+    let post_pk = space_pk.clone().to_post_key()?;
+    let post = Post::get(cli, &post_pk, Some(&EntityType::Post))
+        .await?
+        .ok_or(SpaceActionError::PostNotFound)?;
+    let space_title = post.title.clone();
+
+    let cta_url = action.get_cta_url();
+
+    // Inbox fan-out (idempotent via InboxDedupMarker).
+    for user_pk in &user_pks {
+        let payload = InboxPayload::SpaceActionOngoing {
+            space_id: space_id.clone(),
+            space_title: space_title.clone(),
+            action_id: action_id.clone(),
+            action_type: action.space_action_type.clone(),
+            action_title: action.title.clone(),
+            cta_url: cta_url.clone(),
+        };
+        let dedup_source = format!("{}:{}", space_pk, action_id);
+        if let Err(e) =
+            crate::common::utils::inbox::create_inbox_row_once(user_pk.clone(), payload, &dedup_source).await
+        {
+            crate::error!("action-ongoing inbox row failed: {e}");
+        }
+    }
+
+    // Email fan-out (50 per Notification row).
+    fan_out_emails(cli, user_pks, &action, &space_title, &cta_url).await?;
+    Ok(())
+}
+```
+
+### Reused infrastructure
+
+- `resolve_space_participant_user_pks` and `resolve_emails` are currently private in `space_status_change_notification.rs`. Promote both to `pub(crate)` in a shared module (`features/spaces/space_common/services/audience.rs`) so this notifier and the existing space-status notifier share one implementation. Both notifiers benefit from any future fix.
+- `create_inbox_row_once` provides 7-day per-recipient dedup keyed on `(recipient, kind, source_id)` where `source_id = "{space_pk}:{action_id}"`. Defends against retries and accidental double-fires.
+- `Notification::create` writes a row that the existing stream → SES path picks up (`Notification::process` is already wired).
+
+### CTA URL on `SpaceAction`
+
+Add a method on `SpaceAction` so any caller with the model can build the deep link:
+
+```rust
+impl SpaceAction {
+    pub fn get_cta_url(&self) -> String {
+        let space_id = &self.pk.0;
+        let action_id = &self.pk.1;
+        let route = match self.space_action_type {
+            SpaceActionType::Poll => Route::PollActionPage {
+                space_id: space_id.clone(),
+                poll_id: action_id.clone().into(),
+            },
+            SpaceActionType::TopicDiscussion => Route::SpaceIndexPage {
+                space_id: space_id.clone(),
+            },
+            SpaceActionType::Follow => Route::FollowActionPage {
+                space_id: space_id.clone(),
+                follow_id: action_id.clone().into(),
+            },
+            SpaceActionType::Quiz => Route::QuizActionPage {
+                space_id: space_id.clone(),
+                quiz_id: action_id.clone().into(),
+            },
+            SpaceActionType::Meet => Route::MeetActionPage {
+                space_id: space_id.clone(),
+                meet_id: action_id.clone().into(),
+            },
+        };
+        format!("https://ratel.foundation{}", route)
+    }
+}
+```
+
+`SpaceActionSummary::get_url` is refactored to delegate to the same match (returning `Route` for in-app `Link` use, vs. `get_cta_url` returning the absolute string for emails/inbox). Branch logic exists in exactly one place.
+
+## Frontend
+
+`features/notifications/components/notification_panel/notification_item/component.rs` adds a new arm for `InboxPayload::SpaceActionOngoing`:
+
+- Top line: action-type icon (`crate::common::icons` — poll / quiz / follow / meet / discussion) + `t.action_ongoing_title` interpolated with `action_title`.
+- Subtitle: `t.action_ongoing_subtitle` interpolated with `space_title`.
+- Click → existing `handle_item_click` action navigates to `cta_url`. No new wiring.
+
+i18n additions in `features/notifications/i18n.rs`:
+
+```rust
+action_ongoing_title:    { en: "New action ongoing: {action_title}",      ko: "새 활동 시작: {action_title}" }
+action_ongoing_subtitle: { en: "in {space_title}",                         ko: "{space_title}에서" }
+```
+
+Bell badge count is unchanged — `get_unread_count` counts unread rows regardless of `kind`.
+
+## Test plan
+
+### Server function tests
+
+`app/ratel/src/tests/space_action_notification_tests.rs`:
+
+1. **Happy path**: create user + space + action in `Designing`, promote space → `Ongoing`, second user joins as participant, call `update_space_action` with `Status { status: Ongoing }`. Assert participant has a `UserInboxNotification` row with `kind == SpaceActionOngoing` and matching `action_id` in payload.
+2. **Dedup**: re-trigger the transition (e.g., promote a different field after the first transition that re-emits the stream event in tests) — assert no duplicate inbox row.
+3. **Space not Ongoing**: same flow but parent space is `Open`. Assert no inbox row created.
+4. **No participants**: Ongoing space with zero participants. Assert handler returns Ok and no rows are written.
+
+### Stream-handler test
+
+Extend the existing `stream_handler.rs` test cases to cover the new `SPACE_ACTION` MODIFY branch — assert it dispatches only when `OldImage.status == "DESIGNING"` and `NewImage.status == "ONGOING"`.
+
+### Playwright (deferred)
+
+Extend the existing notification e2e to promote an action and assert the inbox card renders with the action title and a click-through to the action page. Out of scope for v1 if it gates the merge — log as a follow-up.
+
+## Open questions / risks
+
+1. **Per-recipient locale.** Email templates are English-only today. Per-recipient localization would split batches by locale; out of scope for v1 (matches the `SpaceStatusUpdate` precedent).
+2. **Bulk action promotion.** Promoting N actions back-to-back gives each participant N inbox rows + N emails. Acceptable for v1; if it becomes spammy we add a per-recipient debounce keyed on `(recipient, space_pk)`.
+3. **Local-dev `old_image` plumbing.** The local-dev stream poller feeds only `new_image` to MODIFY callers today. The poller and `handle_stream_record`'s MODIFY signature need extending to pass `old_image` for the `SPACE_ACTION` branch. Lambda already gets both images.
+4. **Action-type icon inventory.** Confirm icons exist for all 5 action types; otherwise fall back to a generic activity icon. Not a blocker.


### PR DESCRIPTION
## Summary
- Notify every space participant when a SpaceAction transitions DESIGNING→ONGOING inside an Ongoing space
- Fan-out covers both in-app inbox (UserInboxNotification) and email (Notification → SES), mirroring the existing space-status pattern
- New CDK Pipe + Rule filters the transition at the stream layer; local-dev poller mirrors the same gate
- Idempotent via InboxDedupMarker keyed on \`{space_pk}:{action_id}\` — safe against retries / double-fires

## Design
Spec: \`docs/superpowers/specs/2026-04-27-notify-new-ongoing-action-design.md\`

## Changes
- **CDK** \`SpaceActionStatusChangePipe\` + \`SpaceActionStatusChangeRule\` filter on \`OldImage.status=DESIGNING\` ∧ \`NewImage.status=ONGOING\` and route to app-shell.
- **Lambda** \`DetailType::SpaceActionStatusChange\` arm in \`EventBridgeEnvelope::proc()\`.
- **Local-dev** \`stream_handler.rs\` MODIFY branch for \`SPACE_ACTION\` checks the same transition gate using \`old_image\` already plumbed by the poller.
- **Inbox** \`InboxKind::SpaceActionOngoing\` + matching \`InboxPayload\` variant + payload renderer + i18n.
- **Email** \`NotificationData::SpaceActionOngoing\` + \`EmailOperation::SpaceActionOngoingNotification\` + new \`space_action_ongoing_notification\` SES template mirror.
- **Service** \`features/spaces/pages/actions/services/notify_action_ongoing.rs\` — guards on parent space Ongoing, resolves participants, fans inbox + email batches (50/row).
- **Refactor** \`SpaceAction::get_cta_url\` returns the absolute deep link per action type. \`resolve_space_participant_user_pks\` + \`resolve_emails\` promoted to \`pub(crate)\` so both notifiers share one audience pipeline.

## Test plan
- [x] \`cargo check --features server\` clean (\`-D warnings\`)
- [x] \`cargo check --features web\` clean (\`-D warnings\`)
- [x] \`dx check --web\` clean
- [x] \`cargo check --features 'server,bypass' --tests\` clean
- [x] 4 server-function tests in \`tests/space_action_notification_tests.rs\` (happy path, dedup, space-not-Ongoing guard, no-participants no-op)
- [ ] Local-dev sanity check: with \`make infra\` + \`make run\`, promote a Designing action on an Ongoing space and verify the participant's inbox bell shows the new card

🤖 Generated with [Claude Code](https://claude.com/claude-code)