### PR TITLE
fix(docs): make mobile drawer opaque and expose locale + theme toggle in top bar

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -70,16 +70,23 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      // The desktop navbar is hidden by the swizzled `theme/Navbar/Layout`
-      // (mobile keeps the default behavior so users can open the doc-nav drawer).
-      // Logo, locale dropdown, theme toggle, and GitHub link are owned by
-      // the swizzled `theme/DocRoot/Layout/Sidebar` component
-      // (`docs/src/theme/DocRoot/Layout/Sidebar/index.tsx`).
+      // Desktop (>=996px): the entire navbar is hidden by the swizzled
+      // `theme/Navbar/Layout` — logo, locale, theme toggle, github icon all
+      // live in the swizzled `theme/DocRoot/Layout/Sidebar`.
+      // Mobile (<996px): the top navbar shows hamburger | logo on the left
+      // and locale dropdown + theme toggle on the right. The custom CSS in
+      // `custom.css` reverses Infima's "hide-on-mobile" defaults so these
+      // items are visible without opening the drawer.
       logo: {
         alt: "Ratel Logo",
         src: "img/logo.png",
       },
-      items: [],
+      items: [
+        {
+          type: "localeDropdown",
+          position: "right",
+        },
+      ],
     },
     // Footer intentionally omitted — site has no footer.
     prism: {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -154,6 +154,62 @@ body {
   display: none;
 }
 
+/* --- Mobile navbar + drawer: solid background ---------------------------
+   Infima's `.navbar` and `.navbar-sidebar` both pull from
+   `--ifm-navbar-background-color`, which we set to `transparent` so the
+   desktop chrome blends with the body. That same rule makes the mobile
+   top navbar and the mobile menu drawer see-through — body text bleeds
+   through the menu. Force a solid surface on mobile only. */
+@media (max-width: 996px) {
+  .navbar,
+  .navbar-sidebar,
+  .navbar-sidebar__brand {
+    background-color: var(--ifm-background-color);
+  }
+
+  [data-theme="dark"] .navbar,
+  [data-theme="dark"] .navbar-sidebar,
+  [data-theme="dark"] .navbar-sidebar__brand {
+    background-color: var(--ratel-bg);
+  }
+
+  /* Subtle separator under the mobile top navbar so the content scroll
+     edge is visible against the now-opaque bar. */
+  [data-theme="dark"] .navbar {
+    border-bottom: 1px solid var(--ratel-line-soft);
+  }
+
+  /* Reverse Infima's mobile defaults so the locale dropdown and color-mode
+     toggle render in the mobile top navbar (right side), instead of being
+     hidden until the user opens the hamburger drawer.
+     - Infima sets `.navbar__item { display: none }` at <=996px.
+     - theme-classic sets `Navbar/Content/styles.module.css .colorModeToggle
+       { display: none }` at <=996px (hashed class, hence the attr selector).
+   */
+  .navbar__items--right .navbar__item {
+    display: flex;
+    align-items: center;
+  }
+  .navbar__items--right > [class*="colorModeToggle"] {
+    display: inline-flex !important;
+  }
+
+  /* Compact the locale dropdown so it fits next to the theme toggle. */
+  .navbar__items--right .navbar__item.dropdown .navbar__link {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.85rem;
+    color: var(--ifm-navbar-link-color);
+  }
+  /* Hide the dropdown caret triangle — globe icon + label is enough */
+  .navbar__items--right .navbar__item.dropdown .navbar__link::after {
+    display: none;
+  }
+  [data-theme="dark"] .navbar__items--right .dropdown__menu {
+    background: var(--ratel-card-2);
+    border: 1px solid var(--ratel-line);
+  }
+}
+
 /* --- Desktop layout ---------------------------------------------------- */
 @media (min-width: 996px) {
   :root {


### PR DESCRIPTION
## Summary

- **Mobile drawer transparency.** The docs dark theme sets `--ifm-navbar-background-color: transparent` so the desktop chrome blends with the body. On mobile that rule leaked into `.navbar`, `.navbar-sidebar`, and `.navbar-sidebar__brand`, so body copy was readable through the hamburger menu. Force a solid surface inside the `<= 996px` breakpoint.
- **Locale switcher reachable from the mobile top bar.** Previously the only way to change language on mobile was to open the hamburger drawer and tap "Back to main menu". Added a `localeDropdown` to `themeConfig.navbar.items` and reversed the two CSS rules that hide it (and the color-mode toggle) on mobile:
  - Infima's `@media (max-width: 996px) { .navbar__item { display: none } }`
  - theme-classic's hashed `.colorModeToggle { display: none }` (matched via `[class*="colorModeToggle"]`)
- Desktop layout is untouched — the entire navbar is still hidden by the swizzled `theme/Navbar/Layout`, and `theme/DocRoot/Layout/Sidebar` continues to own the desktop logo / locale / theme / github chrome.

## Why

Two user-visible regressions on mobile:
1. Menu drawer was see-through against the page content.
2. No way to switch between EN/한국어 from the visible chrome — required two extra taps inside the drawer.

## Test plan

- [ ] Mobile width (<= 996px): top bar shows hamburger | logo on the left, language dropdown + theme toggle on the right.
- [ ] Tapping the hamburger opens a drawer with an opaque background — body copy no longer bleeds through.
- [ ] Light and dark mode both render the drawer with a solid background.
- [ ] Desktop width (>= 996px) is unchanged — sidebar-as-chrome layout, no top navbar.

Generated with [Claude Code](https://claude.com/claude-code)
