### PR TITLE
refactor(by-macros): drop begins_with fallback in DynamoEntity::get

### DIFF
--- a/packages/by-macros/src/dynamo_entity/mod.rs
+++ b/packages/by-macros/src/dynamo_entity/mod.rs
@@ -1317,10 +1317,24 @@ fn generate_struct_impl(
                 sk: Option<impl std::fmt::Display>
             ) -> #result_ty <Option<Self>, #err_ctor> {
                 if let Some(sk) = sk {
-                    let sk_str = sk.to_string();
-                    let pk_str = pk.to_string();
-
-                    // Try exact match first (#sk = :sk)
+                    // Exact match only. A previous version of this macro
+                    // fell back to `begins_with(#sk, :sk)` on a miss, which
+                    // made `Model::get(pk, exact_sk)` silently return rows
+                    // whose sk happens to be a prefix of OR a longer string
+                    // starting with the requested sk — i.e. an entirely
+                    // different entity type that lives in the same
+                    // partition. That fallback was always a footgun:
+                    //   - it conflicts with the documented `Model::get`
+                    //     semantics ("get by exact key");
+                    //   - it surfaces as "missing field ..." deserialize
+                    //     errors when the foreign entity lacks fields the
+                    //     requested type requires;
+                    //   - callers that genuinely want prefix matching
+                    //     should reach for `query` / `query_begins_with_sk`
+                    //     directly.
+                    // The handful of places that historically depended on
+                    // the fallback (see `get_post.rs` for the sk-prefix
+                    // workaround) already worked around it explicitly.
                     let resp = cli
                         .query()
                         .table_name(Self::table_name())
@@ -1329,38 +1343,11 @@ fn generate_struct_impl(
                         .expression_attribute_names("#sk", "sk")
                         .expression_attribute_values(
                             ":pk",
-                            aws_sdk_dynamodb::types::AttributeValue::S(pk_str.clone()),
+                            aws_sdk_dynamodb::types::AttributeValue::S(pk.to_string()),
                         )
                         .expression_attribute_values(
                             ":sk",
-                            aws_sdk_dynamodb::types::AttributeValue::S(sk_str.clone()),
-                        )
-                        .limit(1)
-                        .send()
-                        .await
-                        .map_err(Into::<aws_sdk_dynamodb::Error>::into)?;
-
-                    if let Some(items) = &resp.items {
-                        if let Some(item) = items.first() {
-                            let ev: Self = serde_dynamo::from_item(item.clone())?;
-                            return Ok(Some(ev));
-                        }
-                    }
-
-                    // Fall back to begins_with
-                    let resp = cli
-                        .query()
-                        .table_name(Self::table_name())
-                        .key_condition_expression("#pk = :pk AND begins_with(#sk, :sk)")
-                        .expression_attribute_names("#pk", Self::pk_field())
-                        .expression_attribute_names("#sk", "sk")
-                        .expression_attribute_values(
-                            ":pk",
-                            aws_sdk_dynamodb::types::AttributeValue::S(pk_str),
-                        )
-                        .expression_attribute_values(
-                            ":sk",
-                            aws_sdk_dynamodb::types::AttributeValue::S(sk_str),
+                            aws_sdk_dynamodb::types::AttributeValue::S(sk.to_string()),
                         )
                         .limit(1)
                         .send()


### PR DESCRIPTION
## Summary

\`Model::get(pk, Some(sk))\` previously ran an exact-match query, then on a miss fell back to \`begins_with(#sk, :sk)\` and deserialized the first prefix-matching row into \`Self\`. This PR removes the fallback so the method matches its documented contract — exact key lookup, returning \`None\` on a true miss.

### Why the fallback was wrong

1. **API contract drift.** \`Model::get(pk, sk)\` reads as "get by exact key". The silent prefix fallback violated that.
2. **Cross-entity row aliasing.** The \`EntityType\` enum has dense prefix overlaps (\`POST\` ↔ \`POST_COMMENT\` ↔ \`POST_COMMENT_LIKE\`, \`SPACE_POLL\` ↔ \`SPACE_POLL_USER_ANSWER\`, \`SUB_TEAM_ANNOUNCEMENT\` ↔ \`SUB_TEAM_ANNOUNCEMENT_FANOUT\`, ...). On a partition where multiple entities cohabit, an exact-match miss could silently pick up a foreign entity row — deserialize then explodes as "missing field ..." (looks like data corruption while the actual bug is the wrong row being read).
3. **Already worked around in production.** Callers that genuinely want prefix matching already use \`query\` / \`query_begins_with_sk\` (e.g. \`PostMetadata::query_begins_with_sk(pk, "POST")\` in \`get_post_handler\` — added specifically to dodge this macro's surprise fallback).

### Bonus

- One fewer DDB query per \`get\` miss.

## Validation

- \`cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features server\` ✅
- \`cd app/ratel && DYNAMO_TABLE_PREFIX=ratel-dev RUSTFLAGS='-D warnings' cargo check --features web\` ✅
- \`cd app/ratel && make test\` — **447/447 pass** against LocalStack with \`server,bypass\` features. No production code path depended on the fallback.

Pre-existing unrelated issue: \`cargo test\` directly against \`packages/by-macros\` fails to compile its own test targets with \`use of unresolved module \\\`by_types\\\`\` — this error exists on \`origin/dev\` too, not caused by this change.

## Test plan

- [x] cargo check (server + web) clean
- [x] Full app-shell integration test suite passes (447/447)
- [x] CI runs same suite
- [ ] Watch CI \`playwright-tests\` and \`dx-check\` for any unexpected impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)