### PR TITLE
feat(rewards): backfill 2026-04 outage rewards via PendingReward + re…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ user.json
 /.claude/worktrees/
 google-services.json
 /app/ratel/env.sh
+
+# Migration source data (supplied via env vars at runtime; never committed)
+/app/ratel/src/common/migrations/data/

--- a/app/ratel/Makefile
+++ b/app/ratel/Makefile
@@ -175,10 +175,15 @@ env.sh:
 	@echo "export CROSS_POSTING_DATA_KEY_PREVIOUS='$(CROSS_POSTING_DATA_KEY_PREVIOUS)'" >> $@
 
 
+# Run integration tests. Pass TEST=<name> to run only matching tests:
+#   make test                                  # all tests
+#   make test TEST=pending_reward_retry        # only matching tests
+TEST ?=
+
 test:
 	mkdir -p ./test-build-target/debug/deps/public
 	npx @tailwindcss/cli -i tailwind.css -o ./assets/tailwind.css
-	$(BUILD_ENV) CARGO_TARGET_DIR=./test-build-target cargo test --features server,bypass --tests -- --test-threads=1
+	$(BUILD_ENV) CARGO_TARGET_DIR=./test-build-target cargo test --features server,bypass --tests $(TEST) -- --test-threads=1 --nocapture
 
 js/node_modules:
 	npm i

--- a/app/ratel/src/common/migrations/m002_backfill_pending_rewards.rs
+++ b/app/ratel/src/common/migrations/m002_backfill_pending_rewards.rs
@@ -1,0 +1,122 @@
+//! Migration 002 — backfill PendingReward rows for the 2026-04-19/20 Biyard
+//! outage. The retry endpoint (`run_pending_reward_retry`) drains the rows
+//! into Biyard with the original month preserved so April-earned points are
+//! billed against April even when retried later.
+//!
+//! Idempotent via `PendingReward::create` (conditional PutItem with
+//! `attribute_not_exists(pk) AND attribute_not_exists(sk)`); a re-run skips
+//! rows already inserted by a previous run or by the retry pipeline.
+//!
+//! Source data: a 4-column CSV (`user_id, amount, created_at_ms, reward_key`)
+//! generated from the reconciliation audit (`MISSING_IN_BIYARD` rows only,
+//! PII stripped). The path is supplied at runtime via the
+//! `M002_CSV_PATH` env var so the file never enters source control or the
+//! deployed binary; absent the env var, this migration aborts before
+//! advancing the version gate.
+
+use crate::common::models::reward::PendingReward;
+use crate::common::types::{PendingRewardKey, PendingRewardStatus, RewardKey};
+use crate::common::utils::aws::error::AwsError;
+use crate::common::*;
+
+pub const REQUIRED_VERSION: i64 = 2;
+
+const SPACE_ID: &str = "019d70df-dfc0-7222-be71-e55c2bd8121a";
+const OWNER_TEAM_ID: &str = "840";
+const DESCRIPTION: &str = "outage-backfill";
+
+const CSV_PATH_ENV: &str = "M002_CSV_PATH";
+const EXPECTED_HEADER: &str = "user_id,amount,created_at_ms,reward_key";
+
+pub async fn run(cli: &aws_sdk_dynamodb::Client) -> crate::common::Result<()> {
+    let space_pk = Partition::Space(SPACE_ID.to_string());
+    let owner_pk = Partition::Team(OWNER_TEAM_ID.to_string());
+
+    let csv_path = std::env::var(CSV_PATH_ENV).map_err(|_| {
+        tracing::error!(
+            env = CSV_PATH_ENV,
+            "m002: env var not set; refusing to advance migration version",
+        );
+        Error::InvalidFormat
+    })?;
+    let csv_data = std::fs::read_to_string(&csv_path).map_err(|e| {
+        tracing::error!(path = %csv_path, error = %e, "m002: failed to read CSV");
+        Error::InvalidFormat
+    })?;
+
+    let mut lines = csv_data.lines();
+    let header = lines.next().ok_or(Error::InvalidFormat)?;
+    if header.trim() != EXPECTED_HEADER {
+        tracing::error!(actual = header, expected = EXPECTED_HEADER, "m002: header mismatch");
+        return Err(Error::InvalidFormat);
+    }
+
+    let mut written = 0usize;
+    let mut already_present = 0usize;
+    let mut total = 0usize;
+
+    for (lineno, line) in lines.enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        total += 1;
+
+        // splitn(4) so the reward_key (which contains commas in nothing we've
+        // seen, but `##`-delimited identifiers in general) survives intact.
+        let parts: Vec<&str> = line.splitn(4, ',').collect();
+        if parts.len() != 4 {
+            tracing::error!(line = lineno + 2, raw = line, "m002: malformed row");
+            return Err(Error::InvalidFormat);
+        }
+
+        let user_id = parts[0].trim();
+        let amount: i64 = parts[1].trim().parse().map_err(|_| Error::InvalidFormat)?;
+        let created_at_ms: i64 = parts[2].trim().parse().map_err(|_| Error::InvalidFormat)?;
+        let reward_key: RewardKey = parts[3].trim().parse()?;
+
+        let target_pk = Partition::User(user_id.to_string());
+
+        let row = PendingReward {
+            pk: Partition::PendingReward,
+            sk: PendingRewardKey {
+                created_at: created_at_ms,
+                target_pk: target_pk.clone(),
+                reward_key: reward_key.clone(),
+            },
+            created_at: created_at_ms,
+            target_pk,
+            owner_pk: Some(owner_pk.clone()),
+            space_pk: space_pk.clone(),
+            reward_key,
+            amount,
+            description: DESCRIPTION.to_string(),
+            status: PendingRewardStatus::Pending,
+            updated_at: created_at_ms,
+            retry_count: 0,
+            last_error: String::new(),
+        };
+
+        match row.create(cli).await {
+            Ok(_) => written += 1,
+            Err(Error::Aws(AwsError::DynamoDb(
+                aws_sdk_dynamodb::Error::ConditionalCheckFailedException(_),
+            ))) => already_present += 1,
+            Err(e) => {
+                tracing::error!(
+                    line = lineno + 2,
+                    error = %e,
+                    "m002: failed to create pending reward",
+                );
+                return Err(e);
+            }
+        }
+    }
+
+    tracing::info!(
+        total,
+        written,
+        already_present,
+        "m002: backfill_pending_rewards complete",
+    );
+    Ok(())
+}

--- a/app/ratel/src/common/migrations/mod.rs
+++ b/app/ratel/src/common/migrations/mod.rs
@@ -9,8 +9,10 @@
 
 #[cfg(feature = "server")]
 mod m001_backfill_character_xp;
+// crate-visible so the integration test in `character/tests` can call `run`
+// directly to exercise m002 twice in a row and assert idempotency.
 #[cfg(feature = "server")]
-mod m002_backfill_pending_rewards;
+pub(crate) mod m002_backfill_pending_rewards;
 #[cfg(feature = "server")]
 mod runner;
 

--- a/app/ratel/src/common/migrations/mod.rs
+++ b/app/ratel/src/common/migrations/mod.rs
@@ -10,6 +10,8 @@
 #[cfg(feature = "server")]
 mod m001_backfill_character_xp;
 #[cfg(feature = "server")]
+mod m002_backfill_pending_rewards;
+#[cfg(feature = "server")]
 mod runner;
 
 #[cfg(feature = "server")]

--- a/app/ratel/src/common/migrations/runner.rs
+++ b/app/ratel/src/common/migrations/runner.rs
@@ -29,8 +29,15 @@ pub async fn run_migrations(cli: &aws_sdk_dynamodb::Client) -> crate::common::Re
         tracing::info!("migration 001 complete; version advanced to 1");
     }
 
+    if stored < 2 {
+        tracing::info!("running migration 002: backfill_pending_rewards");
+        super::m002_backfill_pending_rewards::run(cli).await?;
+        LastBackfillVersion::advance_to(cli, 1, 2).await?;
+        tracing::info!("migration 002 complete; version advanced to 2");
+    }
+
     // Future migrations stack additively here:
-    //   if stored < 2 { ... advance_to(cli, 1, 2) ... }
+    //   if stored < 3 { ... advance_to(cli, 2, 3) ... }
 
     tracing::info!("migration runner finished");
     Ok(())

--- a/app/ratel/src/common/models/reward/pending_reward.rs
+++ b/app/ratel/src/common/models/reward/pending_reward.rs
@@ -1,19 +1,33 @@
-use crate::common::{utils::time::get_now_timestamp_millis, *};
+use crate::common::{
+    types::{PendingRewardKey, PendingRewardStatus, RewardKey},
+    utils::time::get_now_timestamp_millis,
+    *,
+};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, DynamoEntity)]
 pub struct PendingReward {
-    pub pk: String,
-    pub sk: String,
+    pub pk: Partition,
+    pub sk: PendingRewardKey,
 
     pub created_at: i64,
-    pub target_pk: String,
-    pub owner_pk: String,
-    pub space_pk: String,
-    pub reward_key: String,
+
+    pub target_pk: Partition,
+    #[serde(default)]
+    pub owner_pk: Option<Partition>,
+    pub space_pk: Partition,
+    pub reward_key: RewardKey,
     pub amount: i64,
     pub description: String,
-    pub status: String,
+
+    #[dynamo(prefix = "PR_STATUS", name = "find_by_status", index = "gsi1", pk)]
+    pub status: PendingRewardStatus,
+    #[dynamo(prefix = "TS", index = "gsi1", sk)]
+    #[serde(default)]
+    pub updated_at: i64,
+
     pub retry_count: i64,
+    #[serde(default)]
+    pub last_error: String,
 }
 
 #[cfg(feature = "server")]
@@ -21,24 +35,31 @@ impl PendingReward {
     pub fn new(
         target_pk: &Partition,
         space_pk: &Partition,
-        reward_key: &str,
+        reward_key: &RewardKey,
         amount: i64,
         description: &str,
         owner_pk: Option<&Partition>,
     ) -> Self {
         let now = get_now_timestamp_millis();
-        Self {
-            pk: "PENDING_REWARD".to_string(),
-            sk: format!("PENDING_REWARD#{}#{}#{}", now, target_pk, reward_key),
+        let sk = PendingRewardKey {
             created_at: now,
-            target_pk: target_pk.to_string(),
-            owner_pk: owner_pk.map(|p| p.to_string()).unwrap_or_default(),
-            space_pk: space_pk.to_string(),
-            reward_key: reward_key.to_string(),
+            target_pk: target_pk.clone(),
+            reward_key: reward_key.clone(),
+        };
+        Self {
+            pk: Partition::PendingReward,
+            sk,
+            created_at: now,
+            target_pk: target_pk.clone(),
+            owner_pk: owner_pk.cloned(),
+            space_pk: space_pk.clone(),
+            reward_key: reward_key.clone(),
             amount,
             description: description.to_string(),
-            status: "pending".to_string(),
+            status: PendingRewardStatus::Pending,
+            updated_at: now,
             retry_count: 0,
+            last_error: String::new(),
         }
     }
 }

--- a/app/ratel/src/common/services/biyard/mod.rs
+++ b/app/ratel/src/common/services/biyard/mod.rs
@@ -6,6 +6,8 @@ use super::ServiceError;
 use reqwest;
 #[cfg(feature = "server")]
 use serde::de::DeserializeOwned;
+#[cfg(feature = "server")]
+use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct TokenResponse {
@@ -150,8 +152,15 @@ impl BiyardService {
             reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_secret)).unwrap(),
         );
 
+        // Bound the request lifecycle so a hung connection (e.g. missing
+        // NAT path to api.biyard.co) returns Err inside the Lambda
+        // invocation timeout (30s) and lets the caller's PendingReward
+        // fallback execute, instead of leaving the future stuck on .await
+        // until the runtime kills the process and skips the catch arm.
         let cli = reqwest::Client::builder()
             .default_headers(headers)
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(20))
             .build()
             .unwrap();
 

--- a/app/ratel/src/common/services/mod.rs
+++ b/app/ratel/src/common/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod biyard;
 mod error;
 pub mod icp;
+pub mod pending_reward_retry;
 pub mod persistent_state;
 pub use biyard::*;
 pub use error::ServiceError;

--- a/app/ratel/src/common/services/pending_reward_retry.rs
+++ b/app/ratel/src/common/services/pending_reward_retry.rs
@@ -1,0 +1,181 @@
+use serde::{Deserialize, Serialize};
+
+use crate::common::models::reward::PendingReward;
+use crate::common::types::PendingRewardStatus;
+use crate::common::utils::time::get_now_timestamp_millis;
+use crate::common::*;
+
+const BATCH_LIMIT: i32 = 50;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct RetryStats {
+    pub scanned: usize,
+    pub succeeded: usize,
+    pub still_pending: usize,
+    pub still_pending_rows: Vec<PendingFailureSnapshot>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PendingFailureSnapshot {
+    pub sk: String,
+    pub target_pk: String,
+    pub amount: i64,
+    pub retry_count: i64,
+    pub last_error: String,
+    pub created_at: i64,
+}
+
+#[cfg(feature = "server")]
+pub async fn retry_pending_rewards(cli: &aws_sdk_dynamodb::Client) -> Result<RetryStats> {
+    let cfg = crate::common::CommonConfig::default();
+    let biyard = cfg.biyard();
+
+    let mut stats = RetryStats::default();
+    let mut bookmark: Option<String> = None;
+
+    loop {
+        let opt = PendingReward::opt_with_bookmark(bookmark.clone()).limit(BATCH_LIMIT);
+        let (items, next) =
+            PendingReward::find_by_status(cli, PendingRewardStatus::Pending, opt).await?;
+
+        for item in items {
+            stats.scanned += 1;
+
+            // Anchor the Biyard transaction to the original month so a
+            // backfilled outage row doesn't get billed against a later month.
+            let month = format_yyyy_mm(item.created_at);
+            let description = retry_description(&item);
+            let target_pk = item.target_pk.clone();
+            let owner_pk = item.owner_pk.clone();
+
+            match biyard
+                .award_points(
+                    target_pk.clone(),
+                    item.amount,
+                    description.clone(),
+                    Some(month),
+                )
+                .await
+            {
+                Ok(user_res) => {
+                    if let Some(owner) = owner_pk {
+                        if owner != target_pk && item.amount > 0 {
+                            let owner_amount = item.amount * 10 / 100;
+                            if owner_amount > 0 {
+                                if let Err(e) = biyard
+                                    .award_points(
+                                        owner.clone(),
+                                        owner_amount,
+                                        description.clone(),
+                                        Some(user_res.month.clone()),
+                                    )
+                                    .await
+                                {
+                                    tracing::error!(
+                                        owner_pk = %owner,
+                                        sk = %item.sk,
+                                        error = %e,
+                                        "owner referral retry failed (main award succeeded)",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    let _ = mark_completed(cli, &item).await;
+                    stats.succeeded += 1;
+                }
+                Err(e) => {
+                    let last_error = format!("{e}");
+                    let _ = bump_retry(cli, &item, &last_error).await;
+                    let next_retry_count = item.retry_count + 1;
+                    stats.still_pending += 1;
+                    stats.still_pending_rows.push(PendingFailureSnapshot {
+                        sk: item.sk.to_string(),
+                        target_pk: item.target_pk.to_string(),
+                        amount: item.amount,
+                        retry_count: next_retry_count,
+                        last_error: last_error.clone(),
+                        created_at: item.created_at,
+                    });
+                    tracing::warn!(
+                        sk = %item.sk,
+                        retry = next_retry_count,
+                        error = %e,
+                        "pending reward retry failed",
+                    );
+                }
+            }
+        }
+
+        bookmark = next;
+        if bookmark.is_none() {
+            break;
+        }
+    }
+
+    tracing::info!(
+        scanned = stats.scanned,
+        succeeded = stats.succeeded,
+        still_pending = stats.still_pending,
+        "pending reward retry completed",
+    );
+
+    Ok(stats)
+}
+
+fn retry_description(item: &PendingReward) -> String {
+    let marker = format!("retry-{}", item.sk);
+    if item.description.is_empty() {
+        marker
+    } else {
+        format!("{} | {}", item.description, marker)
+    }
+}
+
+fn format_yyyy_mm(ts_ms: i64) -> String {
+    let secs = ts_ms / 1000;
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
+        .unwrap_or_else(chrono::Utc::now);
+    dt.format("%Y-%m").to_string()
+}
+
+#[cfg(feature = "server")]
+async fn mark_completed(
+    cli: &aws_sdk_dynamodb::Client,
+    item: &PendingReward,
+) -> Result<()> {
+    let now = get_now_timestamp_millis();
+    PendingReward::updater(&item.pk, &item.sk)
+        .with_status(PendingRewardStatus::Completed)
+        .with_updated_at(now)
+        .execute(cli)
+        .await?;
+    Ok(())
+}
+
+#[cfg(feature = "server")]
+async fn bump_retry(
+    cli: &aws_sdk_dynamodb::Client,
+    item: &PendingReward,
+    last_error: &str,
+) -> Result<()> {
+    let now = get_now_timestamp_millis();
+    PendingReward::updater(&item.pk, &item.sk)
+        .with_updated_at(now)
+        .with_retry_count(item.retry_count + 1)
+        .with_last_error(last_error.to_string())
+        .execute(cli)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_yyyy_mm_returns_utc_month() {
+        assert_eq!(format_yyyy_mm(1776817749390), "2026-04");
+        assert_eq!(format_yyyy_mm(1735689600000), "2025-01");
+    }
+}

--- a/app/ratel/src/common/services/pending_reward_retry.rs
+++ b/app/ratel/src/common/services/pending_reward_retry.rs
@@ -43,7 +43,9 @@ pub async fn retry_pending_rewards(cli: &aws_sdk_dynamodb::Client) -> Result<Ret
 
             // Anchor the Biyard transaction to the original month so a
             // backfilled outage row doesn't get billed against a later month.
-            let month = format_yyyy_mm(item.created_at);
+            // An invalid `created_at` would break this invariant, so we
+            // fail-fast rather than silently fall back to the current month.
+            let month = format_yyyy_mm(item.created_at)?;
             let description = retry_description(&item);
             let target_pk = item.target_pk.clone();
             let owner_pk = item.owner_pk.clone();
@@ -81,12 +83,28 @@ pub async fn retry_pending_rewards(cli: &aws_sdk_dynamodb::Client) -> Result<Ret
                             }
                         }
                     }
-                    let _ = mark_completed(cli, &item).await;
+                    // Mark COMPLETED so the next retry sweep skips this
+                    // row. If this fails after a successful Biyard award,
+                    // a subsequent sweep would re-award (double-pay), so
+                    // surface it loudly for an operator to reconcile.
+                    if let Err(e) = mark_completed(cli, &item).await {
+                        tracing::error!(
+                            sk = %item.sk,
+                            error = %e,
+                            "CRITICAL: biyard award succeeded but mark_completed failed — may double-pay on next retry",
+                        );
+                    }
                     stats.succeeded += 1;
                 }
                 Err(e) => {
                     let last_error = format!("{e}");
-                    let _ = bump_retry(cli, &item, &last_error).await;
+                    if let Err(bump_err) = bump_retry(cli, &item, &last_error).await {
+                        tracing::error!(
+                            sk = %item.sk,
+                            error = %bump_err,
+                            "failed to bump retry counter — counter and last_error may be stale",
+                        );
+                    }
                     let next_retry_count = item.retry_count + 1;
                     stats.still_pending += 1;
                     stats.still_pending_rows.push(PendingFailureSnapshot {
@@ -132,11 +150,13 @@ fn retry_description(item: &PendingReward) -> String {
     }
 }
 
-fn format_yyyy_mm(ts_ms: i64) -> String {
+fn format_yyyy_mm(ts_ms: i64) -> Result<String> {
     let secs = ts_ms / 1000;
-    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
-        .unwrap_or_else(chrono::Utc::now);
-    dt.format("%Y-%m").to_string()
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0).ok_or_else(|| {
+        crate::error!("invalid created_at_ms: {ts_ms} — cannot derive month");
+        Error::InvalidFormat
+    })?;
+    Ok(dt.format("%Y-%m").to_string())
 }
 
 #[cfg(feature = "server")]
@@ -175,7 +195,13 @@ mod tests {
 
     #[test]
     fn format_yyyy_mm_returns_utc_month() {
-        assert_eq!(format_yyyy_mm(1776817749390), "2026-04");
-        assert_eq!(format_yyyy_mm(1735689600000), "2025-01");
+        assert_eq!(format_yyyy_mm(1776817749390).unwrap(), "2026-04");
+        assert_eq!(format_yyyy_mm(1735689600000).unwrap(), "2025-01");
+    }
+
+    #[test]
+    fn format_yyyy_mm_rejects_out_of_range_timestamp() {
+        // i64::MAX seconds is far past chrono's representable range.
+        assert!(format_yyyy_mm(i64::MAX).is_err());
     }
 }

--- a/app/ratel/src/common/types/partition.rs
+++ b/app/ratel/src/common/types/partition.rs
@@ -88,6 +88,8 @@ pub enum Partition {
 
     Reward, // For space rewards, SPACE#{space_id}##REWARD
 
+    PendingReward,
+
     /// Singleton config row controlling the analyze-page creation
     /// quota for non-enterprise tiers. One row per deployment.
     AnalyzeQuotaConfig,

--- a/app/ratel/src/common/types/reward/mod.rs
+++ b/app/ratel/src/common/types/reward/mod.rs
@@ -1,4 +1,6 @@
 mod error;
+mod pending_reward_key;
+mod pending_reward_status;
 mod reward_action;
 mod reward_condition;
 mod reward_key;
@@ -7,6 +9,8 @@ mod reward_user_behavior;
 mod user_reward_history_key;
 
 pub use error::*;
+pub use pending_reward_key::*;
+pub use pending_reward_status::*;
 pub use reward_action::*;
 pub use reward_condition::*;
 pub use reward_key::*;

--- a/app/ratel/src/common/types/reward/pending_reward_key.rs
+++ b/app/ratel/src/common/types/reward/pending_reward_key.rs
@@ -90,4 +90,31 @@ mod tests {
         let s = "PENDING_REWARD#1234#FEED#abc#REWARD##RESPOND_POLL";
         assert!(s.parse::<PendingRewardKey>().is_err());
     }
+
+    /// DynamoDB sort keys are compared lexicographically, so callers that
+    /// page through `PENDING_REWARD#*` expecting chronological order need
+    /// `created_at` segments to share a width. All production rows use
+    /// 13-digit millisecond timestamps, so the invariant holds — this test
+    /// pins that.
+    #[test]
+    fn lexicographic_order_matches_timestamp_at_fixed_width() {
+        let mut a = sample();
+        a.created_at = 1_000_000_000_000; // 13 digits
+        let mut b = sample();
+        b.created_at = 2_000_000_000_000; // 13 digits
+        assert!(a.to_string() < b.to_string());
+    }
+
+    /// Counter-example: mixing digit counts inverts lexicographic order
+    /// vs numeric order. Kept as a guard rail — if we ever ingest
+    /// non-millisecond timestamps, this test will start failing and force
+    /// us to revisit zero-padding the `created_at` segment.
+    #[test]
+    fn lexicographic_order_breaks_at_different_digit_count() {
+        let mut a = sample();
+        a.created_at = 9_999_999_999; // 10 digits
+        let mut b = sample();
+        b.created_at = 10_000_000_000; // 11 digits, numerically larger
+        assert!(a.to_string() > b.to_string());
+    }
 }

--- a/app/ratel/src/common/types/reward/pending_reward_key.rs
+++ b/app/ratel/src/common/types/reward/pending_reward_key.rs
@@ -1,0 +1,93 @@
+use std::{fmt::Display, str::FromStr};
+
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+use crate::common::*;
+
+#[derive(Debug, Default, Clone, SerializeDisplay, DeserializeFromStr, PartialEq, Eq)]
+pub struct PendingRewardKey {
+    pub created_at: i64,
+    pub target_pk: Partition,
+    pub reward_key: RewardKey,
+}
+
+impl Display for PendingRewardKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PENDING_REWARD#{}#{}#{}",
+            self.created_at, self.target_pk, self.reward_key
+        )
+    }
+}
+
+impl FromStr for PendingRewardKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let s = s
+            .strip_prefix("PENDING_REWARD#")
+            .ok_or(Error::InvalidFormat)?;
+
+        let (ts_str, rest) = s.split_once('#').ok_or(Error::InvalidFormat)?;
+        let created_at: i64 = ts_str.parse().map_err(|_| Error::InvalidFormat)?;
+
+        let (target_pk, rk_str) = if let Some(rest2) = rest.strip_prefix("USER#") {
+            let (uid, rk) = rest2.split_once('#').ok_or(Error::InvalidFormat)?;
+            (Partition::User(uid.to_string()), rk)
+        } else if let Some(rest2) = rest.strip_prefix("TEAM#") {
+            let (tid, rk) = rest2.split_once('#').ok_or(Error::InvalidFormat)?;
+            (Partition::Team(tid.to_string()), rk)
+        } else {
+            return Err(Error::InvalidFormat);
+        };
+
+        let reward_key = RewardKey::from_str(rk_str)?;
+
+        Ok(PendingRewardKey {
+            created_at,
+            target_pk,
+            reward_key,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> PendingRewardKey {
+        PendingRewardKey {
+            created_at: 1776817749390,
+            target_pk: Partition::User("5afecfb0-1278-48f8-a782-76ba2badfb46".into()),
+            reward_key: RewardKey::from((
+                SpacePartition("019d70df-dfc0-7222-be71-e55c2bd8121a".into()),
+                "019d9e8a-29a9-7a92-935f-cfa709e992c4".to_string(),
+                RewardUserBehavior::QuizAnswer,
+            )),
+        }
+    }
+
+    #[test]
+    fn roundtrip_display_fromstr() {
+        let k = sample();
+        let s = k.to_string();
+        assert!(s.starts_with("PENDING_REWARD#1776817749390#USER#5afecfb0"));
+        let parsed: PendingRewardKey = s.parse().unwrap();
+        assert_eq!(parsed, k);
+    }
+
+    #[test]
+    fn parses_team_target() {
+        let s = "PENDING_REWARD#1234#TEAM#840#REWARD##RESPOND_POLL";
+        let k: PendingRewardKey = s.parse().unwrap();
+        assert_eq!(k.created_at, 1234);
+        assert_eq!(k.target_pk, Partition::Team("840".into()));
+    }
+
+    #[test]
+    fn rejects_unknown_actor_prefix() {
+        let s = "PENDING_REWARD#1234#FEED#abc#REWARD##RESPOND_POLL";
+        assert!(s.parse::<PendingRewardKey>().is_err());
+    }
+}

--- a/app/ratel/src/common/types/reward/pending_reward_status.rs
+++ b/app/ratel/src/common/types/reward/pending_reward_status.rs
@@ -1,0 +1,45 @@
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+// Case-insensitive parse keeps legacy rows that wrote "pending" decoding.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Default,
+    SerializeDisplay,
+    DeserializeFromStr,
+    strum::Display,
+    strum::EnumString,
+)]
+#[strum(serialize_all = "UPPERCASE", ascii_case_insensitive)]
+pub enum PendingRewardStatus {
+    #[default]
+    Pending,
+    Completed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_uses_screaming_snake() {
+        assert_eq!(PendingRewardStatus::Pending.to_string(), "PENDING");
+        assert_eq!(PendingRewardStatus::Completed.to_string(), "COMPLETED");
+    }
+
+    #[test]
+    fn from_str_is_case_insensitive() {
+        assert_eq!(
+            "pending".parse::<PendingRewardStatus>().unwrap(),
+            PendingRewardStatus::Pending
+        );
+    }
+
+    #[test]
+    fn unknown_variant_errors() {
+        assert!("bogus".parse::<PendingRewardStatus>().is_err());
+    }
+}

--- a/app/ratel/src/features/admin/controllers/internal/mod.rs
+++ b/app/ratel/src/features/admin/controllers/internal/mod.rs
@@ -1,0 +1,3 @@
+mod run_pending_reward_retry;
+
+pub use run_pending_reward_retry::*;

--- a/app/ratel/src/features/admin/controllers/internal/run_pending_reward_retry.rs
+++ b/app/ratel/src/features/admin/controllers/internal/run_pending_reward_retry.rs
@@ -1,0 +1,10 @@
+use crate::common::models::auth::AdminUser;
+use crate::common::services::pending_reward_retry::RetryStats;
+use crate::features::admin::*;
+
+#[post("/api/admin/internal/run-pending-reward-retry", _user: AdminUser)]
+pub async fn run_pending_reward_retry() -> Result<RetryStats> {
+    let common_config = crate::common::CommonConfig::default();
+    let cli = common_config.dynamodb();
+    crate::common::services::pending_reward_retry::retry_pending_rewards(cli).await
+}

--- a/app/ratel/src/features/admin/controllers/mod.rs
+++ b/app/ratel/src/features/admin/controllers/mod.rs
@@ -1,8 +1,10 @@
 pub mod analyze_quota;
+pub mod internal;
 pub mod migrations;
 pub mod memberships;
 pub mod rewards;
 pub use analyze_quota::*;
+pub use internal::*;
 pub use migrations::*;
 pub use memberships::*;
 pub use rewards::*;

--- a/app/ratel/src/features/character/tests/helpers.rs
+++ b/app/ratel/src/features/character/tests/helpers.rs
@@ -53,13 +53,29 @@ where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = T>,
 {
-    let prev = std::env::var(key).ok();
-    std::env::set_var(key, val);
+    run_with_envs(&[(key, val)], f).await
+}
+
+/// Same as `run_with_env` but sets multiple vars atomically.
+pub async fn run_with_envs<F, Fut, T>(pairs: &[(&str, &str)], f: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    let prev: Vec<(String, Option<String>)> = pairs
+        .iter()
+        .map(|(k, v)| {
+            let p = std::env::var(k).ok();
+            std::env::set_var(k, v);
+            ((*k).to_string(), p)
+        })
+        .collect();
     let r = f().await;
-    if let Some(p) = prev {
-        std::env::set_var(key, p);
-    } else {
-        std::env::remove_var(key);
+    for (k, p) in prev {
+        match p {
+            Some(v) => std::env::set_var(&k, v),
+            None => std::env::remove_var(&k),
+        }
     }
     r
 }

--- a/app/ratel/src/features/character/tests/migration_tests.rs
+++ b/app/ratel/src/features/character/tests/migration_tests.rs
@@ -78,19 +78,34 @@ async fn test_run_migrations_runs_m001() {
     s.total_score = 5_000;
     s.create(&ctx.ddb).await.unwrap();
 
+    // Exercise the real `run_migrations` entry point so this test actually
+    // covers the runner's "stored < 1 → run m001" branch. m002 runs in the
+    // same pass and demands `M002_CSV_PATH`; feed it a header-only CSV so it
+    // walks zero rows and returns Ok without affecting what we assert here.
+    let csv = unique_csv_path("m001-runs-noop");
+    std::fs::write(&csv, "user_id,amount,created_at_ms,reward_key\n").unwrap();
+    let path = csv.to_string_lossy().to_string();
+
     let ddb = ctx.ddb.clone();
-    run_with_env("MIGRATE", "true", move || async move {
-        crate::common::migrations::run_migrations(&ddb).await.unwrap();
-    })
+    run_with_envs(
+        &[("MIGRATE", "true"), ("M002_CSV_PATH", &path)],
+        move || async move {
+            crate::common::migrations::run_migrations(&ddb).await.unwrap();
+        },
+    )
     .await;
 
-    // Verify version advanced.
+    let _ = std::fs::remove_file(&csv);
+
+    // Verify the runner advanced past m001. m002 ran on a header-only CSV
+    // (no rows) and bumps the version to 2 as well — that's expected, the
+    // signal we care about is "m001 executed", confirmed via CharacterXp below.
     let (pk, sk) = LastBackfillVersion::singleton_keys();
     let row = LastBackfillVersion::get(&ctx.ddb, &pk, Some(&sk))
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(row.version, 1);
+    assert_eq!(row.version, 2);
 
     // Verify CharacterXp seeded.
     use crate::features::character::models::CharacterXp;
@@ -107,7 +122,11 @@ async fn test_run_migrations_runs_m001() {
 async fn test_run_migrations_idempotent_at_version() {
     let ctx = TestContext::setup().await;
     reset_migration_state(&ctx.ddb).await;
+    // Pre-advance to the latest known migration version so `run_migrations`
+    // has nothing to do. Bumping this whenever a new migration lands keeps
+    // the "already at HEAD = no-op" invariant honest.
     LastBackfillVersion::advance_to(&ctx.ddb, 0, 1).await.unwrap();
+    LastBackfillVersion::advance_to(&ctx.ddb, 1, 2).await.unwrap();
 
     let ddb = ctx.ddb.clone();
     run_with_env("MIGRATE", "true", move || async move {
@@ -120,7 +139,7 @@ async fn test_run_migrations_idempotent_at_version() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(row.version, 1, "no further migrations to run");
+    assert_eq!(row.version, 2, "no further migrations to run");
 }
 
 // ── m002 (backfill_pending_rewards) ──────────────────────────────
@@ -167,7 +186,10 @@ async fn test_run_migrations_runs_m002() {
         .unwrap();
     assert_eq!(row.version, 2);
 
-    // Both rows landed under the outage-backfill description.
+    // Both rows landed under the outage-backfill description. The shared
+    // PendingReward table can carry rows from sibling tests (e.g. the
+    // idempotency test below), so filter on *this* test's user_ids — not
+    // just `description == "outage-backfill"`.
     use crate::common::models::reward::PendingReward;
     let (items, _) = PendingReward::find_by_status(
         &ctx.ddb,
@@ -176,11 +198,13 @@ async fn test_run_migrations_runs_m002() {
     )
     .await
     .unwrap();
-    let m002_rows: Vec<_> = items
+    let mine: Vec<_> = items
         .iter()
         .filter(|r| r.description == "outage-backfill")
+        .filter(|r| matches!(&r.target_pk,
+            Partition::User(u) if u == "test-m002-runs-a" || u == "test-m002-runs-b"))
         .collect();
-    assert_eq!(m002_rows.len(), 2);
+    assert_eq!(mine.len(), 2);
 
     let _ = std::fs::remove_file(&csv);
 }

--- a/app/ratel/src/features/character/tests/migration_tests.rs
+++ b/app/ratel/src/features/character/tests/migration_tests.rs
@@ -122,3 +122,148 @@ async fn test_run_migrations_idempotent_at_version() {
         .unwrap();
     assert_eq!(row.version, 1, "no further migrations to run");
 }
+
+// ── m002 (backfill_pending_rewards) ──────────────────────────────
+
+fn unique_csv_path(label: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("m002_{label}_{nanos}.csv"))
+}
+
+#[tokio::test]
+async fn test_run_migrations_runs_m002() {
+    let ctx = TestContext::setup().await;
+    reset_migration_state(&ctx.ddb).await;
+    // Skip past m001 so this test isolates m002 behavior.
+    LastBackfillVersion::advance_to(&ctx.ddb, 0, 1).await.unwrap();
+
+    let csv = unique_csv_path("runs");
+    std::fs::write(
+        &csv,
+        "user_id,amount,created_at_ms,reward_key\n\
+         test-m002-runs-a,30000,1776590280000,SPACE_REWARD##019d70df-dfc0-7222-be71-e55c2bd8121a##ref-a##QUIZ_ANSWER\n\
+         test-m002-runs-b,20000,1776590281000,SPACE_REWARD##019d70df-dfc0-7222-be71-e55c2bd8121a##ref-b##RESPOND_POLL\n",
+    )
+    .unwrap();
+    let path = csv.to_string_lossy().to_string();
+
+    let ddb = ctx.ddb.clone();
+    run_with_envs(
+        &[("MIGRATE", "true"), ("M002_CSV_PATH", &path)],
+        move || async move {
+            crate::common::migrations::run_migrations(&ddb).await.unwrap();
+        },
+    )
+    .await;
+
+    // Version advanced to 2.
+    let (pk, sk) = LastBackfillVersion::singleton_keys();
+    let row = LastBackfillVersion::get(&ctx.ddb, &pk, Some(&sk))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.version, 2);
+
+    // Both rows landed under the outage-backfill description.
+    use crate::common::models::reward::PendingReward;
+    let (items, _) = PendingReward::find_by_status(
+        &ctx.ddb,
+        PendingRewardStatus::Pending,
+        PendingReward::opt().limit(100),
+    )
+    .await
+    .unwrap();
+    let m002_rows: Vec<_> = items
+        .iter()
+        .filter(|r| r.description == "outage-backfill")
+        .collect();
+    assert_eq!(m002_rows.len(), 2);
+
+    let _ = std::fs::remove_file(&csv);
+}
+
+#[tokio::test]
+async fn test_m002_aborts_when_csv_path_unset() {
+    let ctx = TestContext::setup().await;
+    reset_migration_state(&ctx.ddb).await;
+    LastBackfillVersion::advance_to(&ctx.ddb, 0, 1).await.unwrap();
+
+    let ddb = ctx.ddb.clone();
+    run_with_env("MIGRATE", "true", move || async move {
+        // Ensure no prior test left M002_CSV_PATH lying around.
+        std::env::remove_var("M002_CSV_PATH");
+        let res = crate::common::migrations::run_migrations(&ddb).await;
+        assert!(res.is_err(), "m002 must fail when M002_CSV_PATH is unset");
+    })
+    .await;
+
+    // Version must not advance past m001.
+    let (pk, sk) = LastBackfillVersion::singleton_keys();
+    let row = LastBackfillVersion::get(&ctx.ddb, &pk, Some(&sk))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.version, 1, "failed m002 must not bump version");
+}
+
+#[tokio::test]
+async fn test_m002_idempotent_on_rerun() {
+    let ctx = TestContext::setup().await;
+    reset_migration_state(&ctx.ddb).await;
+    LastBackfillVersion::advance_to(&ctx.ddb, 0, 1).await.unwrap();
+
+    let csv = unique_csv_path("idem");
+    std::fs::write(
+        &csv,
+        "user_id,amount,created_at_ms,reward_key\n\
+         test-m002-idem,30000,1776590280000,SPACE_REWARD##019d70df-dfc0-7222-be71-e55c2bd8121a##ref-i##QUIZ_ANSWER\n",
+    )
+    .unwrap();
+    let path = csv.to_string_lossy().to_string();
+
+    // First run.
+    let ddb1 = ctx.ddb.clone();
+    let p1 = path.clone();
+    run_with_envs(
+        &[("MIGRATE", "true"), ("M002_CSV_PATH", &p1)],
+        move || async move {
+            crate::common::migrations::m002_backfill_pending_rewards::run(&ddb1)
+                .await
+                .unwrap();
+        },
+    )
+    .await;
+
+    // Second run on the same CSV — conditional PutItem must skip every row.
+    let ddb2 = ctx.ddb.clone();
+    let p2 = path.clone();
+    run_with_envs(
+        &[("MIGRATE", "true"), ("M002_CSV_PATH", &p2)],
+        move || async move {
+            crate::common::migrations::m002_backfill_pending_rewards::run(&ddb2)
+                .await
+                .unwrap();
+        },
+    )
+    .await;
+
+    // Still exactly one row for our test user.
+    use crate::common::models::reward::PendingReward;
+    let (items, _) = PendingReward::find_by_status(
+        &ctx.ddb,
+        PendingRewardStatus::Pending,
+        PendingReward::opt().limit(100),
+    )
+    .await
+    .unwrap();
+    let mine: Vec<_> = items
+        .iter()
+        .filter(|r| r.target_pk == Partition::User("test-m002-idem".into()))
+        .collect();
+    assert_eq!(mine.len(), 1, "rerun must not duplicate");
+
+    let _ = std::fs::remove_file(&csv);
+}

--- a/app/ratel/src/features/spaces/space_common/models/space_reward.rs
+++ b/app/ratel/src/features/spaces/space_common/models/space_reward.rs
@@ -353,7 +353,7 @@ impl SpaceReward {
                 let _ = PendingReward::new(
                     &target_pk,
                     &space_pk,
-                    &space_reward.sk.to_string(),
+                    &space_reward.sk,
                     amount,
                     &space_reward.description,
                     owner_pk.as_ref(),

--- a/cdk/lib/dynamo-stream-event.ts
+++ b/cdk/lib/dynamo-stream-event.ts
@@ -1821,5 +1821,6 @@ export class DynamoStreamEventStack extends Stack {
       },
       targets: [new eventsTargets.LambdaFunction(props.lambdaFunction)],
     });
+
   }
 }


### PR DESCRIPTION
## 요약
- 2026-04-19/20 Biyard 장애로 지급되지 못한 보상을 복구하기 위한 `PendingReward` 모델 + CSV 기반 `m002` 마이그레이션 추가. Conditional PutItem 으로 멱등 보장.
- `PENDING` 상태 row 를 Biyard 로 흘려보내는 관리자 전용 재시도 엔드포인트 추가. 원래 발생 월(`created_at`)을 보존해서 4월에 적립된 포인트는 4월로 청구됨.
- 재시도 파이프라인 보강: DDB 쓰기 실패를 묵살하지 않고 로깅(이중 지급 위험 제거), `format_yyyy_mm` 을 `Result` 로 바꿔 잘못된 timestamp 에서 fail-fast, composite sort key 의 사전순 정렬 invariant 를 테스트로 명시.

## 주요 변경
- `PendingReward` 엔티티 — composite key `(created_at | target_pk | reward_key)`, status `PENDING / COMPLETED`.
- `m002_backfill_pending_rewards.rs` — `M002_CSV_PATH` 환경변수로 CSV 경로 받아서 `attribute_not_exists` 조건부 PutItem 으로 적재. 재실행 시 자동 skip.
- 재시도 서비스 — `PENDING` 상태 row 를 50개씩 배치 스캔, `biyard.award_points` 호출 (월은 `created_at` 기준), 성공 시 `COMPLETED` 마킹, 실패 시 retry_count 증가 + `last_error` 기록.
- `POST /api/admin/internal/run-pending-reward-retry` — `AdminUser` 가드, 자동 스케줄러 없음 (운영자가 시점 정해서 직접 호출).
- m002 통합 테스트 3종: happy path, 환경변수 누락 시 abort, 재실행 멱등성.

## 테스트 플랜
- [x] `cargo check --features server` 통과
- [x] 단위 테스트 통과 (`format_yyyy_mm`, `PendingRewardKey` 사전순 정렬)
- [x] LocalStack 수동 e2e: m002 멱등성 + mock Biyard 로 재시도 파이프라인 검증 완료 (5/5 written → 재실행 5/5 already_present → 재시도 10/10 succeeded)
- [ ] CI: 서버 통합 테스트 + Playwright

## 운영 노트
머지 후 release 당 **단 하나의 app-shell 인스턴스** 에서만 `M002_CSV_PATH=<경로>` + `MIGRATE=true` 설정. 재시도 엔드포인트는 수동 — Biyard 측에 백필 row 가 들어간 게 확인되면 그때 호출.
