### PR TITLE
feat(editor): selection-triggered bubble toolbar

### DIFF
--- a/app/ratel/assets/main.css
+++ b/app/ratel/assets/main.css
@@ -2383,6 +2383,50 @@ html[data-theme="light"] input[type="time"]::-webkit-calendar-picker-indicator {
   border: 0;
 }
 
+/* ─── Bubble toolbar (selection-triggered) ────────────────── */
+/* Fixed positioning escapes the editor's `overflow: hidden` so the bubble
+   can render outside the editor's rounded box when needed (e.g. auto-flipped
+   above the selection). The JS controller computes top/left in viewport
+   coordinates from `range.getBoundingClientRect()`. */
+.ratel-editor .re-bubble {
+  position: fixed;
+  z-index: 60;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(4px) scale(0.96);
+  transform-origin: top center;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+.ratel-editor .re-bubble[data-visible="true"] {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+.ratel-editor .re-bubble__inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  background: var(--re-toolbar-bg);
+  border: 1px solid var(--re-border-subtle);
+  border-radius: 10px;
+  backdrop-filter: blur(20px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  white-space: nowrap;
+}
+.ratel-editor .re-bubble .re-toolbar__group {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 2px;
+}
+/* Bubble drops the `display: none` baseline of `.re-block__menu` once
+   open — the existing rule already handles `[data-open="true"]`, but we
+   want the menu to anchor below the bubble's block button, not float
+   away. Reuse existing styles; no override needed. */
+
 
 /* === src/common/components/form/style.css === */
 #tos-check {

--- a/app/ratel/src/common/components/editor/component.rs
+++ b/app/ratel/src/common/components/editor/component.rs
@@ -783,6 +783,216 @@ pub fn Editor(props: EditorProps) -> Element {
                 dangerous_inner_html: "{content}",
             }
             if is_editable {
+                // Selection-triggered floating toolbar. Hidden by default;
+                // the JS controller positions it below (or above, on auto-flip)
+                // the active selection and toggles `data-visible`. Buttons
+                // reuse the existing `.re-tb-btn` / `.re-block` classes so the
+                // top-toolbar's click handlers and aria-pressed sync apply
+                // automatically. Touch / coarse-pointer devices skip wiring
+                // entirely — see script.js.
+                div {
+                    aria_label: "Selection toolbar",
+                    class: "re-bubble",
+                    "data-visible": "false",
+                    role: "toolbar",
+                    div { class: "re-bubble__inner",
+                        div {
+                            class: "re-block re-block--bubble",
+                            "data-open": "false",
+                            button {
+                                aria_expanded: "false",
+                                aria_haspopup: "listbox",
+                                class: "re-block__btn",
+                                r#type: "button",
+                                span { class: "re-block__label", "Paragraph" }
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2.5",
+                                    view_box: "0 0 24 24",
+                                    polyline { points: "6 9 12 15 18 9" }
+                                }
+                            }
+                            div { class: "re-block__menu", role: "listbox",
+                                button {
+                                    class: "re-block__item",
+                                    "data-block": "P",
+                                    r#type: "button",
+                                    span { "Paragraph" }
+                                    span { class: "re-block__item-hint", "P" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--h1",
+                                    "data-block": "H1",
+                                    r#type: "button",
+                                    span { "Heading 1" }
+                                    span { class: "re-block__item-hint", "H1" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--h2",
+                                    "data-block": "H2",
+                                    r#type: "button",
+                                    span { "Heading 2" }
+                                    span { class: "re-block__item-hint", "H2" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--h3",
+                                    "data-block": "H3",
+                                    r#type: "button",
+                                    span { "Heading 3" }
+                                    span { class: "re-block__item-hint", "H3" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--quote",
+                                    "data-block": "BLOCKQUOTE",
+                                    r#type: "button",
+                                    span { "Quote" }
+                                    span { class: "re-block__item-hint", "\"" }
+                                }
+                                button {
+                                    class: "re-block__item re-block__item--code",
+                                    "data-block": "PRE",
+                                    r#type: "button",
+                                    span { "Code block" }
+                                    span { class: "re-block__item-hint", "{{ }}" }
+                                }
+                            }
+                        }
+                        div { class: "re-toolbar__group",
+                            button {
+                                aria_label: "Bold",
+                                class: "re-tb-btn",
+                                "data-cmd": "bold",
+                                "data-tip": "Bold",
+                                r#type: "button",
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2.4",
+                                    view_box: "0 0 24 24",
+                                    path { d: "M6 4h8a4 4 0 0 1 0 8H6z" }
+                                    path { d: "M6 12h9a4 4 0 0 1 0 8H6z" }
+                                }
+                            }
+                            button {
+                                aria_label: "Italic",
+                                class: "re-tb-btn",
+                                "data-cmd": "italic",
+                                "data-tip": "Italic",
+                                r#type: "button",
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2",
+                                    view_box: "0 0 24 24",
+                                    line {
+                                        x1: "19",
+                                        x2: "10",
+                                        y1: "4",
+                                        y2: "4",
+                                    }
+                                    line {
+                                        x1: "14",
+                                        x2: "5",
+                                        y1: "20",
+                                        y2: "20",
+                                    }
+                                    line {
+                                        x1: "15",
+                                        x2: "9",
+                                        y1: "4",
+                                        y2: "20",
+                                    }
+                                }
+                            }
+                            button {
+                                aria_label: "Underline",
+                                class: "re-tb-btn",
+                                "data-cmd": "underline",
+                                "data-tip": "Underline",
+                                r#type: "button",
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2",
+                                    view_box: "0 0 24 24",
+                                    path { d: "M6 4v6a6 6 0 0 0 12 0V4" }
+                                    line {
+                                        x1: "4",
+                                        x2: "20",
+                                        y1: "20",
+                                        y2: "20",
+                                    }
+                                }
+                            }
+                            button {
+                                aria_label: "Strikethrough",
+                                class: "re-tb-btn",
+                                "data-cmd": "strikeThrough",
+                                "data-tip": "Strikethrough",
+                                r#type: "button",
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2",
+                                    view_box: "0 0 24 24",
+                                    line {
+                                        x1: "4",
+                                        x2: "20",
+                                        y1: "12",
+                                        y2: "12",
+                                    }
+                                    path { d: "M16 6c-1.5-1.3-3.5-2-6-2-3 0-5 1.5-5 4 0 2 1.5 3 5 4" }
+                                    path { d: "M8 18c1.5 1.3 3.5 2 6 2 3 0 5-1.5 5-4 0-1-.4-1.8-1-2.4" }
+                                }
+                            }
+                            button {
+                                aria_label: "Inline code",
+                                class: "re-tb-btn",
+                                "data-cmd": "code-inline",
+                                "data-tip": "Inline code",
+                                r#type: "button",
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2",
+                                    view_box: "0 0 24 24",
+                                    polyline { points: "16 18 22 12 16 6" }
+                                    polyline { points: "8 6 2 12 8 18" }
+                                }
+                            }
+                            button {
+                                aria_label: "Insert link",
+                                class: "re-tb-btn",
+                                "data-cmd": "link",
+                                "data-tip": "Insert link",
+                                r#type: "button",
+                                svg {
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2",
+                                    view_box: "0 0 24 24",
+                                    path { d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" }
+                                    path { d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" }
+                                }
+                            }
+                        }
+                    }
+                }
                 div { class: "re-statusbar",
                     div { class: "re-statusbar__chips",
                         span { class: "re-statusbar__chip",
@@ -946,7 +1156,7 @@ pub fn Editor(props: EditorProps) -> Element {
                         aria_label: "Insert table",
                         class: "re-modal",
                         role: "dialog",
-                        div { class: "re-modal__title", "Insert table" }
+                        div { class: "table re-modal__title", "Insert" }
                         div { class: "re-modal__row",
                             div { class: "re-modal__field",
                                 label { "Rows" }

--- a/app/ratel/src/common/components/editor/script.js
+++ b/app/ratel/src/common/components/editor/script.js
@@ -126,10 +126,11 @@
       scheduleUpdate();
     }
 
-    // ── Block-format dropdown ──────────────────────────────
-    var blockDropdown = root.querySelector(".re-block");
-    var blockBtn = blockDropdown.querySelector(".re-block__btn");
-    var blockBtnLabel = blockDropdown.querySelector(".re-block__label");
+    // ── Block-format dropdown(s) ──────────────────────────────
+    // There may be more than one `.re-block` instance: one in the static
+    // top toolbar, one in the selection-triggered bubble. Each gets its
+    // own open/close state but they share the active-tag highlight via
+    // `syncBlockLabel`.
     var blockLabels = {
       P: "Paragraph",
       H1: "Heading 1",
@@ -139,30 +140,37 @@
       PRE: "Code block"
     };
 
-    blockBtn.addEventListener("click", function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      var open = blockDropdown.dataset.open === "true";
-      blockDropdown.dataset.open = open ? "false" : "true";
-      blockBtn.setAttribute("aria-expanded", open ? "false" : "true");
+    var blockDropdowns = Array.prototype.slice.call(root.querySelectorAll(".re-block"));
+    blockDropdowns.forEach(function (blockDropdown) {
+      var blockBtn = blockDropdown.querySelector(".re-block__btn");
+      if (!blockBtn) return;
+      blockBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var open = blockDropdown.dataset.open === "true";
+        blockDropdown.dataset.open = open ? "false" : "true";
+        blockBtn.setAttribute("aria-expanded", open ? "false" : "true");
+      });
+      blockDropdown.addEventListener("mousedown", function () {
+        savedRange = saveSelection();
+      });
+      blockDropdown.querySelectorAll("[data-block]").forEach(function (item) {
+        item.addEventListener("click", function (e) {
+          e.preventDefault();
+          var tag = item.dataset.block;
+          blockDropdown.dataset.open = "false";
+          blockBtn.setAttribute("aria-expanded", "false");
+          restoreSelection();
+          applyCmd("formatBlock", "<" + tag + ">");
+        });
+      });
     });
     document.addEventListener("click", function (e) {
-      if (!blockDropdown.contains(e.target)) {
+      blockDropdowns.forEach(function (blockDropdown) {
+        if (blockDropdown.contains(e.target)) return;
         blockDropdown.dataset.open = "false";
-        blockBtn.setAttribute("aria-expanded", "false");
-      }
-    });
-    blockDropdown.addEventListener("mousedown", function () {
-      savedRange = saveSelection();
-    });
-    root.querySelectorAll("[data-block]").forEach(function (item) {
-      item.addEventListener("click", function (e) {
-        e.preventDefault();
-        var tag = item.dataset.block;
-        blockDropdown.dataset.open = "false";
-        blockBtn.setAttribute("aria-expanded", "false");
-        restoreSelection();
-        applyCmd("formatBlock", "<" + tag + ">");
+        var btn = blockDropdown.querySelector(".re-block__btn");
+        if (btn) btn.setAttribute("aria-expanded", "false");
       });
     });
 
@@ -172,18 +180,21 @@
       if (!sel || sel.rangeCount === 0) return;
       var node = sel.getRangeAt(0).startContainer;
       if (node.nodeType === 3) node = node.parentNode;
+      var foundTag = null;
       while (node && node !== editor) {
-        var tag = node.nodeName;
-        if (blockLabels[tag]) {
-          blockBtnLabel.textContent = blockLabels[tag];
-          root.querySelectorAll("[data-block]").forEach(function (item) {
-            item.classList.toggle("re-block__item--active", item.dataset.block === tag);
-          });
-          return;
-        }
+        if (blockLabels[node.nodeName]) { foundTag = node.nodeName; break; }
         node = node.parentNode;
       }
-      blockBtnLabel.textContent = "Paragraph";
+      var label = foundTag ? blockLabels[foundTag] : "Paragraph";
+      root.querySelectorAll(".re-block__label").forEach(function (el) {
+        el.textContent = label;
+      });
+      root.querySelectorAll("[data-block]").forEach(function (item) {
+        item.classList.toggle(
+          "re-block__item--active",
+          item.dataset.block === foundTag
+        );
+      });
     }
 
     // ── Toolbar active-state sync ──────────────────────────
@@ -387,6 +398,98 @@
       else if (k === "u") { e.preventDefault(); applyCmd("underline"); }
       else if (k === "k") { e.preventDefault(); openModal("link"); }
     });
+
+    // ── Selection-triggered bubble toolbar (desktop only) ─────
+    // On coarse-pointer (touch) devices the OS provides its own selection
+    // menu (Copy / Paste / Look up). Layering our bubble on top would
+    // conflict and the static top toolbar remains available, so we skip
+    // wiring entirely on touch. The bubble's DOM is rendered regardless;
+    // it just stays invisible.
+    var bubble = root.querySelector(".re-bubble");
+    var coarsePointer = typeof window.matchMedia === "function" &&
+      window.matchMedia("(pointer: coarse)").matches;
+
+    if (bubble && !coarsePointer) {
+      // Preserving the editor's selection across a bubble button click is
+      // the whole point of this toolbar. Without preventDefault here, the
+      // mousedown moves focus from the editor to the <button>, the
+      // selection collapses, and execCommand has nothing left to act on.
+      bubble.addEventListener("mousedown", function (e) {
+        e.preventDefault();
+      });
+
+      function isFocusInsideEditor() {
+        return document.activeElement === editor ||
+          bubble.contains(document.activeElement);
+      }
+
+      function positionBubble(range) {
+        var sr = range.getBoundingClientRect();
+        if (sr.width === 0 && sr.height === 0) return false;
+        var bw = bubble.offsetWidth;
+        var bh = bubble.offsetHeight;
+        // Position uses viewport coordinates (position: fixed) so the
+        // editor's `overflow: hidden` never clips the bubble.
+        var top = sr.bottom + 8;
+        if (top + bh + 8 > window.innerHeight) {
+          top = sr.top - bh - 8; // auto-flip: place above the selection
+        }
+        var left = sr.left + sr.width / 2 - bw / 2;
+        left = Math.max(8, Math.min(left, window.innerWidth - bw - 8));
+        bubble.style.top = top + "px";
+        bubble.style.left = left + "px";
+        return true;
+      }
+
+      function hideBubble() {
+        if (bubble.dataset.visible !== "true") return;
+        bubble.dataset.visible = "false";
+        // Close any open block dropdown owned by the bubble.
+        var inner = bubble.querySelector(".re-block");
+        if (inner && inner.dataset.open === "true") {
+          inner.dataset.open = "false";
+          var btn = inner.querySelector(".re-block__btn");
+          if (btn) btn.setAttribute("aria-expanded", "false");
+        }
+      }
+
+      function updateBubble() {
+        if (composing) return hideBubble();
+        if (!isFocusInsideEditor()) return hideBubble();
+        var sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return hideBubble();
+        var range = sel.getRangeAt(0);
+        if (!editor.contains(range.commonAncestorContainer)) return hideBubble();
+        if (!positionBubble(range)) return hideBubble();
+        bubble.dataset.visible = "true";
+      }
+
+      // selectionchange fires many times during a drag; rAF-throttle to
+      // one update per frame so we don't thrash layout.
+      var bubbleFrame = null;
+      function scheduleBubbleUpdate() {
+        if (bubbleFrame !== null) return;
+        bubbleFrame = requestAnimationFrame(function () {
+          bubbleFrame = null;
+          updateBubble();
+        });
+      }
+
+      editor.addEventListener("mouseup", scheduleBubbleUpdate);
+      editor.addEventListener("keyup", scheduleBubbleUpdate);
+      document.addEventListener("selectionchange", scheduleBubbleUpdate);
+      // Hide on scroll/resize rather than reposition — keeps the bubble
+      // anchored to a stable selection rect. Capture: true so we also
+      // catch scrolls inside arbitrary scroll containers above the editor.
+      window.addEventListener("scroll", hideBubble, { passive: true, capture: true });
+      window.addEventListener("resize", hideBubble);
+      document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape" && bubble.dataset.visible === "true") {
+          hideBubble();
+          editor.focus();
+        }
+      });
+    }
 
     // Initial paint so word/char counts and toolbar state are correct.
     emitChange();

--- a/docs/superpowers/specs/2026-05-15-reactive-editor-toolbar-design.md
+++ b/docs/superpowers/specs/2026-05-15-reactive-editor-toolbar-design.md
@@ -1,0 +1,258 @@
+# Reactive Editor Bubble Toolbar — Design
+
+**Branch**: `feature/reactive-editor-toolbar`
+**Author / Date**: hackartist · 2026-05-15
+**Scope**: `app/ratel/src/common/components/editor/`
+
+## Summary
+
+Add a selection-triggered "bubble" toolbar to the existing contenteditable editor. When the user drags to select text inside `.re-content`, a compact floating toolbar appears immediately below the selection (auto-flips above if no space). It exposes the subset of commands that act on a selection: inline formatting (Bold / Italic / Underline / Strikethrough / Inline code / Link) plus a block-format dropdown (Paragraph / H1 / H2 / H3 / Quote / Code block). The existing static toolbar at the top of the editor is **unchanged** and remains the home of all other commands (Undo/Redo, alignment, lists, indent, image/youtube/table/hr, clear-format).
+
+## Goals
+
+1. Reduce visual distance between the user's cursor and the format buttons they most often want during writing.
+2. Preserve every existing behavior — no regression to IME composition, no change to read-only rendering, no change to the static toolbar.
+3. Implementation surface stays inside the editor module (three files): `component.rs`, `script.js`, `assets/main.css`.
+
+## Non-goals
+
+- Replacing or hiding the static toolbar.
+- Mobile/touch support — the bubble is desktop-only. Touch devices keep the OS native selection popup + static toolbar.
+- A pointer/arrow tail on the bubble — visually simple v1, no caret/triangle.
+- Smooth follow-on-scroll — scrolling hides the bubble; the user re-selects to bring it back.
+- Multi-range selections (collapses to the first range).
+- Adding any new commands beyond the 6 inline + block dropdown listed above.
+
+## Architecture
+
+The editor is a contenteditable + `document.execCommand` widget where all interactive state lives in plain JS and the Rust/Dioxus layer only renders the DOM scaffolding and bridges content via a hidden `<input>` element. This is intentional: re-rendering the editor through Dioxus during selection changes re-applies `dangerous_inner_html` and destroys the caret position — most visibly during Korean (IME) composition. See the existing comment at `app/ratel/src/common/components/editor/component.rs:19`.
+
+The bubble follows the same split:
+
+```
+component.rs           main.css                          script.js
+─────────────          ────────                          ─────────
+<div class="re-bubble" .ratel-editor .re-bubble { ... }   listen to selectionchange/mouseup/keyup
+     data-visible="false">                                position bubble, toggle data-visible
+   .re-block                                              hide on collapse/blur/ESC/scroll
+   .re-toolbar__group                                     skip wiring entirely on (pointer: coarse)
+     6× .re-tb-btn (existing class)
+   </>
+```
+
+State (visibility, position) lives entirely in JS — Dioxus signals are not involved.
+
+## Components
+
+### 3.1 RSX (`component.rs`)
+
+Add a sibling element after `.re-content`, gated by `is_editable` (no bubble in read-only mode):
+
+```rust
+if is_editable {
+    div { class: "re-bubble", "data-visible": "false",
+        div { class: "re-bubble__inner",
+            // Block-format dropdown — reuses .re-block markup
+            div { class: "re-block", "data-open": "false",
+                button { class: "re-block__btn", ... }
+                div { class: "re-block__menu", role: "listbox",
+                    button { class: "re-block__item", "data-block": "P",         ... }
+                    button { class: "re-block__item re-block__item--h1",  "data-block": "H1",         ... }
+                    button { class: "re-block__item re-block__item--h2",  "data-block": "H2",         ... }
+                    button { class: "re-block__item re-block__item--h3",  "data-block": "H3",         ... }
+                    button { class: "re-block__item re-block__item--quote","data-block": "BLOCKQUOTE",... }
+                    button { class: "re-block__item re-block__item--code", "data-block": "PRE",        ... }
+                }
+            }
+            // Inline buttons — reuse .re-tb-btn / data-cmd codes from the static toolbar
+            div { class: "re-toolbar__group",
+                button { class: "re-tb-btn", "data-cmd": "bold",          ... } // <svg>...</svg>
+                button { class: "re-tb-btn", "data-cmd": "italic",        ... }
+                button { class: "re-tb-btn", "data-cmd": "underline",     ... }
+                button { class: "re-tb-btn", "data-cmd": "strikeThrough", ... }
+                button { class: "re-tb-btn", "data-cmd": "code-inline",   ... }
+                button { class: "re-tb-btn", "data-cmd": "link",          ... }
+            }
+        }
+    }
+}
+```
+
+Because the buttons reuse the existing `.re-tb-btn` / `.re-block` classes and `data-cmd` values, they pick up the existing JS click handlers, modal flow (`link` → existing modal), and `aria-pressed` active-state sync for free.
+
+### 3.2 CSS (`app/ratel/assets/main.css`)
+
+Append to the existing editor section (per `conventions/styling.md` — no per-component stylesheet):
+
+```css
+/* === src/common/components/editor — bubble toolbar ===================== */
+.ratel-editor { position: relative; }       /* if not already set */
+.ratel-editor .re-bubble {
+  position: absolute;
+  z-index: 50;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(4px) scale(0.96);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+.ratel-editor .re-bubble[data-visible="true"] {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+.ratel-editor .re-bubble__inner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  background: var(--re-toolbar-bg);          /* existing token */
+  border: 1px solid var(--re-border-subtle); /* existing token */
+  border-radius: 10px;
+  backdrop-filter: blur(20px);               /* parity with .re-toolbar */
+  box-shadow: 0 6px 24px rgba(0,0,0,0.18);
+  white-space: nowrap;
+}
+```
+
+Token reuse keeps the bubble visually consistent with the static toolbar across dark/light themes without redefinition.
+
+### 3.3 JS (`script.js`)
+
+Two distinct changes:
+
+**A. Tiny refactor — handle multiple `.re-block` dropdowns.**
+
+Today: `var blockDropdown = root.querySelector(".re-block")` picks one element. After this change there will be two `.re-block` instances (static + bubble). Replace the single-element wiring with a per-instance helper that runs over `root.querySelectorAll(".re-block")` and binds open/close, click-outside, item-click, and label-sync independently. `syncBlockLabel()` also walks every `.re-block__label` and every `[data-block]` item.
+
+**B. New bubble controller.**
+
+```js
+// Hard gate: never activate on touch / coarse-pointer devices.
+if (window.matchMedia("(pointer: coarse)").matches) { /* skip bubble wiring */ }
+
+var bubble = root.querySelector(".re-bubble");
+if (bubble) {
+  // Critical: pressing the bubble must NOT move focus / collapse the editor's
+  // selection. Without this, click → focus shifts to <button> → selection
+  // collapses → execCommand has nothing to operate on.
+  bubble.addEventListener("mousedown", function (e) { e.preventDefault(); });
+
+  function showBubble(range) {
+    var sr = range.getBoundingClientRect();
+    var er = root.getBoundingClientRect();
+    var bw = bubble.offsetWidth;
+    var bh = bubble.offsetHeight;
+    var top = sr.bottom - er.top + 8;                         // default: below selection
+    if (sr.bottom + bh + 16 > window.innerHeight) {           // flip when out of viewport
+      top = sr.top - er.top - bh - 8;
+    }
+    var left = sr.left + sr.width / 2 - er.left - bw / 2;     // center horizontally
+    left = Math.max(8, Math.min(left, er.width - bw - 8));    // clamp
+    bubble.style.top  = top + "px";
+    bubble.style.left = left + "px";
+    bubble.dataset.visible = "true";
+  }
+  function hideBubble() { bubble.dataset.visible = "false"; }
+
+  function updateBubble() {
+    if (document.activeElement !== editor) return hideBubble();
+    var sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return hideBubble();
+    var range = sel.getRangeAt(0);
+    if (!editor.contains(range.commonAncestorContainer)) return hideBubble();
+    showBubble(range);
+  }
+
+  // Trigger sources:
+  //   - selectionchange : already wired; add updateBubble() into the existing handler
+  //   - mouseup on editor : selection only stabilizes on mouseup during drag
+  //   - keyup on editor : Shift+arrow / Home / End / PageUp / PageDown keyboard selection
+  //   - scroll / resize : hide (simpler than recomputing)
+  //   - Escape : hide and return focus to editor
+}
+```
+
+The `selectionchange` listener already exists for `syncToolbarState()`/`syncBlockLabel()`; we add a `updateBubble()` call into the same handler — no second listener.
+
+## Data flow
+
+1. User drags / Shift+arrow → browser fires `selectionchange` (and `mouseup` / `keyup`).
+2. `updateBubble()` reads `window.getSelection()`, confirms the range is inside `editor` and non-collapsed.
+3. `getBoundingClientRect()` of the range + editor root → bubble's `top`/`left` (computed in editor-relative coords).
+4. `data-visible="true"` toggles CSS to fade/scale in.
+5. User clicks a bubble button: `mousedown` is prevented (selection preserved) → click → existing `.re-tb-btn` handler → `applyCmd` / modal flow → `document.execCommand` operates on the still-live selection.
+6. User clicks elsewhere / presses Esc / scrolls / blurs → `hideBubble()`.
+
+Dioxus is not involved at any step; no signal is read or written. The hidden-input bridge that already syncs editor HTML back to Rust continues to fire on `input` events from `execCommand`.
+
+## Behavior matrix
+
+| Trigger | Result |
+|---|---|
+| Mouse drag selects text | bubble appears at mouseup, below selection (or flipped above) |
+| Shift + Arrow / Home / End | bubble appears on keyup |
+| Double-click / triple-click | bubble appears on selectionchange |
+| Selection collapses (caret only) | bubble hides |
+| Click outside editor (focus leaves) | bubble hides — note: clicking the bubble itself does NOT blur because of `mousedown` preventDefault |
+| Escape pressed while bubble visible | bubble hides, focus returns to editor |
+| Window scroll or resize | bubble hides (user re-selects to bring it back) |
+| Touch / coarse pointer | bubble never wires up |
+| `is_editable == false` | bubble not rendered |
+
+## Error handling / edge cases
+
+- **`getBoundingClientRect()` returns a zero-width rect on certain selections** (e.g. inside an empty `<br>`-only paragraph). Treat zero-area rect as "no useful anchor" → hide.
+- **Selection spans across nodes outside the editor** (rare, e.g. user selected from outside into the editor). `editor.contains(range.commonAncestorContainer)` filters this — hide.
+- **Bubble wider than editor** at very narrow viewports — `clamp(8, …, er.width - bw - 8)` may produce `left = 8` and overflow on the right. Acceptable for v1 (the toolbar is ~250px; the editor is unlikely to be that narrow on desktop). If it becomes an issue we wrap the buttons to a second row via flex-wrap, no JS change needed.
+- **Existing `.re-block` JS code assumes a single dropdown.** This is the explicit refactor in §3.3.A. We must test the static toolbar's block dropdown still works after the refactor.
+
+## Test plan
+
+### Manual / regression
+- Drag-select prose → bubble appears below; click Bold → text becomes bold; selection remains highlighted.
+- Drag-select at the bottom of a long scrollable editor → bubble auto-flips above.
+- Type Korean Hangul ("안녕하세요") continuously — caret must not jump to start of editor. (Same IME guarantee as today; this is the regression smoke test for the no-Dioxus-rerender contract.)
+- Static toolbar's block dropdown still opens, selects, closes — verifies the `querySelector` → `querySelectorAll` refactor.
+- Touch device (or DevTools touch emulation with `pointer: coarse`) — bubble never appears; static toolbar unaffected.
+- Read-only mode (`editable=false`) — bubble not in DOM.
+
+### Playwright
+Extend the editor-touching spec (likely the post-creation or discussion-editor spec in `playwright/tests/web/`) with a new `test()` block in the existing `describe.serial`:
+
+```js
+test("editor bubble appears on selection", async ({ page }) => {
+  // (assumes editor is already mounted and focused from a previous step)
+  await fill(editorLocator, "Hello world");
+  // select "Hello" — Playwright keyboard selection (Shift+End-of-word) keeps it deterministic
+  await page.keyboard.press("Home");
+  await page.keyboard.press("Shift+End");
+  await expect(page.locator(".re-bubble[data-visible='true']")).toBeVisible();
+  await page.locator(".re-bubble .re-tb-btn[data-cmd='bold']").click();
+  await expect(editorLocator).toContainText("Hello world"); // structurally bolded
+  // Optional: read editor HTML and assert <b>/<strong> wrapping if the editor exposes it.
+});
+```
+
+### Build verification (project convention)
+- `rustywind --custom-regex 'class: "(.*)"' --write` on `component.rs`
+- `dx fmt -f component.rs`
+- `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' dx check --features web`
+- `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features web`
+- `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features server`
+
+## Files changed
+
+| File | Nature of change |
+|---|---|
+| `app/ratel/src/common/components/editor/component.rs` | +~80 lines: new `.re-bubble` subtree gated on `is_editable` |
+| `app/ratel/src/common/components/editor/script.js` | refactor `.re-block` wiring to per-instance loop; +~50 lines: bubble controller (gate + show/hide/position + event listeners) |
+| `app/ratel/assets/main.css` | +~30 lines: `.re-bubble` styles under the editor section, plus `position: relative` on `.ratel-editor` if missing |
+| `playwright/tests/web/<existing-editor-spec>.spec.js` | +1 `test()` step for the bubble selection flow |
+
+No changes to: any feature module under `src/features/`, any controller, any DynamoDB entity, any DTO, any Cargo dependency, any CDK code.
+
+## Open questions / risks
+
+- **`syncToolbarState()` performance with two toolbars.** It already runs on every `selectionchange`. Doubling the `.re-tb-btn` count (+6) is negligible.
+- **Bubble flicker during drag.** `mouseup` is the primary trigger to avoid showing/hiding on every micro-selection during a drag. `selectionchange` still calls `updateBubble()`, but a quick `requestAnimationFrame` throttle can be added inside the existing scheduler (`scheduleUpdate`) if flicker shows up in QA. Plan: ship without throttle, add only if observed.
+- **Existing `.re-block` `mousedown` saves selection.** When we duplicate `.re-block`, both instances will run `savedRange = saveSelection()`. This is the same `savedRange` variable in the same closure — last-write-wins, which is fine because the user can only interact with one dropdown at a time.


### PR DESCRIPTION
## Summary

- When the user drags to select text inside the editor, a compact floating toolbar appears below the selection (auto-flips above when the viewport bottom is too close) with Paragraph dropdown + B / I / U / S / Inline code / Link.
- The existing static top toolbar is preserved unchanged; bubble adds the inline subset that's meaningful only with a non-collapsed selection.
- Implementation keeps with the editor's existing pattern: RSX declares the DOM, JS owns visibility/positioning. Dioxus signals are NOT touched on selection changes — preserves the no-rerender contract that keeps IME (Korean) composition safe.
- `.re-block` dropdown wiring refactored single-instance → per-instance so both static + bubble dropdowns work.
- Bubble is desktop-only (`matchMedia('(pointer: coarse)')`) so OS native selection menus on touch stay unobstructed.

Files: `app/ratel/assets/main.css`, `app/ratel/src/common/components/editor/{component.rs,script.js}`, plus a design doc at `docs/superpowers/specs/2026-05-15-reactive-editor-toolbar-design.md`.

## Test plan

- [ ] Local: drag-select text → bubble appears below selection
- [ ] Local: select near viewport bottom → bubble auto-flips above
- [ ] Local: keyboard selection (Shift + arrow / Home / End) → bubble appears on keyup
- [ ] Local: click Bold/Italic in bubble → selection retained, format applied
- [ ] Local: bubble's Paragraph dropdown → H1/H2/H3/Quote/Code-block change works
- [ ] Local: Esc → bubble hides + focus returns to editor
- [ ] Local: scroll editor → bubble hides
- [ ] Local: IME — type Korean continuously, no caret jump
- [ ] Local: static top toolbar still works (block dropdown regression check)
- [ ] Local: read-only editor → no bubble in DOM
- [ ] CI: dx-check / cargo build / playwright pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)