### PR TITLE
fix(spaces): skip SpaceParticipant load in get_space for admins

### DIFF
--- a/app/ratel/src/features/spaces/space_common/controllers/get_space.rs
+++ b/app/ratel/src/features/spaces/space_common/controllers/get_space.rs
@@ -2,7 +2,7 @@ use crate::common::models::space::{SpaceCommon, SpaceParticipant};
 use crate::common::models::{OptionalUser, User};
 use crate::common::*;
 use crate::features::posts::models::Post;
-use crate::features::posts::types::{BoosterType, SpaceType};
+use crate::features::posts::types::{BoosterType, SpaceType, TeamGroupPermission};
 use crate::spaces::{InvitationStatus, SpaceInvitationMember};
 
 #[mcp_tool(
@@ -44,25 +44,54 @@ pub async fn get_space(
 
     let is_participation_open = space.is_participation_open();
 
-    let (user_participant, can_participate) = if let Some(ref user) = user {
-        let (participant_pk, participant_sk) =
-            SpaceParticipant::keys(space.pk.clone(), user.pk.clone());
-        let participant =
-            SpaceParticipant::get(dynamo, &participant_pk, Some(&participant_sk)).await?;
-        let invited = if space.visibility != SpaceVisibility::Public {
-            let (invitation_pk, invitation_sk) = SpaceInvitationMember::keys(&space.pk, &user.pk);
-            let invitation =
-                SpaceInvitationMember::get(dynamo, &invitation_pk, Some(&invitation_sk)).await?;
+    // Admins/Creators are not participants of their own space — they
+    // own/manage it. `SpaceParticipant` rows for them are either absent
+    // (team-owned spaces created via `publish_announcement_handler`) or
+    // irrelevant to the response (the "Join" CTA / participant identity
+    // fields would never apply). Reusing the already-loaded
+    // `permissions.contains(SpaceEdit)` signal — true for individual
+    // creators (`get_permissions` returns `all()` on `user.pk ==
+    // post.user_pk`) and for team admins/owners (via
+    // `Team::get_user_role`) — lets us skip the read entirely with no
+    // extra DDB round-trip.
+    //
+    // This also sidesteps a latent bug in `bump_participant_activity`:
+    // when an admin triggers e.g. `create_discussion`, the helper issues
+    // a bare `UpdateItem` against the (admin's) non-existent
+    // SpaceParticipant key. DynamoDB upserts a partial row containing
+    // only the keys + `last_activity_at`, and the next `SpaceParticipant::get`
+    // here would deserialize-fail with `missing field 'created_at'`,
+    // surfacing as "Something went wrong" on the space arena. With this
+    // skip, the admin path never reads back the (potentially partial)
+    // row, so the symptom is contained even before the bump helper is
+    // tightened.
+    let is_admin = permissions.contains(TeamGroupPermission::SpaceEdit);
 
-            matches!(
-                invitation.as_ref().map(|member| member.status),
-                Some(InvitationStatus::Invited) | Some(InvitationStatus::Accepted)
-            )
+    let (user_participant, can_participate) = if let Some(ref user) = user {
+        if is_admin {
+            (None, false)
         } else {
-            true
-        };
-        let can_participate = participant.is_none() && is_participation_open && invited;
-        (participant, can_participate)
+            let (participant_pk, participant_sk) =
+                SpaceParticipant::keys(space.pk.clone(), user.pk.clone());
+            let participant =
+                SpaceParticipant::get(dynamo, &participant_pk, Some(&participant_sk)).await?;
+            let invited = if space.visibility != SpaceVisibility::Public {
+                let (invitation_pk, invitation_sk) =
+                    SpaceInvitationMember::keys(&space.pk, &user.pk);
+                let invitation =
+                    SpaceInvitationMember::get(dynamo, &invitation_pk, Some(&invitation_sk))
+                        .await?;
+
+                matches!(
+                    invitation.as_ref().map(|member| member.status),
+                    Some(InvitationStatus::Invited) | Some(InvitationStatus::Accepted)
+                )
+            } else {
+                true
+            };
+            let can_participate = participant.is_none() && is_participation_open && invited;
+            (participant, can_participate)
+        }
     } else {
         (None, false)
     };

--- a/app/ratel/src/tests/get_space_admin_tests.rs
+++ b/app/ratel/src/tests/get_space_admin_tests.rs
@@ -1,0 +1,208 @@
+//! Regression coverage for `get_space` reading-side robustness when the
+//! caller is the space admin/Creator.
+//!
+//! Bug under test: in a team-owned space (e.g. a sub-team broadcast
+//! space), the parent-team admin who pressed Publish is the space's
+//! Creator but never has a `SpaceParticipant` row — the broadcast
+//! publish flow does not create one (unlike `create_space_handler`,
+//! which inserts a participant for the user atomically with the space).
+//!
+//! Independently, `bump_participant_activity` used to issue a bare
+//! `UpdateItem` against the (missing) participant key. DynamoDB upserts
+//! such updates into a partial row carrying only the keys plus
+//! `last_activity_at`, missing every required field on
+//! `SpaceParticipant`. The next `get_space` call would then try to
+//! `SpaceParticipant::get(...)?` that row and surface
+//! `serde_dynamo: missing field 'created_at'` → "Something went wrong".
+//!
+//! These tests pin the admin-skip path so that:
+//!   1. An admin viewing a team-owned space with NO participant row
+//!      gets a successful response with `participated=false`.
+//!   2. The same admin still gets a successful response even when a
+//!      buggy partial participant row already exists in the table.
+//!
+//! Both cases exercise the `permissions.contains(SpaceEdit)` branch in
+//! `get_space` that short-circuits the participant load.
+use super::*;
+use crate::common::models::space::{SpaceCommon, SpaceParticipant};
+use crate::common::types::{
+    EntityType, Partition, SpacePublishState, SpaceStatus, SpaceVisibility, UserType,
+};
+use crate::features::auth::UserTeam;
+use crate::features::posts::models::Team;
+use crate::features::posts::types::{PostStatus, Visibility};
+use crate::features::social::pages::member::dto::TeamRole;
+
+/// Owner = `ctx.test_user`. Returns the team's pk.
+async fn create_team_owned_by_test_user(ctx: &TestContext) -> Partition {
+    let owner = &ctx.test_user.0;
+    let (team_pk, _created_at) = Team::create_new_team(
+        owner,
+        &ctx.ddb,
+        format!("team{}", uuid::Uuid::new_v4()),
+        String::new(),
+        format!("team-{}", uuid::Uuid::new_v4().simple()),
+        "desc".to_string(),
+    )
+    .await
+    .expect("create team");
+    team_pk
+}
+
+/// Insert a team-owned, published, public space directly into DDB and
+/// return both the SpaceCommon row and its raw id string (no prefix).
+/// The Post is seeded with `user_pk = team_pk` and `author_type =
+/// Team`, mirroring real space creation, so `Post::get_permissions`
+/// routes into the `Team::get_permissions_by_team_pk` branch and
+/// returns admin/owner permissions for team admins (i.e. the
+/// `SpaceEdit` bit that `get_space` uses to detect admins).
+async fn insert_team_owned_space(ctx: &TestContext, team_pk: Partition) -> (SpaceCommon, String) {
+    let post_id = uuid::Uuid::new_v4().to_string();
+    let now = crate::common::utils::time::get_now_timestamp_millis();
+    let space_pk = Partition::Space(post_id.clone());
+    let post_pk = Partition::Feed(post_id.clone());
+
+    let mut space = SpaceCommon::default();
+    space.pk = space_pk.clone();
+    space.sk = EntityType::SpaceCommon;
+    space.created_at = now;
+    space.updated_at = now;
+    space.status = Some(SpaceStatus::Open);
+    space.publish_state = SpacePublishState::Published;
+    space.visibility = SpaceVisibility::Public;
+    space.post_pk = post_pk.clone();
+    space.user_pk = team_pk.clone();
+    space.author_display_name = "team".to_string();
+    space.author_profile_url = String::new();
+    space.author_username = "team".to_string();
+    space.create(&ctx.ddb).await.expect("create space");
+
+    let post = crate::features::posts::models::Post {
+        pk: post_pk,
+        sk: EntityType::Post,
+        created_at: now,
+        updated_at: now,
+        title: "Admin Test Space".to_string(),
+        status: PostStatus::Published,
+        visibility: Some(Visibility::Public),
+        user_pk: team_pk,
+        author_type: UserType::Team,
+        ..Default::default()
+    };
+    post.create(&ctx.ddb).await.expect("create post");
+
+    (space, post_id)
+}
+
+#[tokio::test]
+async fn test_get_space_as_team_admin_without_participant_row_succeeds() {
+    let ctx = TestContext::setup().await;
+    let team_pk = create_team_owned_by_test_user(&ctx).await;
+    let (_space, space_id) = insert_team_owned_space(&ctx, team_pk).await;
+
+    // Admin (team owner) hits get_space. Should succeed with
+    // participated=false / can_participate=false, never touching
+    // SpaceParticipant.
+    let (status, _, body) = crate::test_get! {
+        app: ctx.app.clone(),
+        path: &format!("/api/spaces/{}", space_id),
+        headers: ctx.test_user.1.clone(),
+    };
+    assert_eq!(status, 200, "expected 200, body: {body:?}");
+    assert_eq!(
+        body["participated"],
+        serde_json::json!(false),
+        "admin is not a participant; body: {body:?}"
+    );
+    assert_eq!(
+        body["can_participate"],
+        serde_json::json!(false),
+        "admin shouldn't get a Join CTA on their own space; body: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_get_space_as_team_admin_survives_partial_participant_row() {
+    use aws_sdk_dynamodb::types::AttributeValue as AV;
+
+    let ctx = TestContext::setup().await;
+    let team_pk = create_team_owned_by_test_user(&ctx).await;
+    let (space, space_id) = insert_team_owned_space(&ctx, team_pk).await;
+
+    // Simulate what the legacy `bump_participant_activity` did to admins:
+    // a bare UpdateItem against the (missing) SpaceParticipant key, which
+    // DDB upserts into a partial row containing only the keys + the SET
+    // field. `created_at`, `display_name`, etc. are all absent.
+    let (pk, sk) = SpaceParticipant::keys(space.pk.clone(), ctx.test_user.0.pk.clone());
+    let now = crate::common::utils::time::get_now_timestamp_millis();
+    ctx.ddb
+        .update_item()
+        .table_name(SpaceParticipant::table_name())
+        .key("pk", AV::S(pk.to_string()))
+        .key("sk", AV::S(sk.to_string()))
+        .update_expression("SET last_activity_at = :now")
+        .expression_attribute_values(":now", AV::N(now.to_string()))
+        .send()
+        .await
+        .expect("seed partial participant row");
+
+    // Pre-`is_admin`-skip: this returned 500 because
+    // `SpaceParticipant::get(...)?` blew up with
+    // `serde_dynamo: missing field 'created_at'` before producing the
+    // response. With the admin skip, the partial row is never read.
+    let (status, _, body) = crate::test_get! {
+        app: ctx.app.clone(),
+        path: &format!("/api/spaces/{}", space_id),
+        headers: ctx.test_user.1.clone(),
+    };
+    assert_eq!(
+        status, 200,
+        "admin skip should bypass the partial row; body: {body:?}"
+    );
+    assert_eq!(body["participated"], serde_json::json!(false));
+}
+
+#[tokio::test]
+async fn test_get_space_as_non_admin_still_loads_participant() {
+    let ctx = TestContext::setup().await;
+    let team_pk = create_team_owned_by_test_user(&ctx).await;
+    let (space, space_id) = insert_team_owned_space(&ctx, team_pk.clone()).await;
+
+    // Add a SECOND user as a Member of the team (NOT admin/owner). They
+    // should fall through `permissions.contains(SpaceEdit) == false` and
+    // hit the normal participant-loading path. With no SpaceParticipant
+    // row, get_space should still succeed and report participated=false,
+    // can_participate=true (space is Open & Public).
+    let (member, member_headers) = ctx.create_another_user().await;
+    let team = Team::get(&ctx.ddb, &team_pk, Some(EntityType::Team))
+        .await
+        .expect("get team")
+        .expect("team exists");
+    UserTeam::new(
+        member.pk.clone(),
+        team_pk.clone(),
+        team.display_name.clone(),
+        team.profile_url.clone(),
+        team.username.clone(),
+        team.dao_address.clone(),
+        TeamRole::Member,
+    )
+    .create(&ctx.ddb)
+    .await
+    .expect("create UserTeam membership");
+
+    let _ = space; // suppress unused-var when only id is needed
+
+    let (status, _, body) = crate::test_get! {
+        app: ctx.app.clone(),
+        path: &format!("/api/spaces/{}", space_id),
+        headers: member_headers.clone(),
+    };
+    assert_eq!(status, 200, "member should be able to read: {body:?}");
+    assert_eq!(body["participated"], serde_json::json!(false));
+    assert_eq!(
+        body["can_participate"],
+        serde_json::json!(true),
+        "Open + Public space should expose Join CTA to non-admin members"
+    );
+}

--- a/app/ratel/src/tests/mod.rs
+++ b/app/ratel/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod cors_tests;
 mod cross_posting_tests;
 mod discussion_tests;
 mod fact_or_fold_tests;
+mod get_space_admin_tests;
 mod home_tests;
 mod inbox_helper_tests;
 mod mcp_tests;


### PR DESCRIPTION
## Summary

- `get_space` unconditionally loaded `SpaceParticipant` for the authenticated user, blowing up the entire request when the row was a *partial* one — only `pk + sk + last_activity_at`, missing required fields like \`created_at\`. \`serde_dynamo\` failed with \`missing field 'created_at'\`, surfacing as "Something went wrong" on the space arena.
- The partial rows are written by \`bump_participant_activity\` (called by \`create_discussion\`, \`respond_poll\`, \`respond_quiz\`, \`add_comment\`) — it issues a bare \`UpdateItem\` against keys that may not yet exist; DynamoDB upserts into a key-plus-SET-field row. The most reproducible trigger is a **team-owned space's parent-team admin** (Creator, never a Participant in team-owned spaces) calling \`create_discussion\`.
- This handler-side fix reuses the already-loaded \`post.get_permissions(...)\` result: \`permissions.contains(SpaceEdit)\` is true for individual creators (\`get_permissions\` returns \`all()\` when \`user.pk == post.user_pk\`) and for team admins/owners (via \`Team::get_user_role\` inside \`Team::get_permissions_by_team_pk\`). **Zero additional DDB reads.**
- Admins branch onto a \`(None, false)\` participant path — they are not participants of their own space and never need the "Join" CTA. Non-admins keep the existing participant + invitation load unchanged.

## Why this approach over the helper-side fix

The previous proposal was to harden \`bump_participant_activity\` with a conditional \`UpdateItem\`. That's a behavior change on a helper called from 4 different controllers, each with its own role assumptions — too much surface to be confident about side effects in one PR. The handler-side fix is purely additive: admins get a faster, safer path; everyone else's flow is byte-for-byte identical. Hardening the helper can come later as an independent change.

## Tests

Three integration tests in \`tests/get_space_admin_tests.rs\` exercise the new branch end-to-end against LocalStack:

- \`test_get_space_as_team_admin_without_participant_row_succeeds\` — admin views a team-owned space, no participant row exists, response is \`200\` with \`participated=false\`/\`can_participate=false\`.
- \`test_get_space_as_team_admin_survives_partial_participant_row\` — **direct regression for the bug**: seeds a partial \`SpaceParticipant\` row via raw \`UpdateItem\` (exactly what the legacy bump did to admins), then calls \`get_space\` — previously \`500\` with the deserialization error; now \`200\`.
- \`test_get_space_as_non_admin_still_loads_participant\` — a team Member (not admin/owner) hits the normal participant-load path, gets \`can_participate=true\` on an Open Public space.

## Test plan

- [x] \`cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features server\`
- [x] \`cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features web\`
- [x] \`cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features "server,bypass" --tests -p app-shell\`
- [x] \`cd app/ratel && make test TEST="get_space_admin_tests::"\` (3/3 pass)
- [ ] Manual: reproduce the original scenario on a deployed env — parent team broadcast with Space toggle → publish → Read Space → add Discussion → save/next/save → Back. Expect no "Something went wrong".

## Scope notes

This PR intentionally does NOT touch:
- \`bump_participant_activity\` (helper-side hardening — separate PR if/when needed)
- \`SpaceUserRole\` broadcast awareness (separate effort; needed to fix the child-team-member UX gap where they can read a broadcast space but get \`UnauthorizedAccess\` on \`list_actions\`)
- The two-layer permission story (Post-side \`assert_broadcast_access\` vs Space-side \`SpaceUserRole\` not knowing about broadcast)

Those are bigger architectural questions that warrant their own design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)