### PR TITLE
feat(sub-team): unify direct-message composer with broadcast Draft → Publish flow

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -643,7 +643,12 @@ jobs:
 
       - name: Install Dioxus-cli
         run: |
-          cargo binstall dioxus-cli --force
+          # `--locked` makes the `cargo install` fallback (when binstall
+          # can't find a prebuilt binary) honor dioxus-cli's published
+          # Cargo.lock. Without it, fresh transitive resolution picks up
+          # `git2 0.21`, which breaks `auth-git2 0.5.8`'s
+          # `Cred::credential_helper` call → dioxus-cli build fails.
+          cargo binstall dioxus-cli --force --locked
 
       - name: Building test
         id: build
@@ -746,8 +751,13 @@ jobs:
 
       - name: Install dioxus-cli + tauri-cli
         run: |
-          cargo binstall -y dioxus-cli
-          cargo binstall -y --version "^2.0.0" tauri-cli
+          # See companion `--locked` notes above: dioxus-cli's source-build
+          # fallback otherwise grabs `git2 0.21`, which kills
+          # `auth-git2 0.5.8` (`Cred::credential_helper` was removed in
+          # the new git2). `--locked` pins to the lockfile shipped with
+          # the published crate, which used `git2 0.20`.
+          cargo binstall -y --locked dioxus-cli
+          cargo binstall -y --locked --version "^2.0.0" tauri-cli
 
       - name: Build arm64 debug APK (dev)
         working-directory: app/ratel-tauri

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -102,7 +102,12 @@ jobs:
 
       - name: Install Dioxus-cli
         run: |
-          cargo binstall dioxus-cli --force
+          # `--locked` makes the `cargo install` fallback (when binstall
+          # can't find a prebuilt binary) honor dioxus-cli's published
+          # Cargo.lock. Without it, fresh transitive resolution picks up
+          # `git2 0.21`, which breaks `auth-git2 0.5.8`'s
+          # `Cred::credential_helper` call → dioxus-cli build fails.
+          cargo binstall dioxus-cli --force --locked
 
       - name: Building test
         id: build
@@ -193,7 +198,12 @@ jobs:
 
       - name: Install Dioxus-cli
         run: |
-          cargo binstall dioxus-cli --force
+          # `--locked` makes the `cargo install` fallback (when binstall
+          # can't find a prebuilt binary) honor dioxus-cli's published
+          # Cargo.lock. Without it, fresh transitive resolution picks up
+          # `git2 0.21`, which breaks `auth-git2 0.5.8`'s
+          # `Cred::credential_helper` call → dioxus-cli build fails.
+          cargo binstall dioxus-cli --force --locked
 
       - name: Building test
         id: build
@@ -284,7 +294,12 @@ jobs:
 
       - name: Install Dioxus-cli
         run: |
-          cargo binstall dioxus-cli --force
+          # `--locked` makes the `cargo install` fallback (when binstall
+          # can't find a prebuilt binary) honor dioxus-cli's published
+          # Cargo.lock. Without it, fresh transitive resolution picks up
+          # `git2 0.21`, which breaks `auth-git2 0.5.8`'s
+          # `Cred::credential_helper` call → dioxus-cli build fails.
+          cargo binstall dioxus-cli --force --locked
 
       - name: Start infrastructure
         run: |
@@ -493,8 +508,13 @@ jobs:
 
       - name: Install dioxus-cli + tauri-cli
         run: |
-          cargo binstall -y dioxus-cli
-          cargo binstall -y --version "^2.0.0" tauri-cli
+          # See companion `--locked` notes above: dioxus-cli's source-build
+          # fallback otherwise grabs `git2 0.21`, which kills
+          # `auth-git2 0.5.8` (`Cred::credential_helper` was removed in
+          # the new git2). `--locked` pins to the lockfile shipped with
+          # the published crate, which used `git2 0.20`.
+          cargo binstall -y --locked dioxus-cli
+          cargo binstall -y --locked --version "^2.0.0" tauri-cli
 
       - name: Build x86_64 debug APK
         working-directory: app/ratel-tauri

--- a/app/ratel/src/features/sub_team/controllers/announcements.rs
+++ b/app/ratel/src/features/sub_team/controllers/announcements.rs
@@ -151,11 +151,34 @@ pub async fn create_announcement_handler(
     let cfg = crate::common::CommonConfig::default();
     let cli = cfg.dynamodb();
 
+    // Direct-message draft: verify the target is a recognized sub-team of
+    // this parent before creating the row. Stops the composer from being
+    // hand-pointed at arbitrary team ids via the request body. Broadcast
+    // drafts (target = None) skip this — the recognized-list is enforced
+    // at publish time via `count_recognized_sub_teams`.
+    if let Some(target) = &body.target_child_team_id {
+        let link_sk = EntityType::SubTeamLink(target.0.clone());
+        let link = crate::features::sub_team::models::SubTeamLink::get(
+            cli,
+            &team.pk,
+            Some(link_sk),
+        )
+        .await
+        .map_err(|e| {
+            crate::error!("create_announcement target link lookup failed: {e}");
+            SubTeamError::SubTeamLinkNotFound
+        })?;
+        if link.is_none() {
+            return Err(SubTeamError::SubTeamLinkNotFound.into());
+        }
+    }
+
     let mut ann = SubTeamAnnouncement::new_draft(
         team.pk.clone(),
         body.title,
         body.body,
         user.pk.to_string(),
+        body.target_child_team_id,
     );
     ann.html_contents = body.html_contents;
     ann.tags = body.tags;
@@ -283,9 +306,33 @@ pub async fn publish_announcement_handler(
         return Err(SubTeamError::AnnouncementNotInDraft.into());
     }
 
-    let count = count_recognized_sub_teams(cli, &team.pk).await?;
-    if count > MAX_RECOGNIZED_SUB_TEAMS {
-        return Err(SubTeamError::BroadcastTooManySubTeams.into());
+    // Direct messages target exactly one sub-team and bypass the cap
+    // check entirely. Broadcasts must stay under MAX_RECOGNIZED_SUB_TEAMS
+    // because the fanout writes one marker row per recognized child.
+    let is_direct = existing.target_child_team_id.is_some();
+    if !is_direct {
+        let count = count_recognized_sub_teams(cli, &team.pk).await?;
+        if count > MAX_RECOGNIZED_SUB_TEAMS {
+            return Err(SubTeamError::BroadcastTooManySubTeams.into());
+        }
+    } else if let Some(target_id) = existing.target_child_team_id.clone() {
+        // Re-verify the link still exists at publish time — the
+        // relationship may have been deregistered between draft save
+        // and publish.
+        let link_sk = EntityType::SubTeamLink(target_id);
+        let link = crate::features::sub_team::models::SubTeamLink::get(
+            cli,
+            &team.pk,
+            Some(link_sk),
+        )
+        .await
+        .map_err(|e| {
+            crate::error!("publish_announcement direct link lookup failed: {e}");
+            SubTeamError::SubTeamLinkNotFound
+        })?;
+        if link.is_none() {
+            return Err(SubTeamError::SubTeamLinkNotFound.into());
+        }
     }
 
     let now = crate::common::utils::time::get_now_timestamp_millis();
@@ -326,6 +373,17 @@ pub async fn publish_announcement_handler(
         None
     };
 
+    // Anchor `user_pk` decides which wall the Post surfaces on. Broadcasts
+    // own the parent's wall (children read it through fanout markers).
+    // Direct messages live on the **target child's** wall so they show up
+    // in that team's `Post::find_by_user_and_status` query and stay off
+    // the parent's. `pinned_as_announcement` follows the same split: only
+    // broadcasts pin.
+    let anchor_user_pk: Partition = match existing.target_child_team_id.clone() {
+        Some(child_id) => Partition::Team(child_id),
+        None => team.pk.clone(),
+    };
+
     let anchor_post = Post {
         pk: Partition::Feed(existing.announcement_id.clone()),
         sk: EntityType::Post,
@@ -335,16 +393,17 @@ pub async fn publish_announcement_handler(
         body: ContentBody::html(anchor_post_body),
         post_type: PostType::Post,
         status: PostStatus::Published,
-        // Sub-team broadcasts are NEVER publicly visible — `Visibility::Broadcast`
-        // hands access control over to
+        // Sub-team broadcasts / direct messages are NEVER publicly visible —
+        // `Visibility::Broadcast` hands access control over to
         // `sub_team::services::broadcast_access::can_view_broadcast_post`
-        // (parent team's members + every recognized child team's members).
+        // (parent team's members + every recognized child team's members
+        // for broadcast, parent + one target child for direct).
         visibility: Some(crate::features::posts::types::Visibility::Broadcast),
         shares: 0,
         likes: 0,
         comments: 0,
         reports: 0,
-        user_pk: team.pk.clone(),
+        user_pk: anchor_user_pk,
         author_display_name: team.display_name.clone(),
         author_profile_url: team.profile_url.clone(),
         author_username: team.username.clone(),
@@ -362,8 +421,10 @@ pub async fn publish_announcement_handler(
         // Broadcasts pin to the top of every receiving team's wall —
         // parent + recognized children — so the announcement card sits
         // above the regular feed. `list_team_posts_handler` sorts on
-        // this flag first, then created_at desc.
-        pinned_as_announcement: true,
+        // this flag first, then created_at desc. Direct messages skip
+        // the pin so the target child's wall isn't permanently locked
+        // to this card.
+        pinned_as_announcement: !is_direct,
     };
     if let Err(e) = anchor_post.create(cli).await {
         crate::error!("publish_announcement: anchor post create failed: {e}");
@@ -379,12 +440,20 @@ pub async fn publish_announcement_handler(
         existing.space_pk = Some(space_pk_str);
     }
 
+    let anchor_post_pk_str = Partition::Feed(existing.announcement_id.clone()).to_string();
     let mut updater = SubTeamAnnouncement::updater(&team.pk, &sk)
         .with_status(SubTeamAnnouncementStatus::Published)
         .with_published_at(now)
         .with_updated_at(now);
     if let Some(space_pk) = existing.space_pk.clone() {
         updater = updater.with_space_pk(space_pk);
+    }
+    // Pre-populate `target_post_pk` on direct messages so the parent's
+    // history row can deep-link without waiting for the stream-driven
+    // fanout to fill it in. Fanout will overwrite with the same value
+    // later — the anchor pk is deterministic (`Feed(announcement_id)`).
+    if is_direct {
+        updater = updater.with_target_post_pk(anchor_post_pk_str.clone());
     }
     updater.execute(cli).await.map_err(|e| {
         crate::error!("publish_announcement execute failed: {e}");
@@ -394,6 +463,9 @@ pub async fn publish_announcement_handler(
     existing.status = SubTeamAnnouncementStatus::Published;
     existing.published_at = Some(now);
     existing.updated_at = now;
+    if is_direct {
+        existing.target_post_pk = Some(anchor_post_pk_str);
+    }
 
     // Fan-out happens asynchronously via the DynamoDB Stream → Pipe → Lambda
     // chain in deployed envs, or via the local-dev stream poller which

--- a/app/ratel/src/features/sub_team/controllers/direct_message.rs
+++ b/app/ratel/src/features/sub_team/controllers/direct_message.rs
@@ -1,24 +1,19 @@
-//! Direct-to-one-sub-team announcement endpoints.
+//! Direct-to-one-sub-team announcement endpoint (read side).
 //!
-//! Renders the "이 하위팀에만 공지 · Direct announcement" card on the
-//! parent's sub-team detail page. Single-step send (no draft), no
-//! post-publish edits — the trade is that fanout writes ONE post to the
-//! target child's feed and demotes any prior direct-message post from
-//! this parent so only the latest stays pinned.
-//!
-//! Companion list endpoint surfaces the history under the same card.
+//! Powers the history rows under the "이 하위팀에만 공지" card on the
+//! parent's sub-team detail page. The send side now goes through the
+//! shared broadcast composer (`create_announcement_handler` +
+//! `publish_announcement_handler` with `target_child_team_id` set) so
+//! direct messages share the editor, attachments, Space attachment,
+//! and Draft → Publish 2-step lifecycle.
 
 use crate::common::*;
 use crate::features::posts::models::Team;
 use crate::features::social::pages::member::dto::TeamRole;
-use crate::features::sub_team::types::{
-    SendDirectMessageRequest, SubTeamAnnouncementResponse, SubTeamError,
-};
+use crate::features::sub_team::types::{SubTeamAnnouncementResponse, SubTeamError};
 
 #[cfg(feature = "server")]
-use crate::features::sub_team::models::{
-    SubTeamAnnouncement, SubTeamAnnouncementStatus, SubTeamLink,
-};
+use crate::features::sub_team::models::{SubTeamAnnouncement, SubTeamAnnouncementStatus};
 
 #[cfg(feature = "server")]
 // Trailing `#` keeps the begins_with filter from accidentally matching
@@ -27,130 +22,6 @@ use crate::features::sub_team::models::{
 const ANNOUNCEMENT_SK_PREFIX: &str = "SUB_TEAM_ANNOUNCEMENT#";
 #[cfg(feature = "server")]
 const PAGE_LIMIT: i32 = 100;
-
-// ── POST /api/teams/:team_pk/sub-teams/:sub_team_id/direct-message ───────
-//
-// Parent-side action. Sends a direct announcement to a single recognized
-// sub-team. Creates a `SubTeamAnnouncement` row with
-// `target_child_team_id = Some(sub_team_id)` and `status = Published`
-// (skipping the Draft step). The Stream → fanout chain writes one Post
-// to the target child's feed; older direct-message Posts from this
-// parent are demoted so only the newest stays pinned.
-#[post(
-    "/api/teams/:team_pk/sub-teams/:sub_team_id/direct-message",
-    user: crate::features::auth::User,
-    team: Team,
-    role: TeamRole
-)]
-pub async fn send_direct_message_handler(
-    team_pk: TeamPartition,
-    sub_team_id: String,
-    body: SendDirectMessageRequest,
-) -> Result<SubTeamAnnouncementResponse> {
-    let _ = team_pk;
-    let _ = user;
-    if !role.is_admin_or_owner() {
-        return Err(Error::UnauthorizedAccess);
-    }
-    if body.title.trim().is_empty() {
-        return Err(SubTeamError::AnnouncementPublishFailed.into());
-    }
-
-    let cfg = crate::common::CommonConfig::default();
-    let cli = cfg.dynamodb();
-
-    // Verify the target is a recognized sub-team of this parent. Stops
-    // direct-messaging arbitrary teams via guessed ids.
-    let link_sk = EntityType::SubTeamLink(sub_team_id.clone());
-    let link = SubTeamLink::get(cli, &team.pk, Some(link_sk))
-        .await
-        .map_err(|e| {
-            crate::error!("send_direct_message link lookup failed: {e}");
-            SubTeamError::SubTeamLinkNotFound
-        })?
-        .ok_or(SubTeamError::SubTeamLinkNotFound)?;
-    let _ = link;
-
-    let mut announcement = SubTeamAnnouncement::new_direct(
-        team.pk.clone(),
-        sub_team_id.clone(),
-        body.title.clone(),
-        body.body.clone(),
-        user.pk.to_string(),
-    );
-
-    // Write the anchor Post BEFORE the announcement row. Anchor pk is
-    // deterministic (`Feed(announcement_id)`), and we want the row that
-    // children's `/posts/{id}` deep-links land on to exist by the time
-    // any inbox notification fires.
-    //
-    // Anchor `user_pk` is the **target child team** (not the parent),
-    // so the Post surfaces naturally in that child's
-    // `Post::find_by_user_and_status` wall query and stays off the
-    // parent's wall. Author metadata still records the parent team so
-    // the rendered card shows "parent team posted in your wall".
-    use crate::features::posts::models::Post;
-    use crate::features::posts::types::{PostStatus, PostType};
-
-    let parent_team_id_str = match &team.pk {
-        Partition::Team(id) => id.clone(),
-        _ => String::new(),
-    };
-    let child_team_pk = Partition::Team(sub_team_id.clone());
-    let now = crate::common::utils::time::get_now_timestamp_millis();
-    let anchor_post = Post {
-        pk: Partition::Feed(announcement.announcement_id.clone()),
-        sk: EntityType::Post,
-        created_at: now,
-        updated_at: now,
-        title: body.title.clone(),
-        body: ContentBody::html(body.body.clone()),
-        post_type: PostType::Post,
-        status: PostStatus::Published,
-        // Direct messages share the same audience-gate as broadcasts:
-        // resolved at read time by `broadcast_access::can_view_broadcast_post`
-        // (parent's members + the one target child's members).
-        visibility: Some(crate::features::posts::types::Visibility::Broadcast),
-        shares: 0,
-        likes: 0,
-        comments: 0,
-        reports: 0,
-        user_pk: child_team_pk,
-        author_display_name: team.display_name.clone(),
-        author_profile_url: team.profile_url.clone(),
-        author_username: team.username.clone(),
-        author_type: crate::common::types::UserType::Team,
-        space_pk: None,
-        space_type: None,
-        space_visibility: None,
-        booster: None,
-        rewards: None,
-        urls: vec![],
-        attachments: vec![],
-        categories: vec![],
-        announcement_id: Some(announcement.announcement_id.clone()),
-        announcement_parent_team_id: Some(parent_team_id_str),
-        pinned_as_announcement: false,
-    };
-    anchor_post.create(cli).await.map_err(|e| {
-        crate::error!("send_direct_message anchor post create failed: {e}");
-        SubTeamError::AnnouncementPublishFailed
-    })?;
-
-    // Pre-populate `target_post_pk` on the announcement row so the
-    // parent's direct-message history can render deep links without
-    // a backfill. Stream-driven fanout will overwrite this with the
-    // same value later, but writing it now keeps the row consistent
-    // even if the stream is delayed.
-    announcement.target_post_pk = Some(anchor_post.pk.to_string());
-
-    announcement.create(cli).await.map_err(|e| {
-        crate::error!("send_direct_message create failed: {e}");
-        SubTeamError::AnnouncementPublishFailed
-    })?;
-
-    Ok(announcement.into())
-}
 
 // ── GET /api/teams/:team_pk/sub-teams/:sub_team_id/direct-messages ───────
 //
@@ -206,7 +77,6 @@ pub async fn list_direct_messages_handler(
         }
     }
 
-    let response: Vec<SubTeamAnnouncementResponse> =
-        items.into_iter().map(Into::into).collect();
+    let response: Vec<SubTeamAnnouncementResponse> = items.into_iter().map(Into::into).collect();
     Ok((response, next).into())
 }

--- a/app/ratel/src/features/sub_team/hooks/use_sub_team_activity.rs
+++ b/app/ratel/src/features/sub_team/hooks/use_sub_team_activity.rs
@@ -8,11 +8,10 @@ use crate::common::hooks::{use_infinite_query, InfiniteQuery};
 use crate::features::sub_team::controllers::{
     get_sub_team_activity_handler, get_sub_team_detail_handler,
     get_sub_team_member_activity_handler, list_direct_messages_handler,
-    send_direct_message_handler,
 };
 use crate::features::sub_team::types::{
-    ActivityCountsResponse, ActivityWindow, MemberActivityResponse, SendDirectMessageRequest,
-    SubTeamAnnouncementResponse, SubTeamDetailResponse,
+    ActivityCountsResponse, ActivityWindow, MemberActivityResponse, SubTeamAnnouncementResponse,
+    SubTeamDetailResponse,
 };
 use crate::*;
 
@@ -26,12 +25,10 @@ pub struct UseSubTeamActivity {
     pub members:
         InfiniteQuery<String, MemberActivityResponse, ListResponse<MemberActivityResponse>>,
     /// History of direct ("이 하위팀에만 공지") announcements this parent
-    /// has sent to the sub-team in view. Refreshes after each successful
-    /// send via `handle_send_direct`.
+    /// has sent to the sub-team in view. Sends now go through the shared
+    /// broadcast composer (Draft → Publish), which writes the row this
+    /// loader queries on the next mount.
     pub direct_messages: Loader<ListResponse<SubTeamAnnouncementResponse>>,
-    /// Fire-and-await action that posts a single direct announcement and
-    /// re-loads `direct_messages` on success.
-    pub handle_send_direct: Action<(SendDirectMessageRequest,), ()>,
 }
 
 #[track_caller]
@@ -68,19 +65,11 @@ pub fn use_sub_team_activity() -> std::result::Result<UseSubTeamActivity, Render
         async move { get_sub_team_member_activity_handler(tid, sid, Some(w), bookmark).await }
     })?;
 
-    let mut direct_messages = use_loader(move || {
+    let direct_messages = use_loader(move || {
         let tid = team_id_signal();
         let sid = sub_team_id_signal();
         async move { list_direct_messages_handler(tid, sid, None).await }
     })?;
-
-    let handle_send_direct = use_action(move |req: SendDirectMessageRequest| async move {
-        let tid = team_id_signal();
-        let sid = sub_team_id_signal();
-        send_direct_message_handler(tid, sid, req).await?;
-        direct_messages.restart();
-        Ok::<(), crate::common::Error>(())
-    });
 
     Ok(use_context_provider(|| UseSubTeamActivity {
         team_id: team_id_signal,
@@ -90,6 +79,5 @@ pub fn use_sub_team_activity() -> std::result::Result<UseSubTeamActivity, Render
         counts,
         members,
         direct_messages,
-        handle_send_direct,
     }))
 }

--- a/app/ratel/src/features/sub_team/hooks/use_sub_team_broadcast_compose.rs
+++ b/app/ratel/src/features/sub_team/hooks/use_sub_team_broadcast_compose.rs
@@ -45,6 +45,11 @@ pub struct UseSubTeamBroadcastCompose {
     pub attachments: Signal<Vec<File>>,
     pub space_enabled: Signal<bool>,
     pub space_type: Signal<Option<SpaceType>>,
+    /// `Some(child_id)` when the composer was opened from the parent's
+    /// sub-team detail page → publish fans out to exactly that one sub-team.
+    /// `None` for the standard broadcast-to-all flow. Seeded from context
+    /// on first hook construction; immutable for the composer's lifetime.
+    pub target_child_team_id: ReadSignal<Option<TeamPartition>>,
 
     // Draft autosave lifecycle.
     pub draft_status: Signal<BroadcastDraftStatus>,
@@ -91,6 +96,12 @@ pub fn use_sub_team_broadcast_compose(
     let team_id_signal: ReadSignal<TeamPartition> = use_signal(|| team_id).into();
     let initial_announcement_id: Option<String> = try_consume_context().unwrap_or(None);
     let announcement_id: Signal<Option<String>> = use_signal(|| initial_announcement_id);
+    // Direct-message target seeded from context by the page wrapper.
+    // `None` for the broadcast-to-all flow; `Some(child)` for the
+    // direct-to-one flow opened from the parent's sub-team detail page.
+    let initial_target: Option<TeamPartition> = try_consume_context().unwrap_or(None);
+    let target_child_team_id: ReadSignal<Option<TeamPartition>> =
+        use_signal(|| initial_target).into();
 
     let announcement_loader = use_loader(move || {
         let tid = team_id_signal();
@@ -165,6 +176,7 @@ pub fn use_sub_team_broadcast_compose(
         attachments,
         space_enabled,
         space_type,
+        target_child_team_id,
         draft_status,
         last_saved_at,
         handle_save_new,

--- a/app/ratel/src/features/sub_team/i18n.rs
+++ b/app/ratel/src/features/sub_team/i18n.rs
@@ -139,6 +139,11 @@ translate! {
     broadcast_title: { en: "Title", ko: "제목" },
     broadcast_body: { en: "Body", ko: "본문" },
     broadcast_compose: { en: "Write announcement", ko: "공지 작성" },
+    // direct_compose — composer eyebrow + topbar copy + detail-page CTA
+    // for the direct-to-one-sub-team flow. Shares the broadcast editor +
+    // Draft → Publish lifecycle; only the publish-time fanout target
+    // diverges (one child team vs every recognized sub-team).
+    direct_compose: { en: "Write to this sub-team", ko: "이 하위팀에만 공지" },
     broadcast_publish: { en: "Publish", ko: "발행" },
     sub_team_options: { en: "Options", ko: "옵션" },
     sub_team_options_drawer_title: { en: "Document options", ko: "문서 옵션" },
@@ -353,15 +358,6 @@ translate! {
     direct_announce_title: {
         en: "Direct announcement",
         ko: "이 하위팀에만 공지",
-    },
-    direct_announce_placeholder: {
-        en: "Write a private announcement for this sub-team only…",
-        ko: "이 하위팀에만 보낼 공지를 작성하세요…",
-    },
-    direct_announce_send: { en: "Send", ko: "발송" },
-    direct_announce_title_input: {
-        en: "Announcement title",
-        ko: "공지 제목",
     },
     direct_announce_note: {
         en: "Pinned to this sub-team's feed only · not counted as a broadcast",

--- a/app/ratel/src/features/sub_team/models/sub_team_announcement.rs
+++ b/app/ratel/src/features/sub_team/models/sub_team_announcement.rs
@@ -125,11 +125,18 @@ pub enum BroadcastTarget {
 
 #[cfg(feature = "server")]
 impl SubTeamAnnouncement {
+    /// Create a Draft. `target_child_team_id` is `None` for the standard
+    /// broadcast-to-all flow and `Some(child_id)` for the direct-to-one
+    /// flow (composed from the parent's sub-team detail page) — both
+    /// share the same Draft → Publish 2-step lifecycle; the difference
+    /// only shows up at publish time, where the fanout writes one Post
+    /// to the target child's feed instead of every recognized sub-team.
     pub fn new_draft(
         parent_team_pk: Partition,
         title: String,
         body: String,
         author_user_id: String,
+        target_child_team_id: Option<TeamPartition>,
     ) -> Self {
         let announcement_id = uuid::Uuid::new_v4().to_string();
         let now = crate::common::utils::time::get_now_timestamp_millis();
@@ -153,49 +160,10 @@ impl SubTeamAnnouncement {
             space_type: None,
             space_pk: None,
             fan_out_count: 0,
-            target_child_team_id: None,
+            target_child_team_id: target_child_team_id.map(|p| p.0),
             target_post_pk: None,
             broadcast_notified_at: None,
         }
     }
 
-    /// Direct announcement to a single recognized sub-team. Created as
-    /// `Published` immediately — no draft step. The fanout handler picks
-    /// up the `target_child_team_id` and writes exactly one Post to that
-    /// child's feed, demoting any prior direct-message Post from this
-    /// parent so only the latest stays pinned.
-    pub fn new_direct(
-        parent_team_pk: Partition,
-        target_child_team_id: String,
-        title: String,
-        body: String,
-        author_user_id: String,
-    ) -> Self {
-        let announcement_id = uuid::Uuid::new_v4().to_string();
-        let now = crate::common::utils::time::get_now_timestamp_millis();
-        Self {
-            pk: parent_team_pk,
-            sk: EntityType::SubTeamAnnouncement(announcement_id.clone()),
-            created_at: now,
-            updated_at: now,
-            published_at: Some(now),
-            announcement_id,
-            title,
-            body: String::new(),
-            html_contents: body,
-            tags: Vec::new(),
-            attachments: Vec::new(),
-            author_user_id,
-            status: SubTeamAnnouncementStatus::Published,
-            target_type: BroadcastTarget::AllRecognizedSubTeams,
-            visibility: Visibility::Public,
-            space_enabled: false,
-            space_type: None,
-            space_pk: None,
-            fan_out_count: 0,
-            target_child_team_id: Some(target_child_team_id),
-            target_post_pk: None,
-            broadcast_notified_at: None,
-        }
-    }
 }

--- a/app/ratel/src/features/sub_team/pages/broadcast_compose/component.rs
+++ b/app/ratel/src/features/sub_team/pages/broadcast_compose/component.rs
@@ -19,15 +19,29 @@ use crate::*;
 
 #[component]
 pub fn TeamSubTeamBroadcastComposePage(username: String) -> Element {
-    render_compose(username, None)
+    render_compose(username, None, None)
 }
 
 #[component]
 pub fn TeamSubTeamBroadcastEditPage(username: String, announcement_id: String) -> Element {
-    render_compose(username, Some(announcement_id))
+    render_compose(username, Some(announcement_id), None)
 }
 
-fn render_compose(username: String, announcement_id: Option<String>) -> Element {
+/// Direct-to-one-sub-team composer. Same editor, autosave, and
+/// Draft → Publish 2-step flow as the broadcast composer — the
+/// difference is the publish fanout writes one Post to the target
+/// child's feed instead of every recognized sub-team.
+#[component]
+pub fn TeamSubTeamDirectComposePage(username: String, sub_team_id: String) -> Element {
+    let target = TeamPartition(sub_team_id);
+    render_compose(username, None, Some(target))
+}
+
+fn render_compose(
+    username: String,
+    announcement_id: Option<String>,
+    target_child_team_id: Option<TeamPartition>,
+) -> Element {
     let tr: SubTeamTranslate = use_translate();
 
     let username_for_load = username.clone();
@@ -50,6 +64,12 @@ fn render_compose(username: String, announcement_id: Option<String>) -> Element 
     use_context_provider(|| team_id);
     let announcement_id_for_ctx = announcement_id.clone();
     use_context_provider(move || announcement_id_for_ctx.clone());
+    // Seeds `target_child_team_id` inside `use_sub_team_broadcast_compose`.
+    // Provided unconditionally (as `Option<TeamPartition>`) so the hook's
+    // `try_consume_context::<Option<TeamPartition>>()` always finds a value
+    // and the broadcast / direct branches diverge only on `Some` vs `None`.
+    let target_for_ctx = target_child_team_id.clone();
+    use_context_provider(move || target_for_ctx.clone());
 
     rsx! {
         SeoMeta { title: "{tr.broadcast_compose}" }
@@ -75,12 +95,17 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
         mut attachments,
         mut space_enabled,
         space_type,
+        target_child_team_id,
         mut draft_status,
         mut last_saved_at,
         mut handle_save_new,
         mut handle_save_existing,
         ..
     } = ctx;
+    // `is_direct` is fixed for the composer's lifetime (set by the page
+    // wrapper). Used both for the create payload and for the topbar copy
+    // ("Send to one sub-team" vs the default broadcast).
+    let is_direct: bool = target_child_team_id().is_some();
 
     // Local-only signal for the tag-input field. `tags` is the committed
     // chip list; this holds whatever the user is typing before Enter.
@@ -165,6 +190,7 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                             attachments: at,
                             space_enabled: se,
                             space_type: st,
+                            target_child_team_id: target_child_team_id(),
                         });
                     }
                 }
@@ -193,12 +219,19 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
     let username_for_publish = username.clone();
     let username_for_discard = username.clone();
     let _ = username;
+    // Direct messages navigate back to the sub-team detail page they
+    // were composed from; broadcasts return to the management list. The
+    // target id is captured here (rather than inside the async block) so
+    // the closure doesn't have to read the signal across the await.
+    let post_publish_target: Option<TeamPartition> = target_child_team_id();
+    let post_publish_target_for_discard = post_publish_target.clone();
     // Await the publish HTTP request BEFORE navigating. Using `Action::call`
     // here would detach the future from this component; the nav.push that
     // follows would then unmount the component and drop the in-flight
     // request, leaving the draft stuck in `작성중 · DRAFTS`.
     let publish = use_callback(move |_| {
         let username = username_for_publish.clone();
+        let target = post_publish_target.clone();
         spawn(async move {
             if let Some(id) = announcement_id() {
                 if let Err(e) = ctx.publish_announcement(id).await {
@@ -206,12 +239,19 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                     return;
                 }
             }
-            nav.push(Route::TeamSubTeamManagementPage { username });
+            match target {
+                Some(child) => nav.push(Route::TeamSubTeamDetailPage {
+                    username,
+                    sub_team_id: child.0,
+                }),
+                None => nav.push(Route::TeamSubTeamManagementPage { username }),
+            };
         });
     });
 
     let discard = move |_| {
         let username = username_for_discard.clone();
+        let target = post_publish_target_for_discard.clone();
         async move {
             if let Some(id) = announcement_id() {
                 if let Err(e) = ctx.delete_announcement(id).await {
@@ -219,7 +259,13 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                     return;
                 }
             }
-            nav.push(Route::TeamSubTeamManagementPage { username });
+            match target {
+                Some(child) => nav.push(Route::TeamSubTeamDetailPage {
+                    username,
+                    sub_team_id: child.0,
+                }),
+                None => nav.push(Route::TeamSubTeamManagementPage { username }),
+            };
         }
     };
 
@@ -249,8 +295,24 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                         lucide_dioxus::ChevronLeft { class: "w-4 h-4 [&>path]:stroke-current" }
                     }
                     div { class: "topbar-title",
-                        span { class: "topbar-title__eyebrow", "{tr.broadcast_compose}" }
-                        span { class: "topbar-title__main", "{tr.broadcast_compose}" }
+                        // Direct-to-one-sub-team composer shows the
+                        // "Write to this sub-team" copy in both the
+                        // eyebrow and the main row so it visibly diverges
+                        // from the broadcast flow.
+                        span { class: "topbar-title__eyebrow",
+                            if is_direct {
+                                "{tr.direct_compose}"
+                            } else {
+                                "{tr.broadcast_compose}"
+                            }
+                        }
+                        span { class: "topbar-title__main",
+                            if is_direct {
+                                "{tr.direct_compose}"
+                            } else {
+                                "{tr.broadcast_compose}"
+                            }
+                        }
                     }
                 }
                 div { class: "arena-topbar__right",
@@ -309,9 +371,7 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                 }
 
                 // ── Right panel ───────────────────────────────────
-                aside {
-                    class: "side-panel",
-                    "data-open": drawer_open(),
+                aside { class: "side-panel", "data-open": drawer_open(),
                     // Mobile drawer head — handle + title + close button.
                     // Hidden on desktop via base `.side-panel__head { display: none }`.
                     div { class: "side-panel__head",
@@ -328,8 +388,18 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                                 stroke_width: "2",
                                 stroke_linecap: "round",
                                 stroke_linejoin: "round",
-                                line { x1: "18", y1: "6", x2: "6", y2: "18" }
-                                line { x1: "6", y1: "6", x2: "18", y2: "18" }
+                                line {
+                                    x1: "18",
+                                    y1: "6",
+                                    x2: "6",
+                                    y2: "18",
+                                }
+                                line {
+                                    x1: "6",
+                                    y1: "6",
+                                    x2: "18",
+                                    y2: "18",
+                                }
                             }
                         }
                     }
@@ -682,15 +752,60 @@ fn ComposeForm(username: String, team_display: String, team_handle: String) -> E
                             stroke_width: "2",
                             stroke_linecap: "round",
                             stroke_linejoin: "round",
-                            line { x1: "4", y1: "21", x2: "4", y2: "14" }
-                            line { x1: "4", y1: "10", x2: "4", y2: "3" }
-                            line { x1: "12", y1: "21", x2: "12", y2: "12" }
-                            line { x1: "12", y1: "8", x2: "12", y2: "3" }
-                            line { x1: "20", y1: "21", x2: "20", y2: "16" }
-                            line { x1: "20", y1: "12", x2: "20", y2: "3" }
-                            line { x1: "1", y1: "14", x2: "7", y2: "14" }
-                            line { x1: "9", y1: "8", x2: "15", y2: "8" }
-                            line { x1: "17", y1: "16", x2: "23", y2: "16" }
+                            line {
+                                x1: "4",
+                                y1: "21",
+                                x2: "4",
+                                y2: "14",
+                            }
+                            line {
+                                x1: "4",
+                                y1: "10",
+                                x2: "4",
+                                y2: "3",
+                            }
+                            line {
+                                x1: "12",
+                                y1: "21",
+                                x2: "12",
+                                y2: "12",
+                            }
+                            line {
+                                x1: "12",
+                                y1: "8",
+                                x2: "12",
+                                y2: "3",
+                            }
+                            line {
+                                x1: "20",
+                                y1: "21",
+                                x2: "20",
+                                y2: "16",
+                            }
+                            line {
+                                x1: "20",
+                                y1: "12",
+                                x2: "20",
+                                y2: "3",
+                            }
+                            line {
+                                x1: "1",
+                                y1: "14",
+                                x2: "7",
+                                y2: "14",
+                            }
+                            line {
+                                x1: "9",
+                                y1: "8",
+                                x2: "15",
+                                y2: "8",
+                            }
+                            line {
+                                x1: "17",
+                                y1: "16",
+                                x2: "23",
+                                y2: "16",
+                            }
                         }
                         "{tr.sub_team_options}"
                     }

--- a/app/ratel/src/features/sub_team/pages/detail/component.rs
+++ b/app/ratel/src/features/sub_team/pages/detail/component.rs
@@ -369,10 +369,12 @@ fn DirectAnnouncementCard(username: String, sub_team_id: String) -> Element {
             div { class: "direct-msg",
                 div { class: "direct-msg__foot",
                     span { class: "direct-msg__note", "{tr.direct_announce_note}" }
-                    button {
-                        class: "btn btn--primary btn--small",
+                    Button {
+                        size: ButtonSize::Small,
+                        style: ButtonStyle::Primary,
+                        shape: ButtonShape::Rounded,
+                        class: "inline-flex gap-2 items-center".to_string(),
                         "data-testid": "sub-team-direct-msg-compose-cta",
-                        r#type: "button",
                         onclick: move |_| {
                             nav.push(Route::TeamSubTeamDirectComposePage {
                                 username: username_for_nav.clone(),

--- a/app/ratel/src/features/sub_team/pages/detail/component.rs
+++ b/app/ratel/src/features/sub_team/pages/detail/component.rs
@@ -303,7 +303,10 @@ fn DetailView(username: String, sub_team_id: String) -> Element {
                 }
 
                 // Direct announcement (only-to-this-sub-team)
-                DirectAnnouncementCard {}
+                DirectAnnouncementCard {
+                    username: username.clone(),
+                    sub_team_id: sub_team_id.clone(),
+                }
 
                 // Danger zone (deregister)
                 section { class: "card",
@@ -337,28 +340,24 @@ fn DetailView(username: String, sub_team_id: String) -> Element {
     }
 }
 
-/// "이 하위팀에만 공지" card. Inline compose (no draft) + history list.
-/// Posts to `POST /api/teams/:parent/sub-teams/:child/direct-message`
-/// then re-fetches `GET /...direct-messages` so the new entry shows up
-/// without a full page reload.
+/// "이 하위팀에만 공지" card. CTA → full Draft → Publish editor at
+/// `/sub-teams/:sub_team_id/compose`, plus a history list of past direct
+/// messages with deep links. The previous inline single-step compose
+/// (title + plain-text body, immediate publish) was replaced so direct
+/// messages share the broadcast composer's rich editor, attachments,
+/// Space attachment, and Draft → Publish 2-step lifecycle — only the
+/// publish-time fanout target differs.
 #[component]
-fn DirectAnnouncementCard() -> Element {
-    use crate::features::sub_team::types::SendDirectMessageRequest;
-
+fn DirectAnnouncementCard(username: String, sub_team_id: String) -> Element {
     let tr: SubTeamTranslate = use_translate();
+    let nav = use_navigator();
 
-    let UseSubTeamActivity {
-        direct_messages,
-        mut handle_send_direct,
-        ..
-    } = use_sub_team_activity()?;
+    let UseSubTeamActivity { direct_messages, .. } = use_sub_team_activity()?;
 
-    let mut title: Signal<String> = use_signal(String::new);
-    let mut body: Signal<String> = use_signal(String::new);
-    let mut error_msg: Signal<Option<String>> = use_signal(|| None);
-
-    let send_disabled = title().trim().is_empty() || handle_send_direct.pending();
     let items = direct_messages();
+    let sub_team_id_for_nav = sub_team_id.clone();
+    let username_for_nav = username.clone();
+    let _ = (username, sub_team_id);
 
     rsx! {
         section { class: "card",
@@ -368,49 +367,21 @@ fn DirectAnnouncementCard() -> Element {
             }
 
             div { class: "direct-msg",
-                input {
-                    class: "direct-msg__title",
-                    r#type: "text",
-                    "data-testid": "sub-team-direct-msg-title",
-                    placeholder: "{tr.direct_announce_title_input}",
-                    value: "{title()}",
-                    oninput: move |e| {
-                        title.set(e.value());
-                        error_msg.set(None);
-                    },
-                }
-                textarea {
-                    class: "direct-msg__body",
-                    "data-testid": "sub-team-direct-msg-body",
-                    placeholder: "{tr.direct_announce_placeholder}",
-                    value: "{body()}",
-                    oninput: move |e| body.set(e.value()),
-                }
                 div { class: "direct-msg__foot",
                     span { class: "direct-msg__note", "{tr.direct_announce_note}" }
                     button {
                         class: "btn btn--primary btn--small",
-                        "data-testid": "sub-team-direct-msg-send",
+                        "data-testid": "sub-team-direct-msg-compose-cta",
                         r#type: "button",
-                        disabled: send_disabled,
                         onclick: move |_| {
-                            if !send_disabled {
-                                let req = SendDirectMessageRequest {
-                                    title: title(),
-                                    body: body(),
-                                };
-                                handle_send_direct.call(req);
-                                title.set(String::new());
-                                body.set(String::new());
-                                error_msg.set(None);
-                            }
+                            nav.push(Route::TeamSubTeamDirectComposePage {
+                                username: username_for_nav.clone(),
+                                sub_team_id: sub_team_id_for_nav.clone(),
+                            });
                         },
                         lucide_dioxus::Send { class: "w-3 h-3 [&>path]:stroke-current" }
-                        "{tr.direct_announce_send}"
+                        "{tr.direct_compose}"
                     }
-                }
-                if let Some(msg) = error_msg() {
-                    div { class: "direct-msg__error", "{msg}" }
                 }
             }
 

--- a/app/ratel/src/features/sub_team/services/broadcast_access.rs
+++ b/app/ratel/src/features/sub_team/services/broadcast_access.rs
@@ -1,10 +1,11 @@
 //! Audience gate for sub-team broadcast / direct-message Posts.
 //!
 //! Posts authored via `publish_announcement_handler` (broadcast to every
-//! recognized child) and `send_direct_message_handler` (1:1 to a single
-//! recognized child) are written with `visibility = Visibility::Broadcast`.
-//! That marker hands access control off to this module — Posts and any
-//! attached Space refuse to render to viewers outside the audience.
+//! recognized child when `target_child_team_id = None`, 1:1 to a single
+//! recognized child when `target_child_team_id = Some(child)`) are
+//! written with `visibility = Visibility::Broadcast`. That marker hands
+//! access control off to this module — Posts and any attached Space
+//! refuse to render to viewers outside the audience.
 //!
 //! Audience by announcement shape:
 //! - **Broadcast** (`SubTeamAnnouncement.target_child_team_id = None`):

--- a/app/ratel/src/features/sub_team/types/dto.rs
+++ b/app/ratel/src/features/sub_team/types/dto.rs
@@ -556,25 +556,13 @@ pub struct SubTeamAnnouncementResponse {
     /// (rendered on the parent's sub-team detail page); `None` for the
     /// standard broadcast-to-all flow.
     #[serde(default)]
-    pub target_child_team_id: Option<String>,
+    pub target_child_team_id: Option<TeamPartition>,
     /// Fan-out Post pk in the target child's feed (raw uuid, no "FEED#"
     /// prefix). Set after `handle_announcement_published` writes the
     /// Post — used by the parent's history row to link to the actual
     /// Post detail page rather than rebuilding URLs from announcement_id.
     #[serde(default)]
     pub target_post_pk: Option<String>,
-}
-
-/// Request body for `POST /sub-teams/:sub_team_id/direct-message` — the
-/// "이 하위팀에만 공지" card on the parent's sub-team detail page.
-/// Single-step (no draft); publishes immediately on call.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[cfg_attr(feature = "server", derive(rmcp::schemars::JsonSchema))]
-pub struct SendDirectMessageRequest {
-    pub title: String,
-    /// HTML body. Rendered as-is in the child team's fanned-out Post.
-    #[serde(default)]
-    pub body: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -593,6 +581,12 @@ pub struct CreateSubTeamAnnouncementRequest {
     pub space_enabled: bool,
     #[serde(default)]
     pub space_type: Option<crate::features::posts::types::SpaceType>,
+    /// `Some(child_team_id)` makes this a direct-to-one-sub-team draft —
+    /// it follows the same Draft → Publish 2-step flow as a broadcast, but
+    /// publish fans out exactly one Post to the target child's feed and
+    /// keeps the announcement off the parent's wall.
+    #[serde(default)]
+    pub target_child_team_id: Option<TeamPartition>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -636,7 +630,7 @@ impl From<crate::features::sub_team::models::SubTeamAnnouncement> for SubTeamAnn
             created_at: a.created_at,
             updated_at: a.updated_at,
             published_at: a.published_at,
-            target_child_team_id: a.target_child_team_id,
+            target_child_team_id: a.target_child_team_id.map(TeamPartition),
             target_post_pk: a.target_post_pk,
         }
     }

--- a/app/ratel/src/route.rs
+++ b/app/ratel/src/route.rs
@@ -59,8 +59,8 @@ use crate::FactFoldRoundEntityType;
 use crate::features::sub_team::pages::{
     TeamBylawsPage, TeamLeaveParentPage, TeamSubTeamApplicationStatusPage, TeamSubTeamApplyPage,
     TeamSubTeamBroadcastComposePage, TeamSubTeamBroadcastEditPage, TeamSubTeamDeregisterPage,
-    TeamSubTeamBylawsComposePage, TeamSubTeamDetailPage, TeamSubTeamDocEditPage,
-    TeamSubTeamManagementPage,
+    TeamSubTeamBylawsComposePage, TeamSubTeamDetailPage, TeamSubTeamDirectComposePage,
+    TeamSubTeamDocEditPage, TeamSubTeamManagementPage,
 };
 
 use crate::features::posts::{Index as PostIndex, PostDetail, PostEdit};
@@ -249,6 +249,15 @@ pub enum Route {
                 TeamSubTeamManagementPage { username: String },
             #[end_layout]
 
+            // Direct-to-one-sub-team composer. Same shared editor as
+            // `TeamSubTeamBroadcastComposePage`, but the publish fans
+            // out to exactly one sub-team (the route's `sub_team_id`)
+            // instead of every recognized child. Declared BEFORE the
+            // wildcard `:sub_team_id` detail route so the router matches
+            // the more specific `/sub-teams/:sub_team_id/compose` path
+            // first.
+            #[route("/sub-teams/:sub_team_id/compose")]
+            TeamSubTeamDirectComposePage { username: String, sub_team_id: String },
             // Sub-team detail — declared AFTER the layout block so the
             // dioxus router matches the more specific `/sub-teams/manage`
             // (inside the layout) before falling back to this wildcard.


### PR DESCRIPTION
## Summary

- Specific sub-team detail page (`/teams/:username/sub-teams/:sub_team_id`) used to render a single-step inline form for "이 하위팀에만 공지" — no rich editor, no attachments, no Space attach, no draft.
- This change routes that flow through the **same composer** as the broadcast tab (`/teams/:username/sub-teams/announcements/compose`), so direct messages get the full editor, attachments, Space attachment, and the Draft → Publish 2-step lifecycle. Only the publish-time fanout target diverges: one child team vs every recognized sub-team.
- Drops the now-unused `send_direct_message_handler` 1-step endpoint, its DTO, the model's `new_direct` constructor, the `handle_send_direct` action on `UseSubTeamActivity`, and three inline-form i18n keys. The `list_direct_messages_handler` history endpoint is kept — the detail page still renders past direct messages from it.

## Type safety

Per a reviewer preference, every API surface carrying a team id now uses the typed `TeamPartition` SubPartition wrapper instead of `String` — DTO fields, hook signals, component props. The DynamoDB storage column inside `SubTeamAnnouncement` stays `Option<String>` (storage layer); the boundary types do the conversion.

## Changes

**Server**
- `CreateSubTeamAnnouncementRequest.target_child_team_id: Option<TeamPartition>` (new)
- `SubTeamAnnouncementResponse.target_child_team_id: Option<TeamPartition>` (was `Option<String>`)
- `SubTeamAnnouncement::new_draft` now takes `Option<TeamPartition>`
- `create_announcement_handler` verifies the target is a recognized sub-team via `SubTeamLink::get` before persisting
- `publish_announcement_handler` branches on direct/broadcast: anchor Post `user_pk = Partition::Team(target_child_team_id)`, `pinned_as_announcement: false`, `target_post_pk` pre-populated when direct; bypasses the `MAX_RECOGNIZED_SUB_TEAMS` cap (single target) but re-verifies the link still exists at publish time
- Existing fanout in `services::announcement_fanout::handle_announcement_published` already supports `target_child_team_id` — no fanout changes

**Client**
- `UseSubTeamBroadcastCompose` exposes `target_child_team_id: ReadSignal<Option<TeamPartition>>`, seeded from context by the page wrapper, included in the create payload, and used to decide post-publish navigation (back to the detail page vs the broadcast management list)
- New `TeamSubTeamDirectComposePage` component reusing the broadcast composer with the target seeded
- New route: `#[route(\"/sub-teams/:sub_team_id/compose\")] TeamSubTeamDirectComposePage`
- Detail page swaps its inline title+textarea form for a CTA button that navigates to the new composer
- Topbar copy switches to "Write to this sub-team" when `is_direct`; new i18n key `direct_compose` (en/ko)

**Removed**
- `controllers/direct_message.rs::send_direct_message_handler`
- `types/dto.rs::SendDirectMessageRequest`
- `models/sub_team_announcement.rs::SubTeamAnnouncement::new_direct`
- `hooks/use_sub_team_activity.rs::UseSubTeamActivity::handle_send_direct`
- i18n keys: `direct_announce_placeholder`, `direct_announce_send`, `direct_announce_title_input`

## Test plan

- [x] `cargo check --features server` passes with `-D warnings`
- [x] `cargo check --features web` passes with `-D warnings`
- [x] `dx check --web` passes
- [x] `cargo check --tests --features bypass` passes
- [ ] Manual: open `/teams/{parent}/sub-teams/{child}` → click "Write to this sub-team" → composer opens with same UI as `/sub-teams/announcements/compose` → type → autosave persists Draft → "Publish" → only the target child team's feed receives the Post (parent's broadcast tab does NOT show it as a sent broadcast)
- [ ] Manual: open the same composer with `space_enabled = true` → publish → Space is attached to the single target child's Post only
- [ ] Manual: existing broadcast flow at `/sub-teams/announcements/compose` still fans out to every recognized sub-team
- [ ] Follow-up: Playwright coverage for the direct-compose flow (added on next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)