### PR TITLE
Bugfix/arena space

### DIFF
--- a/app/ratel/src/common/components/mention_autocomplete/mod.rs
+++ b/app/ratel/src/common/components/mention_autocomplete/mod.rs
@@ -19,7 +19,7 @@ pub struct MentionInsert {
 
 #[component]
 pub fn MentionAutocomplete(
-    text: ReadSignal<String>,
+    text: Signal<String>,
     on_select: EventHandler<MentionInsert>,
     members: ReadSignal<Vec<MentionCandidate>>,
     // Fires whenever the active `@` query changes. `Some("")` means the user
@@ -39,11 +39,17 @@ pub fn MentionAutocomplete(
     let mut selected_index = use_signal(|| 0usize);
 
     // Tracks the last value we reported upstream so we can skip redundant
-    // callback calls. Read via `.peek()` to avoid subscribing the effect to
-    // its own writes (which would re-trigger the effect every frame).
+    // callback calls. Read via `.peek()` to avoid re-subscribing on writes.
     let mut last_reported: Signal<Option<String>> = use_signal(|| None);
 
-    use_effect(move || {
+    // Recompute mention state from the current text. Called from the
+    // wrapper's `oninput` (which captures bubbled input events from the
+    // child textarea). Driven by the DOM event rather than `use_effect`
+    // because Dioxus 0.7 does not reliably re-establish reactive
+    // subscriptions on prop signals after SSR hydration — the effect can
+    // silently fail to re-run on the first input post-hydration, leaving
+    // the dropdown permanently dormant.
+    let mut recompute = move || {
         let val = text();
         if let Some(pos) = find_active_at(&val) {
             let after_at = &val[pos + 1..];
@@ -67,7 +73,7 @@ pub fn MentionAutocomplete(
             }
             show_dropdown.set(false);
         }
-    });
+    };
 
     // Client-side prefix filter mirrors the server's prefix semantics.
     // When the dropdown consumer (e.g. space discussion) already fetches a
@@ -106,6 +112,11 @@ pub fn MentionAutocomplete(
     rsx! {
         div {
             class: "relative",
+            // Children's textarea `oninput` bubbles here. Driving the
+            // mention recompute from the wrapper's bubbled event keeps the
+            // logic out of `use_effect`, which is unreliable on
+            // SSR-hydrated prop signals (see `recompute` definition above).
+            oninput: move |_| recompute(),
             onkeydown: move |evt: KeyboardEvent| {
                 if !show_dropdown() {
                     return;

--- a/app/ratel/src/common/components/mention_autocomplete/mod.rs
+++ b/app/ratel/src/common/components/mention_autocomplete/mod.rs
@@ -19,7 +19,7 @@ pub struct MentionInsert {
 
 #[component]
 pub fn MentionAutocomplete(
-    text: Signal<String>,
+    text: ReadSignal<String>,
     on_select: EventHandler<MentionInsert>,
     members: ReadSignal<Vec<MentionCandidate>>,
     // Fires whenever the active `@` query changes. `Some("")` means the user

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
@@ -82,7 +82,6 @@ pub struct UseDiscussionArena {
         InfiniteQuery<String, DiscussionCommentResponse, ListResponse<DiscussionCommentResponse>>,
     pub parent_loader: Loader<DiscussionCommentResponse>,
     pub replies_loader: Loader<ListResponse<DiscussionCommentResponse>>,
-    pub members_loader: Loader<ListResponse<SpaceMemberResponse>>,
     pub polled_new: Signal<Vec<DiscussionCommentResponse>>,
     pub last_seen_at: Signal<i64>,
     /// Bumped every poll tick so a `use_memo` over `comment_score` re-runs
@@ -283,16 +282,29 @@ pub fn use_discussion_arena(
         });
     });
 
-    let members_loader = use_loader(move || async move {
-        match mention_query() {
-            None => Ok(ListResponse::<SpaceMemberResponse>::default()),
-            Some(q) => list_space_members(space_id(), None, Some(q)).await,
-        }
-    })?;
+    // `use_loader` does not reliably re-run on prop signal changes after SSR
+    // hydration in Dioxus 0.7 — confirmed empirically: even when
+    // `mention_query` flips from None to Some(""), the loader closure never
+    // fires post-hydration. Drive the fetch from `use_effect` (which does
+    // re-run reliably, as the debounce above demonstrates) and store
+    // results in a plain Signal that downstream `use_memo` reads.
+    let mut members_signal: Signal<Vec<SpaceMemberResponse>> = use_signal(Vec::new);
+    use_effect(move || {
+        let q = mention_query();
+        spawn(async move {
+            let items = match q {
+                None => Vec::new(),
+                Some(q) => list_space_members(space_id(), None, Some(q))
+                    .await
+                    .map(|r| r.items)
+                    .unwrap_or_default(),
+            };
+            members_signal.set(items);
+        });
+    });
 
     let members_memo = use_memo(move || {
-        members_loader()
-            .items
+        members_signal()
             .into_iter()
             .map(|m| {
                 let pk: Partition = m.user_id.clone().into();
@@ -496,7 +508,6 @@ pub fn use_discussion_arena(
         comments_query,
         parent_loader,
         replies_loader,
-        members_loader,
         polled_new,
         last_seen_at,
         sort_tick,

--- a/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
+++ b/app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs
@@ -230,6 +230,36 @@ pub fn use_discussion_arena(
         .await
     })?;
 
+    // Reply-aware mention priority needs the active thread's replies live.
+    // `replies_loader` above (use_loader) does not reliably re-run on
+    // `active_reply_thread` changes after SSR hydration — same race that
+    // broke `members_loader`. Drive a dedicated fetch from `use_effect`
+    // instead so the priority memo always sees current thread replies.
+    let mut thread_replies: Signal<Vec<DiscussionCommentResponse>> = use_signal(Vec::new);
+    use_effect(move || {
+        let id = active_reply_thread();
+        spawn(async move {
+            let items = match id {
+                None => Vec::new(),
+                Some(parent_id) => match list_replies(
+                    space_id(),
+                    discussion_id(),
+                    SpacePostCommentEntityType(parent_id),
+                    None,
+                )
+                .await
+                {
+                    Ok(r) => r.items,
+                    Err(e) => {
+                        crate::error!("thread_replies fetch failed: {e}");
+                        Vec::new()
+                    }
+                },
+            };
+            thread_replies.set(items);
+        });
+    });
+
     let mut polled_new: Signal<Vec<DiscussionCommentResponse>> = use_signal(Vec::new);
     let mut last_seen_at: Signal<i64> = use_signal(move || {
         comments_query
@@ -302,10 +332,13 @@ pub fn use_discussion_arena(
         spawn(async move {
             let items = match q {
                 None => Vec::new(),
-                Some(q) => list_space_members(space_id(), None, Some(q))
-                    .await
-                    .map(|r| r.items)
-                    .unwrap_or_default(),
+                Some(q) => match list_space_members(space_id(), None, Some(q)).await {
+                    Ok(r) => r.items,
+                    Err(e) => {
+                        crate::error!("mention members fetch failed: {e}");
+                        Vec::new()
+                    }
+                },
             };
             members_signal.set(items);
         });
@@ -332,6 +365,43 @@ pub fn use_discussion_arena(
         let polled = polled_new();
         let base_sks: std::collections::HashSet<String> =
             base.iter().map(|c| c.sk.to_string()).collect();
+
+        // Reply mode: hoist parent comment author as primary, reply
+        // authors as the thread. Falls back to the discussion-wide
+        // ordering below if the parent isn't in the loaded base/polled
+        // set (very old thread scrolled past).
+        if let Some(parent_id) = active_reply_thread() {
+            let parent_sk_str =
+                EntityType::SpacePostComment(parent_id).to_string();
+            let parent = base
+                .iter()
+                .chain(polled.iter())
+                .find(|c| c.sk.to_string() == parent_sk_str);
+
+            if let Some(parent) = parent {
+                let replies = thread_replies();
+                let parent_tuple =
+                    (parent.author_pk.to_string(), parent.content.clone());
+                let reply_tuples: Vec<(String, String)> = replies
+                    .iter()
+                    .map(|r| (r.author_pk.to_string(), r.content.clone()))
+                    .collect();
+
+                let primary_ref = (parent_tuple.0.as_str(), parent_tuple.1.as_str());
+                let thread_refs: Vec<(&str, &str)> = reply_tuples
+                    .iter()
+                    .map(|(a, c)| (a.as_str(), c.as_str()))
+                    .collect();
+
+                return crate::common::utils::mention::build_mention_priority(
+                    Some(primary_ref),
+                    &thread_refs,
+                );
+            }
+        }
+
+        // Non-reply mode: every loaded participant gets equal-rank
+        // priority over non-participants (no single primary).
         let tuples: Vec<(String, String)> = base
             .iter()
             .chain(


### PR DESCRIPTION
## 개요

Discussion 페이지의 멘션 자동완성 관련 두 가지 버그 수정.

---

## 버그 1 — 새로고침 후 멘션 자동완성 동작 안 함

### 원인
Dioxus 0.7 의 SSR hydration 후 reactive subscription 이 재연결되지 않음. 두 군데에서 동일 race:
- `MentionAutocomplete` 의 `use_effect` (textarea 의 `text` prop signal 구독)
- `use_discussion_arena` 의 `members_loader = use_loader(...)` (`mention_query` signal 구독)

SSR 단계에서 effect/loader 가 한 번 실행되며 signal subscriber 목록에 등록되지만, hydration 시 그 subscription 이 끊긴 채 재연결되지 않음.

### 발생 경로
1. Discussion 페이지에서 F5 새로고침 (혹은 외부 링크/직접 URL 로 진입)
2. Textarea 클릭 → `@` 입력
3. `text` signal 은 업데이트 되지만 `use_effect` 가 재발화 안 함
4. `mention_query` 가 변하지 않아 `list_space_members` API 호출이 한 번도 안 나감
5. Dropdown 영구히 비활성

(검증: `tracing::info!` 로 chain 추적 → `recompute` 까지는 도달하나 `members_loader fired` 가 절대 안 찍힘)

### 설명
정상 네비게이션 흐름에서는 컴포넌트가 클라이언트에서 마운트되며 effect/loader 의 subscription 이 정상 등록됨. 그러나 SSR 결과를 hydration 하는 경로에서는 server-side 에 등록된 subscription 이 클라이언트로 그대로 이전되지 않음. 사용자가 signal 을 변경해도 effect/loader 가 그 변경을 인지하지 못해 dropdown 이 절대 뜨지 않는 영구 dormant 상태.

### 해결
1. **`MentionAutocomplete`**: `use_effect` 제거 → wrapper `div` 의 `oninput` 핸들러 (DOM event bubble) 에서 mention 감지 로직 직접 호출. Subscription 이 아닌 DOM event 로 트리거되므로 hydration race 와 무관.
2. **Members fetch**: `use_loader` 대신 `use_effect + spawn + Signal` 패턴으로 교체. 같은 파일의 디바운스 effect 가 동일 패턴으로 reactive 정상 동작함이 로그로 확인됨.

---

## 버그 2 — 답글 모드에서 멘션 우선순위 무시됨

### 원인
`top_priority` memo 가 `active_reply_thread` signal 을 전혀 읽지 않음. 모든 컨텍스트에서 동일하게 `build_mention_priority(None, &all_comments)` 로 호출됨.

### 발생 경로
1. 댓글의 Reply 버튼 클릭 → reply 모드 진입 (`active_reply_thread = Some(parent_id)`)
2. Composer 에 `@` 입력
3. Dropdown 에 부모 댓글 작성자와 같은 thread 의 답글 작성자가 다른 참여자와 동일 우선순위로 섞여서 표시

### 설명
`build_mention_priority(primary, thread)` API 는 `primary` 를 최상위 랭크, `thread` 를 그 다음 랭크로 정렬하도록 설계되어 있음. 그러나 현 구현은 reply 컨텍스트에서도 `primary=None`, `thread=전체 댓글 작성자` 로 호출하므로 reply 의 의미적 컨텍스트 (부모 + 같은 thread 참여자) 가 우선순위에 반영되지 않음.

### 해결
`top_priority` 를 `active_reply_thread` 변경에 reactive 하게 수정:
- `Some(parent_id)` → 부모 댓글 작성자 = `primary`, 해당 thread 의 답글 작성자들 = `thread`
- `None` → 기존 로직 (모든 참여자 평등 우선순위)

답글 데이터는 새 `thread_replies` signal + `use_effect + spawn` 으로 직접 fetch. 기존 `replies_loader` 도 `use_loader` 라 동일 hydration race 가 잠재적으로 있어 외부 우회.

---

## 변경 파일
- `app/ratel/src/common/components/mention_autocomplete/mod.rs`
- `app/ratel/src/features/spaces/pages/index/action_pages/discussion/hooks/use_discussion_arena.rs`

## 테스트 시나리오
- [ ] Discussion 페이지에서 F5 새로고침 → textarea 클릭 → `@` 입력 → dropdown 정상 표시 + 멤버 리스트 보임
- [ ] 답글 모드에서 `@` 입력 → 부모 댓글 작성자가 최상단, 그 다음 thread 의 다른 답글 작성자
- [ ] 일반 댓글 작성 시 `@` → 기존 동작 유지 (모든 참여자 표시)
- [ ] Network 탭에 `list_space_members` 요청이 정상으로 나가는지 확인

## 비고
`use_loader` 의 hydration race 는 본 PR 에서는 회피만 함. 같은 패턴이 다른 페이지에도 잠재적으로 존재할 가능성 있음 (직접 진입 / 새로고침 시 reactive 데이터 fetch 가 멈추는 케이스). 추후 `use_loader` 자체 패치 또는 컨벤션 차원의 가이드라인 정리 검토 필요.
