### PR TITLE
fix(spaces): guard bump_participant_activity against partial row writes

### DIFF
--- a/app/ratel/src/features/spaces/space_common/services/participant_activity.rs
+++ b/app/ratel/src/features/spaces/space_common/services/participant_activity.rs
@@ -3,21 +3,54 @@ use crate::common::models::space::SpaceParticipant;
 use crate::common::utils::time::get_now_timestamp_millis;
 
 /// Best-effort: failures must not block the user's underlying action.
+///
+/// Conditional on `attribute_exists(created_at)` so we never write a
+/// partial SpaceParticipant row. The naive
+/// `SpaceParticipant::updater(pk, sk).with_last_activity_at(now).execute(cli)`
+/// path used to fail closed: DynamoDB's `UpdateItem` creates a brand-new
+/// item containing ONLY the keys plus `last_activity_at` when the row
+/// didn't exist, which then made every subsequent
+/// `SpaceParticipant::get` (e.g. inside `get_space`) blow up with
+/// `serde_dynamo: missing field 'created_at'`. The most common trigger
+/// was a team-owned space's parent-team admin (Creator role, never a
+/// Participant) running `create_discussion` — they have no
+/// SpaceParticipant row to bump, so the partial row would get created
+/// here and the next page load would render "Something went wrong".
+///
+/// Same condition also covers the "row exists but is partial because of
+/// the old bug" case in already-deployed environments: those rows lack
+/// `created_at`, so the condition fails and we skip them too.
 pub async fn bump_participant_activity(
     cli: &aws_sdk_dynamodb::Client,
     space_pk: &Partition,
     user_pk: &Partition,
 ) {
+    use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
+    use aws_sdk_dynamodb::types::AttributeValue as AV;
+
     let (pk, sk) = SpaceParticipant::keys(space_pk.clone(), user_pk.clone());
     let now = get_now_timestamp_millis();
 
-    if let Err(e) = SpaceParticipant::updater(pk, sk)
-        .with_last_activity_at(now)
-        .execute(cli)
-        .await
-    {
+    let resp = cli
+        .update_item()
+        .table_name(SpaceParticipant::table_name())
+        .key("pk", AV::S(pk.to_string()))
+        .key("sk", AV::S(sk.to_string()))
+        .update_expression("SET last_activity_at = :now")
+        .condition_expression("attribute_exists(created_at)")
+        .expression_attribute_values(":now", AV::N(now.to_string()))
+        .send()
+        .await;
+
+    if let Err(e) = resp {
+        let svc = e.into_service_error();
+        // ConditionalCheckFailedException → row missing or partial; not a
+        // participant we care about. Silent skip is intentional.
+        if matches!(svc, UpdateItemError::ConditionalCheckFailedException(_)) {
+            return;
+        }
         crate::error!(
-            "bump_participant_activity failed (space={}, user={}): {e}",
+            "bump_participant_activity failed (space={}, user={}): {svc}",
             space_pk,
             user_pk
         );

--- a/app/ratel/src/tests/mod.rs
+++ b/app/ratel/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod inbox_helper_tests;
 mod mcp_tests;
 mod meet_action_tests;
 mod notifications_tests;
+mod participant_activity_tests;
 mod post_tests;
 mod space_action_notification_tests;
 mod space_member_tests;

--- a/app/ratel/src/tests/participant_activity_tests.rs
+++ b/app/ratel/src/tests/participant_activity_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use crate::common::models::space::SpaceParticipant;
+use crate::common::types::{EntityType, Partition};
+use crate::features::spaces::space_common::services::bump_participant_activity;
+
+/// Regression test for the sub-team broadcast "Something went wrong" bug.
+///
+/// Before the fix `bump_participant_activity` issued a bare
+/// `SpaceParticipant::updater(pk, sk).with_last_activity_at(now).execute(cli)`
+/// against the DDB row. When the row did not exist (always the case for
+/// a team-owned space whose Creator is the parent-team admin — they're a
+/// Creator role but never a participant), DynamoDB's `UpdateItem`
+/// happily created a brand-new item containing ONLY the keys plus
+/// `last_activity_at`, missing every required field of
+/// `SpaceParticipant` (`created_at`, `display_name`, ...). The next
+/// `SpaceParticipant::get` issued from `get_space` then panicked with
+/// `serde_dynamo: missing field 'created_at'`, and the entire space
+/// arena rendered "Something went wrong" on the next page load.
+///
+/// The fix makes the helper a no-op when no participant row exists by
+/// conditioning the update on `attribute_exists(created_at)`. This test
+/// covers both shapes:
+///   1. No participant row → bump is a silent no-op, no partial row is
+///      written.
+///   2. Real participant row → bump updates `last_activity_at` without
+///      clobbering other fields.
+#[tokio::test]
+async fn test_bump_participant_activity_no_partial_row_when_user_is_not_participant() {
+    let ctx = TestContext::setup().await;
+
+    // Pick arbitrary keys. We don't even need a real SpaceCommon row —
+    // the helper only writes against SpaceParticipant.
+    let space_pk = Partition::Space(uuid::Uuid::new_v4().to_string());
+    let user_pk = ctx.test_user.0.pk.clone();
+
+    // Sanity: row doesn't exist before the bump.
+    let (lookup_pk, lookup_sk) = SpaceParticipant::keys(space_pk.clone(), user_pk.clone());
+    let pre = SpaceParticipant::get(&ctx.ddb, &lookup_pk, Some(&lookup_sk))
+        .await
+        .expect("pre-bump get must not error");
+    assert!(pre.is_none(), "precondition: no SpaceParticipant row");
+
+    // Bump must not panic, must not propagate an error, and must NOT
+    // create a partial row.
+    bump_participant_activity(&ctx.ddb, &space_pk, &user_pk).await;
+
+    let post = SpaceParticipant::get(&ctx.ddb, &lookup_pk, Some(&lookup_sk))
+        .await
+        .expect(
+            "post-bump get must succeed — if this fails with `missing field`, \
+             the helper wrote a partial row again",
+        );
+    assert!(
+        post.is_none(),
+        "no SpaceParticipant row should exist after bumping a non-participant — \
+         got {post:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_bump_participant_activity_updates_last_activity_when_participant_exists() {
+    let ctx = TestContext::setup().await;
+
+    let space_pk = Partition::Space(uuid::Uuid::new_v4().to_string());
+    let user = ctx.test_user.0.clone();
+    let user_pk = user.pk.clone();
+
+    // Seed a real, complete participant row.
+    let participant = SpaceParticipant::new_non_anonymous(space_pk.clone(), user);
+    participant
+        .create(&ctx.ddb)
+        .await
+        .expect("seed participant");
+
+    let (lookup_pk, lookup_sk) = SpaceParticipant::keys(space_pk.clone(), user_pk.clone());
+    let before = SpaceParticipant::get(&ctx.ddb, &lookup_pk, Some(&lookup_sk))
+        .await
+        .expect("get before")
+        .expect("seeded row");
+    assert!(
+        before.last_activity_at.is_none(),
+        "seeded row should have no last_activity_at yet"
+    );
+
+    bump_participant_activity(&ctx.ddb, &space_pk, &user_pk).await;
+
+    let after = SpaceParticipant::get(&ctx.ddb, &lookup_pk, Some(&lookup_sk))
+        .await
+        .expect("get after")
+        .expect("row should still exist");
+    assert!(
+        after.last_activity_at.is_some(),
+        "bump must populate last_activity_at on an existing participant"
+    );
+    // Other required fields must remain intact — proves the update did
+    // not clobber the row.
+    assert_eq!(after.created_at, before.created_at);
+    assert_eq!(after.username, before.username);
+    assert_eq!(after.display_name, before.display_name);
+    assert_eq!(after.sk, EntityType::SpaceParticipant);
+}


### PR DESCRIPTION
## Summary

- `bump_participant_activity` was issuing a bare `SpaceParticipant::updater(...).with_last_activity_at(now).execute(cli)`. When no participant row existed, DynamoDB's `UpdateItem` created a brand-new item containing only the keys + `last_activity_at` — every required field of `SpaceParticipant` (including `created_at`) was missing. The next `SpaceParticipant::get` then failed with `serde_dynamo: missing field 'created_at'`, surfacing as "Something went wrong" on the space arena.
- Most reproducible trigger: a team-owned space's parent-team admin (Creator role, never a Participant) calling `create_discussion` — exactly the sub-team broadcast → space → add discussion → back flow.
- Fix swaps the helper for a raw `update_item` with `condition_expression("attribute_exists(created_at)")`, so the write is a silent no-op when the row is missing or already partial. Same pattern as the prior CharacterXp insert-vs-update fix.
- New server integration test `participant_activity_tests` covers both shapes: (1) bump on a non-participant produces no row, (2) bump on a real participant populates `last_activity_at` without clobbering other fields.

## Test plan

- [x] `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features server`
- [x] `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features web`
- [x] `cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' dx check --web`
- [x] `cd app/ratel && make test TEST="participant_activity_tests::"` (2/2 pass against LocalStack)
- [ ] Manual: reproduce the bug scenario on a deployed env after merge — parent team broadcast with Space toggle → publish → Read Space → add Discussion → save/next/save → Back. Expect no "Something went wrong".

🤖 Generated with [Claude Code](https://claude.com/claude-code)