### PR TITLE
fix(ci): export CROSS_POSTING_DATA_KEY into Makefile-generated env.sh

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -231,14 +231,6 @@ jobs:
           CROSS_POSTING_DATA_KEY: ${{ secrets.DEV_CROSS_POSTING_DATA_KEY }}
           CROSS_POSTING_DATA_KEY_PREVIOUS: ${{ secrets.DEV_CROSS_POSTING_DATA_KEY_PREVIOUS }}
         run: |
-          # === TEMP DEBUG: cross-posting envvar baking 진단용. 머지 즉시 revert. ===
-          echo "ENV CHECK (length only - values not exposed):"
-          echo "  CROSS_POSTING_DATA_KEY length=${#CROSS_POSTING_DATA_KEY}"
-          echo "  CROSS_POSTING_DATA_KEY_PREVIOUS length=${#CROSS_POSTING_DATA_KEY_PREVIOUS}"
-          echo "  KAIA_FEEPAYER_KEY length=${#KAIA_FEEPAYER_KEY}"
-          echo "  TELEGRAM_TOKEN length=${#TELEGRAM_TOKEN}"
-          # === ====================================================================
-
           rm -rf target/dx
 
           cd app/ratel

--- a/app/ratel/Makefile
+++ b/app/ratel/Makefile
@@ -171,6 +171,8 @@ env.sh:
 	@echo "export HOST_UID='$(HOST_UID)'" >> $@
 	@echo "export HOST_GID='$(HOST_GID)'" >> $@
 	@echo "export BIYARD_API_URL='$(BIYARD_API_URL)'" >> $@
+	@echo "export CROSS_POSTING_DATA_KEY='$(CROSS_POSTING_DATA_KEY)'" >> $@
+	@echo "export CROSS_POSTING_DATA_KEY_PREVIOUS='$(CROSS_POSTING_DATA_KEY_PREVIOUS)'" >> $@
 
 
 test:


### PR DESCRIPTION
`make build-lambda` runs cargo inside a docker container that sources `app/ratel/env.sh`. The Makefile's `env.sh` target was missing CROSS_POSTING_DATA_KEY, so cargo never saw the secret and `option_env!()` baked None into the binary — runtime panicked on every connect_bluesky call. Add the two missing exports and revert the length-print debug.